### PR TITLE
feat 8: Simplify Word Practice page and add drill mode logging

### DIFF
--- a/src/components/practice/WordDrillCard.tsx
+++ b/src/components/practice/WordDrillCard.tsx
@@ -1,0 +1,105 @@
+import { memo } from 'react';
+import type { Word } from '@/lib/types';
+import WordAudioButton from './WordAudioButton';
+
+interface WordDrillCardProps {
+  word: Word;
+  showTranslation: boolean;
+  onKnowIt: () => void;
+  onDontKnowIt: () => void;
+}
+
+/**
+ * Word card specifically for drill mode.
+ * Shows word with optional translation toggle and Know it/Don't know it buttons.
+ */
+function WordDrillCard({ word, showTranslation, onKnowIt, onDontKnowIt }: WordDrillCardProps) {
+  const difficultyColors = {
+    1: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200',
+    2: 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200',
+    3: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200',
+    4: 'bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-200',
+    5: 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200',
+  };
+
+  const difficultyLabels = {
+    1: 'Very Easy',
+    2: 'Easy',
+    3: 'Medium',
+    4: 'Hard',
+    5: 'Very Hard',
+  };
+
+  return (
+    <div className="card card-hover">
+      {/* Header with category and difficulty */}
+      <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2 mb-4">
+        <span className="badge badge-secondary">
+          {word.categoryLabelEn}
+        </span>
+        <div className="flex flex-wrap items-center gap-2">
+          {word.difficultForEnglish && (
+            <span className="badge badge-warning">
+              ⚠️ Tricky
+            </span>
+          )}
+          <span
+            className={`badge ${difficultyColors[word.difficulty]}`}
+          >
+            {difficultyLabels[word.difficulty]}
+          </span>
+        </div>
+      </div>
+
+      {/* Portuguese word - large and prominent */}
+      <div className="mb-4">
+        <p className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-gray-100 text-center">
+          {word.textPt}
+        </p>
+      </div>
+
+      {/* English translation - only shown if toggle is on */}
+      {showTranslation && (
+        <div className="mb-4 p-4 bg-gray-50 dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700">
+          <p className="text-lg text-gray-700 dark:text-gray-300 italic text-center">
+            {word.translationEn}
+          </p>
+          <p className="text-sm text-gray-500 dark:text-gray-400 mt-2 text-center">
+            {word.partOfSpeech}
+          </p>
+        </div>
+      )}
+
+      {/* Pronunciation notes */}
+      {word.pronunciationNotes && (
+        <div className="mb-4 p-3 bg-blue-50 dark:bg-blue-900/20 border-l-4 border-blue-400 dark:border-blue-500 rounded text-sm">
+          <p className="text-blue-800 dark:text-blue-300">{word.pronunciationNotes}</p>
+        </div>
+      )}
+
+      {/* Audio playback control */}
+      <div className="mb-6 flex justify-center">
+        <WordAudioButton wordId={word.id} label="Play Pronunciation" compact={false} />
+      </div>
+
+      {/* Action buttons - Know it / Don't know it */}
+      <div className="flex flex-col sm:flex-row gap-3 mt-6 pt-6 border-t border-gray-200 dark:border-gray-700">
+        <button
+          onClick={onKnowIt}
+          className="btn btn-success btn-md flex-1"
+        >
+          ✓ Know it
+        </button>
+        <button
+          onClick={onDontKnowIt}
+          className="btn btn-danger btn-md flex-1"
+        >
+          ✗ Don't know it
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default memo(WordDrillCard);
+

--- a/src/components/practice/WordStudyCard.tsx
+++ b/src/components/practice/WordStudyCard.tsx
@@ -1,0 +1,85 @@
+import { memo } from 'react';
+import type { Word } from '@/lib/types';
+import WordAudioButton from './WordAudioButton';
+
+interface WordStudyCardProps {
+  word: Word;
+}
+
+/**
+ * Simplified word card for study/learning mode.
+ * Shows word, translation, and a play button using the selected voice from settings.
+ * No recording, no assessment, no "Know it" button.
+ */
+function WordStudyCard({ word }: WordStudyCardProps) {
+  const difficultyColors = {
+    1: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200',
+    2: 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200',
+    3: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200',
+    4: 'bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-200',
+    5: 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200',
+  };
+
+  const difficultyLabels = {
+    1: 'Very Easy',
+    2: 'Easy',
+    3: 'Medium',
+    4: 'Hard',
+    5: 'Very Hard',
+  };
+
+  return (
+    <div className="card card-hover card-compact">
+      {/* Header with category and difficulty */}
+      <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2 mb-4">
+        <span className="badge badge-secondary">
+          {word.categoryLabelEn}
+        </span>
+        <div className="flex flex-wrap items-center gap-2">
+          {word.difficultForEnglish && (
+            <span className="badge badge-warning">
+              ⚠️ Tricky
+            </span>
+          )}
+          <span
+            className={`badge ${difficultyColors[word.difficulty]}`}
+          >
+            {difficultyLabels[word.difficulty]}
+          </span>
+        </div>
+      </div>
+
+      {/* Portuguese word - large and prominent */}
+      <div className="mb-3">
+        <p className="text-2xl md:text-3xl font-bold text-gray-900 dark:text-gray-100">
+          {word.textPt}
+        </p>
+      </div>
+
+      {/* English translation */}
+      <div className="mb-4">
+        <p className="text-base text-gray-600 dark:text-gray-300 italic">
+          {word.translationEn}
+        </p>
+        <p className="text-xs text-gray-400 dark:text-gray-500 mt-1">
+          {word.partOfSpeech}
+        </p>
+      </div>
+
+      {/* Pronunciation notes */}
+      {word.pronunciationNotes && (
+        <div className="mb-4 p-3 bg-blue-50 dark:bg-blue-900/20 border-l-4 border-blue-400 dark:border-blue-500 rounded text-sm">
+          <p className="text-blue-800 dark:text-blue-300">{word.pronunciationNotes}</p>
+        </div>
+      )}
+
+      {/* Audio playback control - single button using selected voice from settings */}
+      <div className="mb-4 flex gap-2">
+        <WordAudioButton wordId={word.id} label="Play" compact={false} />
+      </div>
+    </div>
+  );
+}
+
+export default memo(WordStudyCard);
+

--- a/src/pages/WordPractice.tsx
+++ b/src/pages/WordPractice.tsx
@@ -1,24 +1,26 @@
 import { useEffect, useState, useMemo, useCallback } from 'react';
 import { setLastPracticeMode } from '@/lib/storage';
-import { useProgressStore } from '@/state/progressStore';
 import {
   loadAllWords,
   loadAllCategories,
   filterWordsByCategory,
 } from '@/lib/data';
 import type { Word, Category } from '@/lib/types';
-import WordCard from '@/components/practice/WordCard';
+import WordStudyCard from '@/components/practice/WordStudyCard';
+import WordDrillCard from '@/components/practice/WordDrillCard';
 import CategoryFilterChips from '@/components/practice/CategoryFilterChips';
 import ViewModeToggle, { type ViewMode } from '@/components/practice/ViewModeToggle';
 import NavigationButtons from '@/components/practice/NavigationButtons';
 import LoadingSpinner from '@/components/common/LoadingSpinner';
 import PageTransition from '@/components/common/PageTransition';
 import { stopAllAudio } from '@/hooks/useAudioPlayer';
+import { appendWordDrillLog } from '@/utils/drillLog';
+import type { WordDrillLogEntry } from '@/types/drill';
 
 const WORDS_PER_PAGE = 20;
+const TRANSLATION_TOGGLE_STORAGE_KEY = 'lusopronounce_word_drill_show_translation';
 
 export default function WordPractice() {
-  const { rateWord } = useProgressStore();
   const [words, setWords] = useState<Word[]>([]);
   const [categories, setCategories] = useState<Category[]>([]);
   const [loading, setLoading] = useState(true);
@@ -26,9 +28,23 @@ export default function WordPractice() {
   const [displayedCount, setDisplayedCount] = useState(WORDS_PER_PAGE);
   const [viewMode, setViewMode] = useState<ViewMode>('list');
   const [drillIndex, setDrillIndex] = useState(0);
+  const [showTranslation, setShowTranslation] = useState<boolean>(false);
 
   useEffect(() => {
     setLastPracticeMode('word');
+  }, []);
+
+  // Load translation toggle preference from localStorage
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      const stored = window.localStorage.getItem(TRANSLATION_TOGGLE_STORAGE_KEY);
+      if (stored === 'true') {
+        setShowTranslation(true);
+      }
+    } catch (error) {
+      console.warn('Failed to load translation toggle preference:', error);
+    }
   }, []);
 
   useEffect(() => {
@@ -84,14 +100,6 @@ export default function WordPractice() {
     setDisplayedCount(prev => prev + WORDS_PER_PAGE);
   }, []);
 
-  const handleKnowIt = useCallback((wordId: string) => {
-    rateWord(wordId, 'know');
-  }, [rateWord]);
-
-  const handleReviewLater = useCallback((wordId: string) => {
-    rateWord(wordId, 'review');
-  }, [rateWord]);
-
   // Drill mode navigation
   const handleDrillPrevious = useCallback(() => {
     if (drillIndex > 0) {
@@ -107,31 +115,78 @@ export default function WordPractice() {
     }
   }, [drillIndex, filteredWords.length]);
 
-  // Auto-advance in drill mode after action
-  const handleDrillKnowIt = useCallback((wordId: string) => {
-    handleKnowIt(wordId);
-    if (drillIndex < filteredWords.length - 1) {
-      setTimeout(() => {
-        stopAllAudio();
-        setDrillIndex(prev => prev + 1);
-      }, 300);
-    }
-  }, [handleKnowIt, drillIndex, filteredWords.length]);
-
-  const handleDrillReviewLater = useCallback((wordId: string) => {
-    handleReviewLater(wordId);
-    if (drillIndex < filteredWords.length - 1) {
-      setTimeout(() => {
-        stopAllAudio();
-        setDrillIndex(prev => prev + 1);
-      }, 300);
-    }
-  }, [handleReviewLater, drillIndex, filteredWords.length]);
-
   // Current word in drill mode
   const currentDrillWord = useMemo(() => {
     return filteredWords[drillIndex];
   }, [filteredWords, drillIndex]);
+
+  // Handle translation toggle
+  const handleTranslationToggle = useCallback(() => {
+    const newValue = !showTranslation;
+    setShowTranslation(newValue);
+    // Persist preference to localStorage
+    try {
+      if (typeof window !== 'undefined') {
+        window.localStorage.setItem(TRANSLATION_TOGGLE_STORAGE_KEY, String(newValue));
+      }
+    } catch (error) {
+      console.warn('Failed to save translation toggle preference:', error);
+    }
+  }, [showTranslation]);
+
+  // Handle "Know it" action in drill mode
+  const handleDrillKnowIt = useCallback(() => {
+    if (!currentDrillWord) return;
+
+    // Create log entry
+    const logEntry: WordDrillLogEntry = {
+      id: `${currentDrillWord.id}-${Date.now()}`,
+      wordId: currentDrillWord.id,
+      wordText: currentDrillWord.textPt,
+      translation: currentDrillWord.translationEn,
+      known: true,
+      timestamp: new Date().toISOString(),
+      mode: 'word-drill',
+    };
+
+    // Append to log
+    appendWordDrillLog(logEntry);
+
+    // Auto-advance to next word
+    if (drillIndex < filteredWords.length - 1) {
+      setTimeout(() => {
+        stopAllAudio();
+        setDrillIndex(prev => prev + 1);
+      }, 300);
+    }
+  }, [currentDrillWord, drillIndex, filteredWords.length]);
+
+  // Handle "Don't know it" action in drill mode
+  const handleDrillDontKnowIt = useCallback(() => {
+    if (!currentDrillWord) return;
+
+    // Create log entry
+    const logEntry: WordDrillLogEntry = {
+      id: `${currentDrillWord.id}-${Date.now()}`,
+      wordId: currentDrillWord.id,
+      wordText: currentDrillWord.textPt,
+      translation: currentDrillWord.translationEn,
+      known: false,
+      timestamp: new Date().toISOString(),
+      mode: 'word-drill',
+    };
+
+    // Append to log
+    appendWordDrillLog(logEntry);
+
+    // Auto-advance to next word
+    if (drillIndex < filteredWords.length - 1) {
+      setTimeout(() => {
+        stopAllAudio();
+        setDrillIndex(prev => prev + 1);
+      }, 300);
+    }
+  }, [currentDrillWord, drillIndex, filteredWords.length]);
 
   // Memoize category label lookup
   const selectedCategoryLabel = useMemo(() => {
@@ -216,14 +271,30 @@ export default function WordPractice() {
           </button>
         </div>
       ) : viewMode === 'drill' ? (
-        /* Drill Mode - Single card view */
+        /* Drill Mode - Single card view with logging */
         <div className="max-w-2xl mx-auto">
+          {/* Translation toggle */}
+          <div className="mb-4 flex items-center justify-center">
+            <label className="flex items-center gap-2 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={showTranslation}
+                onChange={handleTranslationToggle}
+                className="w-4 h-4 text-primary-600 rounded focus:ring-primary-500"
+              />
+              <span className="text-sm text-gray-700 dark:text-gray-300">
+                Show translation
+              </span>
+            </label>
+          </div>
+
           {currentDrillWord && (
             <>
-              <WordCard
+              <WordDrillCard
                 word={currentDrillWord}
+                showTranslation={showTranslation}
                 onKnowIt={handleDrillKnowIt}
-                onReviewLater={handleDrillReviewLater}
+                onDontKnowIt={handleDrillDontKnowIt}
               />
               <NavigationButtons
                 onPrevious={handleDrillPrevious}
@@ -235,15 +306,13 @@ export default function WordPractice() {
           )}
         </div>
       ) : (
-        /* List Mode - Grid view */
+        /* List Mode - Grid view (study-only) */
         <>
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 mb-6">
             {displayedWords.map((word) => (
-              <WordCard
+              <WordStudyCard
                 key={word.id}
                 word={word}
-                onKnowIt={handleKnowIt}
-                onReviewLater={handleReviewLater}
               />
             ))}
           </div>

--- a/src/types/drill.ts
+++ b/src/types/drill.ts
@@ -1,0 +1,14 @@
+/**
+ * Types for word drill logging functionality
+ */
+
+export type WordDrillLogEntry = {
+  id: string;            // unique log id (e.g., `${wordId}-${timestamp}`)
+  wordId: string;
+  wordText: string;
+  translation: string;
+  known: boolean;        // true if user marked they knew it
+  timestamp: string;     // ISO string
+  mode: "word-drill";    // to distinguish from other modes in future
+};
+

--- a/src/utils/drillLog.ts
+++ b/src/utils/drillLog.ts
@@ -1,0 +1,78 @@
+/**
+ * Drill log utilities for storing word drill attempts in localStorage
+ */
+
+import type { WordDrillLogEntry } from '@/types/drill';
+
+export const WORD_DRILL_LOG_STORAGE_KEY = "lusopronounce_word_drill_log";
+
+/**
+ * Load all word drill log entries from localStorage
+ * @returns Array of log entries, or empty array if none exist or on error
+ */
+export function loadWordDrillLog(): WordDrillLogEntry[] {
+  if (typeof window === 'undefined') {
+    return [];
+  }
+
+  try {
+    const stored = window.localStorage.getItem(WORD_DRILL_LOG_STORAGE_KEY);
+    if (!stored) {
+      return [];
+    }
+
+    const parsed = JSON.parse(stored);
+    
+    // Validate that it's an array
+    if (!Array.isArray(parsed)) {
+      console.warn('Word drill log in localStorage is not an array, resetting');
+      return [];
+    }
+
+    // Validate entries have required fields
+    const validEntries = parsed.filter((entry: any) => {
+      return (
+        entry &&
+        typeof entry.id === 'string' &&
+        typeof entry.wordId === 'string' &&
+        typeof entry.wordText === 'string' &&
+        typeof entry.translation === 'string' &&
+        typeof entry.known === 'boolean' &&
+        typeof entry.timestamp === 'string' &&
+        entry.mode === 'word-drill'
+      );
+    });
+
+    if (validEntries.length !== parsed.length) {
+      console.warn('Some word drill log entries were invalid and filtered out');
+    }
+
+    return validEntries;
+  } catch (error) {
+    console.error('Error loading word drill log from localStorage:', error);
+    return [];
+  }
+}
+
+/**
+ * Append a new word drill log entry to localStorage
+ * @param entry The log entry to append
+ */
+export function appendWordDrillLog(entry: WordDrillLogEntry): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  try {
+    const existing = loadWordDrillLog();
+    const updated = [...existing, entry];
+    window.localStorage.setItem(WORD_DRILL_LOG_STORAGE_KEY, JSON.stringify(updated));
+  } catch (error) {
+    console.error('Error appending word drill log to localStorage:', error);
+    // Try to handle quota exceeded errors gracefully
+    if (error instanceof Error && error.name === 'QuotaExceededError') {
+      console.warn('localStorage quota exceeded, cannot save drill log entry');
+    }
+  }
+}
+


### PR DESCRIPTION
Simplify Practice Words page to be study-only:
- Create WordStudyCard component for clean study view (no recording, no assessment)
- Remove 'Know it' button from list view
- Remove male/female icons - use single play button based on settings voice
- Remove recording/pronunciation assessment from list view
- Keep drill mode separate with enhanced functionality

Add drill mode logging and translation toggle:
- Create WordDrillLogEntry type for logging word drill attempts
- Implement drill log utilities (loadWordDrillLog, appendWordDrillLog)
- Store logs in localStorage under 'lusopronounce_word_drill_log'
- Create WordDrillCard component with:
  - Translation show/hide toggle (persisted to localStorage)
  - 'Know it' and 'Don't know it' buttons
  - Auto-advance to next word after logging
- Log each drill action with timestamp, word info, and known status
- Translation toggle preference persists across sessions

Files added:
- src/components/practice/WordStudyCard.tsx - Study-only word card
- src/components/practice/WordDrillCard.tsx - Drill mode card with logging
- src/types/drill.ts - WordDrillLogEntry type definition
- src/utils/drillLog.ts - Drill log storage utilities

Files modified:
- src/pages/WordPractice.tsx - Use WordStudyCard in list view, WordDrillCard in drill mode