### PR TITLE
Codex/fix/phase0 1 core loop hardening

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ Thumbs.db
 node_modules/
 dist/
 *.tsbuildinfo
+
+# Speech debug / temp artifacts
+data/debug/
+data/temp-audio/

--- a/docs/audio-assessment-pipeline.md
+++ b/docs/audio-assessment-pipeline.md
@@ -1,0 +1,88 @@
+# Audio Assessment Pipeline
+
+## Pre-change audit note
+Before implementation, the codebase had three contract drift points:
+- Frontend submit paths in `useLivePronunciationPractice`, `SentenceCard`, and `wordPronunciation` used `/api/pronunciation-assessment`.
+- Express mounted pronunciation routes under `/api/pronunciation/assessment`.
+- `vite.config.ts` included a dev-only middleware shim that directly handled `/api/pronunciation-assessment` and bypassed normal server routing.
+
+It also had unrestricted speech debug logging/dumps and broad CORS defaults without pronunciation-specific abuse controls.
+
+## Canonical endpoint contract
+Canonical endpoint:
+- `POST /api/pronunciation/assessment`
+
+Temporary legacy alias:
+- `POST /api/pronunciation-assessment`
+- Alias reuses the same upload middleware and request handler as the canonical route.
+
+Response shape (unchanged):
+- `{ rawAzure, attemptScore }`
+
+## Dev/prod routing behavior
+Development and production now follow the same routing contract:
+- Vite proxies all `/api/*` traffic to Express at `http://localhost:4000`.
+- No Vite speech-specific request parsing or handler shim.
+- Express owns pronunciation routing in both environments.
+
+## Speech debug logging policy
+Default behavior (`SPEECH_DEBUG` unset):
+- No Azure response dumps to disk.
+- No logs with reference text, pronunciation headers, or raw Azure payloads.
+- Speech route logs are request-scoped and emit operational metadata (`requestId`, timing, status class).
+
+Debug behavior (`SPEECH_DEBUG=1`):
+- Enables detailed speech debug logging.
+- Enables controlled debug dumps under `data/debug/`.
+
+## Abuse controls (pronunciation routes)
+Applied to both canonical and alias endpoints:
+- Strict origin guard middleware with allowlist:
+  - Always allows local dev defaults (`localhost`/`127.0.0.1` on `3000`/`5173`).
+  - Supports production origins from env via `SPEECH_CORS_ALLOWED_ORIGINS` (fallbacks: `CORS_ALLOWED_ORIGINS`, `APP_ORIGINS`).
+- In-memory rate limiting:
+  - Default `20 requests / 5 minutes`.
+  - Tunable via `SPEECH_RATE_LIMIT_MAX_REQUESTS` and `SPEECH_RATE_LIMIT_WINDOW_MS`.
+  - Returns `429` with `Retry-After`.
+- Upload size limits:
+  - Tunable via `SPEECH_MAX_UPLOAD_BYTES` (default `10MB`).
+  - Oversized requests return `413` before conversion work starts.
+
+## Audio quality gate (client-side)
+Pre-submit gate runs before any network call:
+- Minimum duration threshold: `MIN_DURATION_MS` (default `900`).
+- Minimum loudness threshold: `MIN_RMS` (default `0.012`).
+
+Location:
+- `src/lib/audioQuality.ts`
+
+Tuning:
+- Increase `MIN_DURATION_MS` to reduce incomplete submissions.
+- Decrease `MIN_RMS` if soft speakers are rejected too often.
+- Increase `MIN_RMS` to more aggressively block near-silent recordings.
+
+User-facing failures:
+- Too short: asks user to speak the whole sentence.
+- Too quiet: asks user to move closer to the microphone.
+
+## Attempt lifecycle state machine
+States:
+- `idle`
+- `recording`
+- `recorded`
+- `submitting`
+- `scored`
+- `error`
+- `canceled`
+
+Transition sketch:
+- `idle -> recording -> recorded -> submitting -> scored`
+- `submitting -> canceled` (user cancel)
+- `submitting -> error` (request/server failure)
+- `recorded -> error` (quality gate failure)
+- `* -> idle` (reset/new sentence)
+
+Stale-response protection:
+- Each submit gets a client request id.
+- Only the latest request id is allowed to write result state.
+- Cancel/unmount invalidates the active request id and aborts in-flight fetch.

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev:server": "tsx src/server/app.ts",
     "build": "tsc && vite build",
     "preview": "vite preview",
+    "lint": "echo \"lint not configured\"",
     "generate:audio": "node scripts/generate_audio.js",
     "generate:word-practice": "tsx scripts/buildSyntheticWordPracticeData.ts",
     "analyze:words": "tsx scripts/analyzeWordsAndSentences.ts",
@@ -20,6 +21,7 @@
     "generate:sentences:stage0": "npm run generate:gemini:sentences && npm run generate:normalize:sentences",
     "dev:test-enrichment": "tsx scripts/devTestEnrichment.ts",
     "test": "vitest",
+    "test:phase01": "vitest src/server/routes/pronunciationAssessment.contract.test.ts src/lib/audioQuality.test.ts src/hooks/useLivePronunciationPractice.test.tsx",
     "test:watch": "vitest --watch"
   },
   "dependencies": {

--- a/src/components/common/PremiumPlayButton.tsx
+++ b/src/components/common/PremiumPlayButton.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 interface PremiumPlayButtonProps {
   isPlaying?: boolean;
@@ -103,4 +103,3 @@ export default function PremiumPlayButton({
     </button>
   );
 }
-

--- a/src/components/common/PremiumRecordButton.tsx
+++ b/src/components/common/PremiumRecordButton.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 interface PremiumRecordButtonProps {
   isRecording: boolean;
@@ -151,4 +151,3 @@ export default function PremiumRecordButton({
     </div>
   );
 }
-

--- a/src/components/dashboard/CategoryProgress.tsx
+++ b/src/components/dashboard/CategoryProgress.tsx
@@ -1,0 +1,37 @@
+import { Link } from 'react-router-dom';
+import type { Category } from '@/lib/types';
+
+interface CategoryProgressProps {
+  category: Category;
+  progress: number;
+  totalItems: number;
+  completedItems: number;
+}
+
+export default function CategoryProgress({
+  category,
+  progress,
+  totalItems,
+  completedItems,
+}: CategoryProgressProps) {
+  return (
+    <Link
+      to={`/practice/sentences?category=${encodeURIComponent(category.id)}`}
+      className="card card-hover p-4 space-y-3"
+    >
+      <div className="flex items-center justify-between">
+        <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">{category.labelEn}</h3>
+        <span className="text-sm font-medium text-gray-600 dark:text-gray-300">{progress}%</span>
+      </div>
+      <div className="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-2">
+        <div
+          className="bg-primary-500 h-2 rounded-full transition-all"
+          style={{ width: `${Math.max(0, Math.min(100, progress))}%` }}
+        />
+      </div>
+      <p className="text-sm text-gray-600 dark:text-gray-400">
+        {completedItems}/{totalItems} completed
+      </p>
+    </Link>
+  );
+}

--- a/src/components/dashboard/ContinuePracticeCard.tsx
+++ b/src/components/dashboard/ContinuePracticeCard.tsx
@@ -1,0 +1,27 @@
+import { Link } from 'react-router-dom';
+
+interface ContinuePracticeCardProps {
+  lastMode: 'sentence' | 'word' | null;
+}
+
+export default function ContinuePracticeCard({ lastMode }: ContinuePracticeCardProps) {
+  const href = lastMode === 'word' ? '/practice/words' : '/practice/sentences';
+  const label = lastMode === 'word' ? 'Continue Word Practice' : 'Continue Sentence Practice';
+  const description =
+    lastMode === 'word'
+      ? 'Pick up where you left off with vocabulary drills.'
+      : 'Keep improving your sentence pronunciation flow.';
+
+  return (
+    <Link
+      to={href}
+      className="block bg-gradient-to-br from-emerald-500 to-emerald-600 dark:from-emerald-600 dark:to-emerald-700 rounded-lg shadow-lg p-6 text-white hover:shadow-xl transition-all focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2"
+    >
+      <div className="flex items-center justify-between gap-4 mb-3">
+        <h3 className="text-xl font-bold">{label}</h3>
+        <span className="text-3xl">▶</span>
+      </div>
+      <p className="text-emerald-50">{description}</p>
+    </Link>
+  );
+}

--- a/src/components/practice/LivePracticeSection.tsx
+++ b/src/components/practice/LivePracticeSection.tsx
@@ -74,6 +74,7 @@ export default function LivePracticeSection({
     resetRecording,
     submitting,
     error,
+    attemptState,
     attempts,
     currentAttempt,
     rawAzureResponse,
@@ -158,13 +159,19 @@ export default function LivePracticeSection({
     showDifficultyBadge: false,
   }), [attempts, currentAttempt, sentence, sentenceAudio, wordAudios, enrichedWords]);
 
-  const canSubmit = Boolean(audioUrl) && !submitting && !isRecording;
+  const canSubmit = Boolean(audioUrl) && attemptState !== 'submitting' && attemptState !== 'recording';
   const recordingFileExists = Boolean(audioUrl);
 
-  // Determine current state
-  const isReadyToRecord = !isRecording && !recordingFileExists;
-  const isRecordingInProgress = isRecording;
-  const isReviewState = !isRecording && recordingFileExists;
+  // UI rendering is driven from the centralized attempt lifecycle state.
+  const isReadyToRecord = attemptState === 'idle' || (!recordingFileExists && attemptState !== 'recording');
+  const isRecordingInProgress = attemptState === 'recording' || isRecording;
+  const isReviewState =
+    recordingFileExists &&
+    (attemptState === 'recorded' ||
+      attemptState === 'submitting' ||
+      attemptState === 'scored' ||
+      attemptState === 'error' ||
+      attemptState === 'canceled');
 
   return (
     <div className="space-y-6">
@@ -283,4 +290,3 @@ export default function LivePracticeSection({
     </div>
   );
 }
-

--- a/src/components/practice/LivePracticeSection.tsx
+++ b/src/components/practice/LivePracticeSection.tsx
@@ -79,6 +79,7 @@ export default function LivePracticeSection({
     currentAttempt,
     rawAzureResponse,
     submitAttempt,
+    cancelAnalysis,
   } = useLivePronunciationPractice();
 
   // Notify parent of current attempt changes
@@ -277,6 +278,17 @@ export default function LivePracticeSection({
             </>
           )}
         </div>
+
+        {submitting && (
+          <div className="flex justify-center">
+            <button
+              onClick={cancelAnalysis}
+              className="px-4 py-2 rounded-md border border-gray-300 dark:border-gray-600 text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500"
+            >
+              Cancel analysis
+            </button>
+          </div>
+        )}
 
         {error && (
           <div className="p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded text-sm text-red-800 dark:text-red-200">

--- a/src/components/practice/SentenceCard.tsx
+++ b/src/components/practice/SentenceCard.tsx
@@ -72,7 +72,7 @@ function SentenceCard({ sentence, currentIndex, totalCount, sessionId }: Sentenc
       formData.append('language', 'pt-BR');
 
       // POST to API endpoint
-      const response = await fetch('/api/pronunciation-assessment', {
+      const response = await fetch('/api/pronunciation/assessment', {
         method: 'POST',
         body: formData,
       });

--- a/src/components/practice/SentenceFeedback.tsx
+++ b/src/components/practice/SentenceFeedback.tsx
@@ -1,7 +1,6 @@
 import { memo, useMemo } from 'react';
 import type { AttemptScore } from '@/types/pronunciation';
 import type { Sentence } from '@/lib/types';
-import type { NormalizedAudioVariant } from '@/components/pronunciation/shared/types';
 import { PronunciationFeedbackPanel } from '@/components/pronunciation';
 import type { PronunciationFeedbackPanelProps } from '@/components/pronunciation';
 import {
@@ -31,28 +30,6 @@ export interface SentenceFeedbackProps {
   className?: string;
 }
 
-
-/**
- * Builds normalized audio variants from sentence audio URLs.
- * Only includes the native audio variant that matches the selected voice preference.
- */
-function buildSentenceAudioVariants(
-  sentence: Sentence,
-  selectedVoice: 'male' | 'female'
-): NormalizedAudioVariant[] {
-  const variants: NormalizedAudioVariant[] = [];
-  
-  // Add native audio variant based on selected voice preference
-  const nativeAudioUrl = selectedVoice === 'male' ? sentence.audioMaleUrl : sentence.audioFemaleUrl;
-  if (nativeAudioUrl) {
-    variants.push({
-      type: 'native',
-      url: nativeAudioUrl,
-    });
-  }
-  
-  return variants;
-}
 
 /**
  * SentenceFeedback displays pronunciation assessment results.
@@ -101,14 +78,6 @@ function SentenceFeedback({
     }
     return enrichWordsWithCanonicalData(sentence, normalizedWords, canonicalWordMap);
   }, [sentence, normalizedWords, canonicalWordMap]);
-
-  // Build sentence audio variants (only if sentence is provided)
-  const sentenceAudio = useMemo(() => {
-    if (sentence) {
-      return buildSentenceAudioVariants(sentence, selectedVoice);
-    }
-    return [];
-  }, [sentence, selectedVoice]);
 
   // Build word audio variants from sentence wordRefs
   // Returns empty array if no sentence or wordRefs (not undefined)

--- a/src/components/practice/WordCard.tsx
+++ b/src/components/practice/WordCard.tsx
@@ -20,6 +20,7 @@ interface WordCardProps {
   sessionId: string | null;
   status?: 'new' | 'learning' | 'review' | 'known';
   showTranslation?: boolean;
+  onToggleTranslation?: () => void;
   onKnowIt: (wordId: string) => void;
   onReviewLater: (wordId: string) => void;
 }
@@ -447,4 +448,3 @@ function WordCard({ word, sessionId, status, showTranslation = false, onToggleTr
 }
 
 export default memo(WordCard);
-

--- a/src/components/practice/WordListeningMcqCard.tsx
+++ b/src/components/practice/WordListeningMcqCard.tsx
@@ -40,7 +40,6 @@ function WordListeningMcqCard({
   const { logWordAttempt } = usePracticeLogStore();
   const [selectedAnswer, setSelectedAnswer] = useState<string | null>(null);
   const [hasAnswered, setHasAnswered] = useState(false);
-  const [hasPlayedAudio, setHasPlayedAudio] = useState(false);
   const [audioError, setAudioError] = useState<string | null>(null);
   const cardStartTimeRef = useRef<number>(Date.now());
   const firstPlayTimeRef = useRef<number | null>(null);
@@ -89,7 +88,6 @@ function WordListeningMcqCard({
     if (isPlaying && !prevIsPlayingRef.current && firstPlayTimeRef.current === null) {
       // Audio just started playing
       firstPlayTimeRef.current = Date.now();
-      setHasPlayedAudio(true);
     }
     prevIsPlayingRef.current = isPlaying;
   }, [isPlaying]);
@@ -154,7 +152,6 @@ function WordListeningMcqCard({
   useEffect(() => {
     setSelectedAnswer(null);
     setHasAnswered(false);
-    setHasPlayedAudio(false);
     setAudioError(null);
     cardStartTimeRef.current = Date.now();
     firstPlayTimeRef.current = null;
@@ -433,4 +430,3 @@ function WordListeningMcqCard({
 }
 
 export default memo(WordListeningMcqCard);
-

--- a/src/components/pronunciation/PronunciationFeedbackPanel.tsx
+++ b/src/components/pronunciation/PronunciationFeedbackPanel.tsx
@@ -69,7 +69,6 @@ export default function PronunciationFeedbackPanel({
   translationText,
   difficulty,
   sentenceAudio,
-  wordAudios,
   words,
   title,
   showDevControls = false,
@@ -82,12 +81,9 @@ export default function PronunciationFeedbackPanel({
   
   // Centralized audio state
   const [activeSentenceType, setActiveSentenceType] = useState<'native' | 'user' | null>(null);
-  const [activeWordIndex, setActiveWordIndex] = useState<number | null>(null);
-  const [activeWordType, setActiveWordType] = useState<'native' | 'user' | null>(null);
   
   // Refs for audio elements to enable stopping from parent
   const sentenceAudioRef = useRef<HTMLAudioElement>(null);
-  const wordAudioRef = useRef<HTMLAudioElement>(null);
 
   // Reset practice mode when sentence changes (use sentenceText as key)
   useEffect(() => {
@@ -138,14 +134,6 @@ export default function PronunciationFeedbackPanel({
 
   // Sentence audio callbacks
   const handleSentenceStart = (type: 'native' | 'user') => {
-    // Stop word audio if playing
-    if (wordAudioRef.current) {
-      wordAudioRef.current.pause();
-      wordAudioRef.current.currentTime = 0;
-    }
-    // Clear word state
-    setActiveWordIndex(null);
-    setActiveWordType(null);
     // Set sentence state
     setActiveSentenceType(type);
     
@@ -158,25 +146,6 @@ export default function PronunciationFeedbackPanel({
 
   const handleSentenceStop = () => {
     setActiveSentenceType(null);
-  };
-
-  // Word audio callbacks
-  const handleWordStart = (wordIndex: number, type: 'native' | 'user') => {
-    // Stop sentence audio if playing
-    if (sentenceAudioRef.current) {
-      sentenceAudioRef.current.pause();
-      sentenceAudioRef.current.currentTime = 0;
-    }
-    // Clear sentence state
-    setActiveSentenceType(null);
-    // Set word state
-    setActiveWordIndex(wordIndex);
-    setActiveWordType(type);
-  };
-
-  const handleWordStop = () => {
-    setActiveWordIndex(null);
-    setActiveWordType(null);
   };
 
   const handleInteractiveWordClick = (wordData: any, index: number) => {
@@ -208,7 +177,7 @@ export default function PronunciationFeedbackPanel({
 
       return {
         word: token,
-        overallScore: normalizedWord?.score ?? normalizedWord?.accuracyScore ?? null,
+        overallScore: normalizedWord?.score ?? normalizedWord?.accuracyScore ?? 0,
         normalizedWord,
       };
     });
@@ -308,4 +277,3 @@ export default function PronunciationFeedbackPanel({
     </div>
   );
 }
-

--- a/src/components/pronunciation/shared/InteractiveWordStrip.tsx
+++ b/src/components/pronunciation/shared/InteractiveWordStrip.tsx
@@ -120,52 +120,6 @@ export default function InteractiveWordStrip({
     }
   }, [externalActiveWordIndex, internalActiveWordIndex]);
 
-  const handleAudioClick = (
-    e: React.MouseEvent,
-    word: NormalizedWordFeedback,
-    type: 'native' | 'user'
-  ) => {
-    e.stopPropagation();
-    
-    if (!audioRef.current) return;
-
-    const wordIdx = word.index ?? parseInt(word.id, 10);
-    // Find the audio variant
-    const audioVariant = wordAudios?.find(
-      a => a.type === type && a.wordIndex === wordIdx
-    );
-    
-    // Guard against missing audio URL
-    if (!audioVariant || !audioVariant.url) {
-      return;
-    }
-
-    // Stop any currently playing audio
-    audioRef.current.pause();
-    audioRef.current.currentTime = 0;
-
-    // Notify parent
-    if (onWordStart) {
-      onWordStart(wordIdx, type);
-    } else {
-      // Fallback to internal state if no parent callback
-      setInternalActiveWordIndex(wordIdx);
-      setInternalActiveWordType(type);
-    }
-
-    // Play the audio
-    audioRef.current.src = audioVariant.url;
-    audioRef.current.play().catch((error) => {
-      console.error(`Failed to play ${type} audio for word "${word.text}":`, error);
-      if (onWordStop) {
-        onWordStop();
-      } else {
-        setInternalActiveWordIndex(null);
-        setInternalActiveWordType(null);
-      }
-    });
-  };
-
   const handleAudioEnded = () => {
     if (onWordStop) {
       onWordStop();
@@ -332,10 +286,6 @@ export default function InteractiveWordStrip({
       <div className="flex flex-wrap gap-2">
         {words.map((word) => {
           const wordIdx = word.index ?? parseInt(word.id, 10);
-          const nativeAudio = wordAudios?.find(
-            a => a.type === 'native' && a.wordIndex === wordIdx
-          );
-          
           const isNativePlaying = activeWordIndex === wordIdx && activeWordType === 'native';
           const isTtsPlaying = activeTtsWordId === word.wordId;
           const isPlaying = isNativePlaying || isTtsPlaying;
@@ -407,4 +357,3 @@ export default function InteractiveWordStrip({
     </div>
   );
 }
-

--- a/src/features/migration/LocalStorageMigrator.tsx
+++ b/src/features/migration/LocalStorageMigrator.tsx
@@ -1,18 +1,10 @@
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { isAuthenticated } from '@/api/auth';
 import { authenticatedFetch } from '@/api/auth';
 import { usePracticeLogStore } from '@/state/practiceLogStore';
 import { useProgressStore } from '@/state/progressStore';
 
 const MIGRATION_FLAG_KEY = 'luso_cloud_migrated';
-
-interface MigrationResult {
-  importedSessions: number;
-  importedAttempts: number;
-  skippedSessions: number;
-  skippedAttempts: number;
-  errors: string[];
-}
 
 /**
  * LocalStorageMigrator component
@@ -25,12 +17,6 @@ interface MigrationResult {
  * so it runs once after login.
  */
 export default function LocalStorageMigrator() {
-  const [migrationStatus, setMigrationStatus] = useState<
-    'idle' | 'checking' | 'migrating' | 'completed' | 'error'
-  >('idle');
-  const [migrationResult, setMigrationResult] = useState<MigrationResult | null>(null);
-  const [error, setError] = useState<string | null>(null);
-
   const practiceLogStore = usePracticeLogStore();
   const progressStore = useProgressStore();
 
@@ -42,15 +28,12 @@ export default function LocalStorageMigrator() {
       }
 
       // Check if migration has already been completed
-      if (typeof window !== 'undefined') {
-        const alreadyMigrated = localStorage.getItem(MIGRATION_FLAG_KEY);
-        if (alreadyMigrated === 'true') {
-          setMigrationStatus('completed');
-          return;
+        if (typeof window !== 'undefined') {
+          const alreadyMigrated = localStorage.getItem(MIGRATION_FLAG_KEY);
+          if (alreadyMigrated === 'true') {
+            return;
+          }
         }
-      }
-
-      setMigrationStatus('checking');
 
       try {
         // Read legacy data from stores
@@ -69,11 +52,8 @@ export default function LocalStorageMigrator() {
           if (typeof window !== 'undefined') {
             localStorage.setItem(MIGRATION_FLAG_KEY, 'true');
           }
-          setMigrationStatus('completed');
           return;
         }
-
-        setMigrationStatus('migrating');
 
         // Prepare migration payload
         const payload = {
@@ -97,15 +77,12 @@ export default function LocalStorageMigrator() {
           throw new Error(errorData.message || errorData.error || `HTTP ${response.status}`);
         }
 
-        const result: MigrationResult = await response.json();
-        setMigrationResult(result);
+        const result = await response.json();
 
         // Mark migration as completed
         if (typeof window !== 'undefined') {
           localStorage.setItem(MIGRATION_FLAG_KEY, 'true');
         }
-
-        setMigrationStatus('completed');
 
         // Log migration results
         console.log('[Migration] Migration completed:', {
@@ -120,9 +97,6 @@ export default function LocalStorageMigrator() {
           console.warn('[Migration] Some items failed to migrate:', result.errors);
         }
       } catch (err) {
-        const errorMessage = err instanceof Error ? err.message : 'Unknown error';
-        setError(errorMessage);
-        setMigrationStatus('error');
         console.error('[Migration] Migration failed:', err);
       }
     }
@@ -134,4 +108,3 @@ export default function LocalStorageMigrator() {
   // It runs silently in the background
   return null;
 }
-

--- a/src/hooks/useLivePronunciationPractice.test.tsx
+++ b/src/hooks/useLivePronunciationPractice.test.tsx
@@ -1,0 +1,169 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+import { useLivePronunciationPractice } from './useLivePronunciationPractice';
+import { analyzeAudioBlob } from '@/lib/audioQuality';
+
+const mockLogSentenceAttempt = vi.fn();
+const mockAudioBlob = new Blob([new Uint8Array([1, 2, 3])], { type: 'audio/ogg' });
+const mockRecorderState = {
+  isRecording: false,
+  audioBlob: mockAudioBlob,
+  audioUrl: 'blob://recording',
+  startRecording: vi.fn().mockResolvedValue(undefined),
+  stopRecording: vi.fn(),
+  reset: vi.fn(),
+  error: null as string | null,
+};
+
+vi.mock('./useMicrophoneRecorder', () => ({
+  useMicrophoneRecorder: () => mockRecorderState,
+}));
+
+vi.mock('@/state/practiceLogStore', () => ({
+  usePracticeLogStore: () => ({
+    logSentenceAttempt: mockLogSentenceAttempt,
+  }),
+}));
+
+vi.mock('@/lib/audioQuality', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/audioQuality')>('@/lib/audioQuality');
+  return {
+    ...actual,
+    analyzeAudioBlob: vi.fn(),
+  };
+});
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason?: unknown) => void;
+};
+
+function createDeferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function buildAssessmentResponse(attemptId: string): Response {
+  return new Response(
+    JSON.stringify({
+      rawAzure: {
+        RecognitionStatus: 'Success',
+        NBest: [{ Words: [] }],
+      },
+      attemptScore: {
+        attemptId,
+        sentenceId: 'sentence-1',
+        overallAccuracy: 85,
+        fluency: 80,
+        completeness: 90,
+        wordScores: [],
+        createdAt: new Date().toISOString(),
+      },
+    }),
+    {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }
+  );
+}
+
+describe('useLivePronunciationPractice lifecycle', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('fetch', vi.fn());
+    vi.mocked(analyzeAudioBlob).mockResolvedValue({
+      durationMs: 1400,
+      rms: 0.12,
+      isTooShort: false,
+      isSilent: false,
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('transitions submitting -> canceled when cancelAnalysis is triggered', async () => {
+    const fetchMock = vi.fn((_input: RequestInfo | URL, init?: RequestInit) => {
+      return new Promise<Response>((_resolve, reject) => {
+        const signal = init?.signal;
+        signal?.addEventListener('abort', () => {
+          reject(new DOMException('The operation was aborted.', 'AbortError'));
+        });
+      });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { result } = renderHook(() => useLivePronunciationPractice());
+
+    act(() => {
+      void result.current.submitAttempt('sentence-1', 'ola mundo');
+    });
+
+    await waitFor(() => {
+      expect(result.current.attemptState).toBe('submitting');
+    });
+
+    act(() => {
+      result.current.cancelAnalysis();
+    });
+
+    await waitFor(() => {
+      expect(result.current.attemptState).toBe('canceled');
+    });
+    expect(result.current.submitting).toBe(false);
+    expect(result.current.audioUrl).toBe('blob://recording');
+  });
+
+  it('ignores stale responses from older submissions', async () => {
+    const first = createDeferred<Response>();
+    const second = createDeferred<Response>();
+
+    const fetchMock = vi
+      .fn()
+      .mockImplementationOnce(() => first.promise)
+      .mockImplementationOnce(() => second.promise);
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { result } = renderHook(() => useLivePronunciationPractice());
+
+    act(() => {
+      void result.current.submitAttempt('sentence-1', 'ola mundo');
+    });
+    await waitFor(() => {
+      expect(result.current.attemptState).toBe('submitting');
+    });
+
+    act(() => {
+      void result.current.submitAttempt('sentence-1', 'ola mundo');
+    });
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    await act(async () => {
+      second.resolve(buildAssessmentResponse('attempt_new'));
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(result.current.currentAttempt?.attemptId).toBe('attempt_new');
+    });
+
+    await act(async () => {
+      first.resolve(buildAssessmentResponse('attempt_old'));
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(result.current.currentAttempt?.attemptId).toBe('attempt_new');
+    });
+  });
+});

--- a/src/hooks/useLivePronunciationPractice.ts
+++ b/src/hooks/useLivePronunciationPractice.ts
@@ -48,6 +48,15 @@ export interface LogAttemptParams {
   recordingDurationSeconds?: number;
 }
 
+export type AttemptLifecycleState =
+  | 'idle'
+  | 'recording'
+  | 'recorded'
+  | 'submitting'
+  | 'scored'
+  | 'error'
+  | 'canceled';
+
 /**
  * Result type for the useLivePronunciationPractice hook
  */
@@ -62,6 +71,7 @@ export type UseLivePronunciationPracticeResult = {
   // Submission state
   submitting: boolean;
   error: string | null;
+  attemptState: AttemptLifecycleState;
 
   // Attempt state
   attempts: AttemptScore[];
@@ -104,6 +114,7 @@ export function useLivePronunciationPractice(): UseLivePronunciationPracticeResu
 
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [attemptState, setAttemptState] = useState<AttemptLifecycleState>('idle');
   const [attempts, setAttempts] = useState<AttemptScore[]>([]);
   const [allRawAzureResponses, setAllRawAzureResponses] = useState<Map<string, any>>(new Map());
 
@@ -120,9 +131,22 @@ export function useLivePronunciationPractice(): UseLivePronunciationPracticeResu
   useEffect(() => {
     if (isRecording) {
       setError(null);
+      setAttemptState('recording');
       recordingStartTimeRef.current = Date.now();
     }
   }, [isRecording]);
+
+  useEffect(() => {
+    if (!isRecording && audioBlob && (attemptState === 'idle' || attemptState === 'recording' || attemptState === 'canceled')) {
+      setAttemptState('recorded');
+    }
+  }, [audioBlob, isRecording, attemptState]);
+
+  useEffect(() => {
+    if (recorderError) {
+      setAttemptState('error');
+    }
+  }, [recorderError]);
 
   // Cleanup abort controller on unmount
   useEffect(() => {
@@ -139,6 +163,7 @@ export function useLivePronunciationPractice(): UseLivePronunciationPracticeResu
   const resetRecording = useCallback(() => {
     resetRecorder();
     setError(null);
+    setAttemptState('idle');
     recordingStartTimeRef.current = null;
   }, [resetRecorder]);
 
@@ -158,6 +183,7 @@ export function useLivePronunciationPractice(): UseLivePronunciationPracticeResu
     // Guard against missing audio blob
     if (!audioBlob) {
       setError('No recording available. Please record audio first.');
+      setAttemptState('error');
       return;
     }
 
@@ -170,15 +196,18 @@ export function useLivePronunciationPractice(): UseLivePronunciationPracticeResu
         setError(
           `Too short - try speaking the whole sentence (at least ${(MIN_DURATION_MS / 1000).toFixed(1)}s).`
         );
+        setAttemptState('error');
         return;
       }
       if (quality.isSilent) {
         setError('Too quiet - move closer to the mic and try again.');
+        setAttemptState('error');
         return;
       }
     } catch (qualityError) {
       console.error('Audio quality analysis failed:', qualityError);
       setError('Could not analyze this recording. Please record again and speak clearly.');
+      setAttemptState('error');
       return;
     }
 
@@ -192,6 +221,7 @@ export function useLivePronunciationPractice(): UseLivePronunciationPracticeResu
     abortControllerRef.current = abortController;
 
     setSubmitting(true);
+    setAttemptState('submitting');
 
     try {
       // Build FormData
@@ -357,6 +387,7 @@ export function useLivePronunciationPractice(): UseLivePronunciationPracticeResu
       // 2. User starts a new recording (startRecording clears previous state)
       // 3. Sentence changes (handled by parent component)
       recordingStartTimeRef.current = null;
+      setAttemptState('scored');
     } catch (err) {
       // Check if request was aborted
       if (abortController.signal.aborted) {
@@ -383,8 +414,10 @@ export function useLivePronunciationPractice(): UseLivePronunciationPracticeResu
         }
         
         setError(errorMessage);
+        setAttemptState('error');
       } else {
         setError('Failed to assess pronunciation. Please try again.');
+        setAttemptState('error');
       }
 
       console.error('Error submitting pronunciation assessment:', err);
@@ -425,6 +458,7 @@ export function useLivePronunciationPractice(): UseLivePronunciationPracticeResu
     // Submission state
     submitting,
     error: combinedError,
+    attemptState,
 
     // Attempt state
     attempts,

--- a/src/hooks/useLivePronunciationPractice.ts
+++ b/src/hooks/useLivePronunciationPractice.ts
@@ -139,7 +139,7 @@ export function useLivePronunciationPractice(): UseLivePronunciationPracticeResu
   }, [isRecording]);
 
   useEffect(() => {
-    if (!isRecording && audioBlob && (attemptState === 'idle' || attemptState === 'recording' || attemptState === 'canceled')) {
+    if (!isRecording && audioBlob && (attemptState === 'idle' || attemptState === 'recording')) {
       setAttemptState('recorded');
     }
   }, [audioBlob, isRecording, attemptState]);

--- a/src/hooks/useLivePronunciationPractice.ts
+++ b/src/hooks/useLivePronunciationPractice.ts
@@ -78,7 +78,7 @@ export type UseLivePronunciationPracticeResult = {
  * 
  * Encapsulates:
  * - Microphone recording (via useMicrophoneRecorder)
- * - Audio submission to /api/pronunciation-assessment
+ * - Audio submission to /api/pronunciation/assessment
  * - Round-trip latency measurement
  * - Attempt history management
  * - Optional practice log integration
@@ -181,7 +181,7 @@ export function useLivePronunciationPractice(): UseLivePronunciationPracticeResu
       const startedAt = performance.now();
 
       // POST to API endpoint
-      const response = await fetch('/api/pronunciation-assessment', {
+      const response = await fetch('/api/pronunciation/assessment', {
         method: 'POST',
         body: formData,
         signal: abortController.signal,
@@ -353,7 +353,7 @@ export function useLivePronunciationPractice(): UseLivePronunciationPracticeResu
         if (err.message.includes('Failed to fetch') || err.message.includes('NetworkError')) {
           errorMessage = 'Network error: Could not connect to the server. Please check your connection and ensure the API route is configured.';
         } else if (err.message.includes('404')) {
-          errorMessage = 'API endpoint not found. Please ensure the server is running and the /api/pronunciation-assessment route is configured.';
+          errorMessage = 'API endpoint not found. Please ensure the server is running and the /api/pronunciation/assessment route is configured.';
         } else if (err.message.includes('500')) {
           errorMessage = 'Server error: The pronunciation assessment service encountered an error. Please try again.';
         }

--- a/src/hooks/useLivePronunciationPractice.ts
+++ b/src/hooks/useLivePronunciationPractice.ts
@@ -85,6 +85,7 @@ export type UseLivePronunciationPracticeResult = {
     referenceText: string,
     logParams?: LogAttemptParams | null
   ) => Promise<void>;
+  cancelAnalysis: () => void;
 };
 
 /**
@@ -120,6 +121,7 @@ export function useLivePronunciationPractice(): UseLivePronunciationPracticeResu
 
   // AbortController for canceling in-flight requests
   const abortControllerRef = useRef<AbortController | null>(null);
+  const activeRequestIdRef = useRef<string | null>(null);
 
   // Track recording start time for duration calculation (optional, for logging)
   const recordingStartTimeRef = useRef<number | null>(null);
@@ -154,6 +156,7 @@ export function useLivePronunciationPractice(): UseLivePronunciationPracticeResu
       if (abortControllerRef.current) {
         abortControllerRef.current.abort();
       }
+      activeRequestIdRef.current = null;
     };
   }, []);
 
@@ -166,6 +169,19 @@ export function useLivePronunciationPractice(): UseLivePronunciationPracticeResu
     setAttemptState('idle');
     recordingStartTimeRef.current = null;
   }, [resetRecorder]);
+
+  const cancelAnalysis = useCallback(() => {
+    if (!abortControllerRef.current) {
+      return;
+    }
+
+    abortControllerRef.current.abort();
+    abortControllerRef.current = null;
+    activeRequestIdRef.current = null;
+    setSubmitting(false);
+    setError(null);
+    setAttemptState('canceled');
+  }, []);
 
   /**
    * Submits the recorded audio to the pronunciation assessment API.
@@ -215,10 +231,13 @@ export function useLivePronunciationPractice(): UseLivePronunciationPracticeResu
     if (abortControllerRef.current) {
       abortControllerRef.current.abort();
     }
+    activeRequestIdRef.current = null;
 
     // Create new AbortController for this request
     const abortController = new AbortController();
+    const requestId = `req_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
     abortControllerRef.current = abortController;
+    activeRequestIdRef.current = requestId;
 
     setSubmitting(true);
     setAttemptState('submitting');
@@ -246,7 +265,7 @@ export function useLivePronunciationPractice(): UseLivePronunciationPracticeResu
       const latencyMs = Math.round(finishedAt - startedAt);
 
       // Check if request was aborted
-      if (abortController.signal.aborted) {
+      if (abortController.signal.aborted || activeRequestIdRef.current !== requestId) {
         return; // Don't update state if component unmounted
       }
 
@@ -278,7 +297,7 @@ export function useLivePronunciationPractice(): UseLivePronunciationPracticeResu
       }
 
       // Check if request was aborted after JSON parsing
-      if (abortController.signal.aborted) {
+      if (abortController.signal.aborted || activeRequestIdRef.current !== requestId) {
         return;
       }
 
@@ -390,7 +409,7 @@ export function useLivePronunciationPractice(): UseLivePronunciationPracticeResu
       setAttemptState('scored');
     } catch (err) {
       // Check if request was aborted
-      if (abortController.signal.aborted) {
+      if (abortController.signal.aborted || activeRequestIdRef.current !== requestId) {
         return; // Don't update state if component unmounted
       }
 
@@ -429,12 +448,13 @@ export function useLivePronunciationPractice(): UseLivePronunciationPracticeResu
         });
       }
     } finally {
-      // Only update submitting state if request wasn't aborted
-      if (!abortController.signal.aborted) {
+      if (activeRequestIdRef.current === requestId) {
+        activeRequestIdRef.current = null;
+        abortControllerRef.current = null;
         setSubmitting(false);
       }
     }
-  }, [audioBlob, audioUrl, resetRecorder, logSentenceAttempt]);
+  }, [audioBlob, audioUrl, logSentenceAttempt]);
 
   // Derive current attempt (most recent)
   const currentAttempt = attempts.length > 0 ? attempts[0] : null;
@@ -468,5 +488,6 @@ export function useLivePronunciationPractice(): UseLivePronunciationPracticeResu
 
     // Actions
     submitAttempt,
+    cancelAnalysis,
   };
 }

--- a/src/hooks/useLivePronunciationPractice.ts
+++ b/src/hooks/useLivePronunciationPractice.ts
@@ -2,6 +2,10 @@ import { useState, useCallback, useRef, useEffect } from 'react';
 import { useMicrophoneRecorder } from './useMicrophoneRecorder';
 import { usePracticeLogStore } from '@/state/practiceLogStore';
 import type { AttemptScore, WordScore } from '@/types/pronunciation';
+import {
+  analyzeAudioBlob,
+  MIN_DURATION_MS,
+} from '@/lib/audioQuality';
 
 /**
  * Response type from the pronunciation assessment API
@@ -157,6 +161,27 @@ export function useLivePronunciationPractice(): UseLivePronunciationPracticeResu
       return;
     }
 
+    setError(null);
+
+    // Client-side audio quality gate: block very short or effectively silent submissions.
+    try {
+      const quality = await analyzeAudioBlob(audioBlob);
+      if (quality.isTooShort) {
+        setError(
+          `Too short - try speaking the whole sentence (at least ${(MIN_DURATION_MS / 1000).toFixed(1)}s).`
+        );
+        return;
+      }
+      if (quality.isSilent) {
+        setError('Too quiet - move closer to the mic and try again.');
+        return;
+      }
+    } catch (qualityError) {
+      console.error('Audio quality analysis failed:', qualityError);
+      setError('Could not analyze this recording. Please record again and speak clearly.');
+      return;
+    }
+
     // Cancel any in-flight request
     if (abortControllerRef.current) {
       abortControllerRef.current.abort();
@@ -167,7 +192,6 @@ export function useLivePronunciationPractice(): UseLivePronunciationPracticeResu
     abortControllerRef.current = abortController;
 
     setSubmitting(true);
-    setError(null);
 
     try {
       // Build FormData
@@ -412,4 +436,3 @@ export function useLivePronunciationPractice(): UseLivePronunciationPracticeResu
     submitAttempt,
   };
 }
-

--- a/src/hooks/useLivePronunciationPractice.ts
+++ b/src/hooks/useLivePronunciationPractice.ts
@@ -1,6 +1,7 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
 import { useMicrophoneRecorder } from './useMicrophoneRecorder';
 import { usePracticeLogStore } from '@/state/practiceLogStore';
+import type { Difficulty } from '@/lib/types';
 import type { AttemptScore, WordScore } from '@/types/pronunciation';
 import {
   analyzeAudioBlob,
@@ -39,7 +40,7 @@ async function blobToDataUrl(blob: Blob): Promise<string> {
 export interface LogAttemptParams {
   sessionId: string;
   sentenceId: string;
-  difficulty: number;
+  difficulty: Difficulty;
   category: string;
   retriesInThisSession?: number;
   usedHint?: boolean;

--- a/src/lib/audioQuality.test.ts
+++ b/src/lib/audioQuality.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { analyzeAudioBlob, MIN_DURATION_MS, MIN_RMS } from './audioQuality';
+
+const dummyBlob = new Blob([new Uint8Array([1, 2, 3])], { type: 'audio/wav' });
+
+describe('analyzeAudioBlob', () => {
+  it('flags recordings shorter than minimum duration', async () => {
+    const result = await analyzeAudioBlob(dummyBlob, {
+      decodeAudioData: async () => ({
+        durationSeconds: (MIN_DURATION_MS - 200) / 1000,
+        channels: [new Float32Array([0.2, -0.2, 0.2, -0.2])],
+      }),
+    });
+
+    expect(result.isTooShort).toBe(true);
+    expect(result.isSilent).toBe(false);
+    expect(result.durationMs).toBeLessThan(MIN_DURATION_MS);
+  });
+
+  it('flags effectively silent recordings', async () => {
+    const result = await analyzeAudioBlob(dummyBlob, {
+      decodeAudioData: async () => ({
+        durationSeconds: 1.4,
+        channels: [new Float32Array([0.0002, -0.0001, 0.0001, -0.0002])],
+      }),
+    });
+
+    expect(result.isTooShort).toBe(false);
+    expect(result.isSilent).toBe(true);
+    expect(result.rms).toBeLessThan(MIN_RMS);
+  });
+});

--- a/src/lib/audioQuality.ts
+++ b/src/lib/audioQuality.ts
@@ -1,0 +1,107 @@
+export const MIN_DURATION_MS = 900;
+export const MIN_RMS = 0.012;
+const DEFAULT_SAMPLE_STRIDE = 4;
+
+type WebkitWindow = Window & {
+  webkitAudioContext?: typeof AudioContext;
+};
+
+export type DecodedAudioChannels = {
+  durationSeconds: number;
+  channels: Float32Array[];
+};
+
+export type AudioQualityAnalysis = {
+  durationMs: number;
+  rms: number;
+  isTooShort: boolean;
+  isSilent: boolean;
+};
+
+export type AnalyzeAudioOptions = {
+  minDurationMs?: number;
+  minRms?: number;
+  sampleStride?: number;
+  decodeAudioData?: (blob: Blob) => Promise<DecodedAudioChannels>;
+};
+
+export function computeRms(signal: Float32Array, sampleStride: number = DEFAULT_SAMPLE_STRIDE): number {
+  if (signal.length === 0) {
+    return 0;
+  }
+
+  let sumSquares = 0;
+  let sampledCount = 0;
+  const stride = Math.max(1, Math.floor(sampleStride));
+
+  for (let index = 0; index < signal.length; index += stride) {
+    const sample = signal[index];
+    sumSquares += sample * sample;
+    sampledCount += 1;
+  }
+
+  if (sampledCount === 0) {
+    return 0;
+  }
+
+  return Math.sqrt(sumSquares / sampledCount);
+}
+
+export function computeCombinedRms(
+  channels: Float32Array[],
+  sampleStride: number = DEFAULT_SAMPLE_STRIDE
+): number {
+  if (channels.length === 0) {
+    return 0;
+  }
+
+  const sum = channels.reduce((total, channel) => total + computeRms(channel, sampleStride), 0);
+  return sum / channels.length;
+}
+
+async function decodeAudioBlob(blob: Blob): Promise<DecodedAudioChannels> {
+  const AudioContextConstructor =
+    window.AudioContext || (window as WebkitWindow).webkitAudioContext;
+
+  if (!AudioContextConstructor) {
+    throw new Error('AudioContext is not available in this browser.');
+  }
+
+  const audioContext = new AudioContextConstructor();
+  try {
+    const encoded = await blob.arrayBuffer();
+    const decoded = await audioContext.decodeAudioData(encoded.slice(0));
+    const channels: Float32Array[] = [];
+    for (let channelIndex = 0; channelIndex < decoded.numberOfChannels; channelIndex += 1) {
+      channels.push(decoded.getChannelData(channelIndex));
+    }
+
+    return {
+      durationSeconds: decoded.duration,
+      channels,
+    };
+  } finally {
+    await audioContext.close().catch(() => undefined);
+  }
+}
+
+export async function analyzeAudioBlob(
+  blob: Blob,
+  options: AnalyzeAudioOptions = {}
+): Promise<AudioQualityAnalysis> {
+  const minDurationMs = options.minDurationMs ?? MIN_DURATION_MS;
+  const minRms = options.minRms ?? MIN_RMS;
+  const sampleStride = options.sampleStride ?? DEFAULT_SAMPLE_STRIDE;
+  const decode = options.decodeAudioData ?? decodeAudioBlob;
+  const decoded = await decode(blob);
+
+  const durationMs = Math.round(decoded.durationSeconds * 1000);
+  const rms = computeCombinedRms(decoded.channels, sampleStride);
+
+  return {
+    durationMs,
+    rms,
+    isTooShort: durationMs < minDurationMs,
+    isSilent: rms < minRms,
+  };
+}

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -332,7 +332,7 @@ export async function loadAllSentences(): Promise<Sentence[]> {
         .replace(/[^\w\s]/g, ''); // Remove punctuation
     };
     
-    let wordsForWordRefs: EnrichedWord[] = [];
+    let wordsForWordRefs: Array<Pick<EnrichedWord, 'id' | 'text' | 'normalizedText'>> = [];
     try {
       const wordsData = await loadAllWords();
       // Convert Word[] to EnrichedWord[] format for buildWordRefs
@@ -651,4 +651,3 @@ export function clearDataCache(): void {
   cachedCategories = null;
   cachedAudioIndex = null;
 }
-

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -240,6 +240,7 @@ export interface SentencePracticeAttempt {
     overallScore: number;
     accuracyScore?: number;
     fluencyScore?: number;
+    errorType?: 'none' | 'mispronounced' | 'omitted' | 'extra';
     phonemeScores?: {
       phonemeId: PhonemeId;
       overallScore: number;
@@ -395,4 +396,3 @@ export interface PhonemeStats {
   lastPracticedAt?: string; // ISO timestamp
   weaknessLabel?: "weak" | "ok" | "strong";
 }
-

--- a/src/lib/wordPronunciation.ts
+++ b/src/lib/wordPronunciation.ts
@@ -29,7 +29,7 @@ export async function scoreWordPronunciation(
   formData.append('language', 'pt-BR');
 
   // POST to API endpoint (same endpoint as sentences)
-  const response = await fetch('/api/pronunciation-assessment', {
+  const response = await fetch('/api/pronunciation/assessment', {
     method: 'POST',
     body: formData,
   });

--- a/src/pages/AuthPage.tsx
+++ b/src/pages/AuthPage.tsx
@@ -5,7 +5,7 @@ import type { User } from '@/shared/types';
 export default function AuthPage() {
   const navigate = useNavigate();
 
-  const handleSuccess = (user: User) => {
+  const handleSuccess = (_user: User) => {
     // Redirect to dashboard after successful auth
     navigate('/');
   };
@@ -16,4 +16,3 @@ export default function AuthPage() {
     </div>
   );
 }
-

--- a/src/pages/SentencePractice.tsx
+++ b/src/pages/SentencePractice.tsx
@@ -5,7 +5,6 @@ import {
   loadAllSentences,
   loadAllCategories,
   filterSentencesByCategory,
-  filterSentencesByDifficulty,
 } from '@/lib/data';
 import { preloadAudioIndex } from '@/utils/audioRouting';
 import type { Sentence, Category, Difficulty, SentencePracticeAttempt } from '@/lib/types';
@@ -18,7 +17,6 @@ import ScoreHistory from '@/components/practice/ScoreHistory';
 import AttemptHistory from '@/components/practice/AttemptHistory';
 import SentenceFeedback from '@/components/practice/SentenceFeedback';
 import FilterControls from '@/components/practice/FilterControls';
-import NavigationButtons from '@/components/practice/NavigationButtons';
 import LoadingSpinner from '@/components/common/LoadingSpinner';
 import PageTransition from '@/components/common/PageTransition';
 

--- a/src/pages/WordPractice.tsx
+++ b/src/pages/WordPractice.tsx
@@ -6,7 +6,7 @@ import {
   loadAllCategories,
   filterWordsByCategory,
 } from '@/lib/data';
-import type { Word, Category, Difficulty, WordProgress, WordId } from '@/lib/types';
+import type { Word, Category, Difficulty } from '@/lib/types';
 import { buildWordProgress, getWeakWordIds } from '@/lib/practiceAnalytics';
 import WordStudyCard from '@/components/practice/WordStudyCard';
 import WordCard from '@/components/practice/WordCard';

--- a/src/pages/dev/pronunciation-fixtures.tsx
+++ b/src/pages/dev/pronunciation-fixtures.tsx
@@ -8,8 +8,8 @@ import {
   type NormalizedWordAudioVariant,
 } from '@/components/pronunciation/shared';
 import type { AudioVariant, WordAudioVariant } from '@/types/pronunciationFixtures';
-import { loadAllCategories, loadAllSentences, type Category } from '@/lib/data';
-import type { Sentence } from '@/lib/types';
+import { loadAllCategories, loadAllSentences } from '@/lib/data';
+import type { Category, Sentence } from '@/lib/types';
 import type { AttemptScore } from '@/types/pronunciation';
 import MultiSelect, { type MultiSelectOption } from '@/components/common/MultiSelect';
 import ScoringPanel from '@/components/pronunciation/ScoringPanel';
@@ -150,8 +150,19 @@ export default function PronunciationFixtures() {
 
   // Start a practice session on mount
   useEffect(() => {
-    const newSessionId = startSession('sentences');
-    setSessionId(newSessionId);
+    let mounted = true;
+    startSession('sentences')
+      .then((newSessionId) => {
+        if (mounted) {
+          setSessionId(newSessionId);
+        }
+      })
+      .catch((error) => {
+        console.warn('Failed to start practice session:', error);
+      });
+    return () => {
+      mounted = false;
+    };
   }, [startSession]);
 
   useEffect(() => {
@@ -445,4 +456,3 @@ export default function PronunciationFixtures() {
     </div>
   );
 }
-

--- a/src/pipeline/sentenceWordRefs.ts
+++ b/src/pipeline/sentenceWordRefs.ts
@@ -116,12 +116,12 @@ export function computeSentenceWordRefs(
  */
 export function buildWordRefs(
   sentence: string,
-  words: EnrichedWord[]
+  words: Array<Pick<EnrichedWord, 'id' | 'text' | 'normalizedText'>>
 ): Array<{ wordId: string; tokenIndex: number; startChar: number; endChar: number }> {
   const wordRefs: Array<{ wordId: string; tokenIndex: number; startChar: number; endChar: number }> = [];
   
-  // Create a lookup map of normalized word text to EnrichedWord
-  const wordMap = new Map<string, EnrichedWord>();
+  // Create a lookup map of normalized word text to source word metadata.
+  const wordMap = new Map<string, Pick<EnrichedWord, 'id' | 'text' | 'normalizedText'>>();
   for (const word of words) {
     const normalized = word.normalizedText || normalizeToken(word.text);
     // If multiple words have the same normalized form, keep the first one
@@ -182,4 +182,3 @@ export function buildWordRefs(
 
   return wordRefs;
 }
-

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -3,7 +3,7 @@ import cors from 'cors';
 import { config } from 'dotenv';
 import { connectMongo } from './db/mongoClient';
 import healthRouter from './routes/health';
-import pronunciationRouter from './routes/pronunciationAssessment';
+import pronunciationRouter, { legacyPronunciationAssessmentRouter } from './routes/pronunciationAssessment';
 import authRouter from './routes/auth';
 import practiceRouter from './routes/practice';
 import migrationRouter from './routes/migration';
@@ -26,6 +26,7 @@ app.use('/api', practiceRouter);
 app.use('/api/migrate', migrationRouter);
 app.use('/api/flashcards', flashcardsRouter);
 app.use('/api/pronunciation', pronunciationRouter);
+app.use('/api/pronunciation-assessment', legacyPronunciationAssessmentRouter);
 
 // Root route
 app.get('/', (req, res) => {
@@ -77,4 +78,3 @@ if (require.main === module) {
 }
 
 export default app;
-

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -41,7 +41,7 @@ app.use(
 );
 
 // Root route
-app.get('/', (req, res) => {
+app.get('/', (_req, res) => {
   res.json({
     message: 'LusoPronunciation API',
     version: '1.0.0',

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -1,5 +1,4 @@
 import express, { Express } from 'express';
-import cors from 'cors';
 import { config } from 'dotenv';
 import { connectMongo } from './db/mongoClient';
 import healthRouter from './routes/health';
@@ -8,6 +7,10 @@ import authRouter from './routes/auth';
 import practiceRouter from './routes/practice';
 import migrationRouter from './routes/migration';
 import flashcardsRouter from './routes/flashcards';
+import {
+  pronunciationCorsMiddleware,
+  pronunciationRateLimitMiddleware,
+} from './middleware/pronunciationSecurity';
 
 // Load environment variables
 config();
@@ -16,7 +19,6 @@ const app: Express = express();
 const PORT = process.env.PORT || 4000;
 
 // Middleware
-app.use(cors());
 app.use(express.json());
 
 // Routes
@@ -25,8 +27,18 @@ app.use('/api/auth', authRouter);
 app.use('/api', practiceRouter);
 app.use('/api/migrate', migrationRouter);
 app.use('/api/flashcards', flashcardsRouter);
-app.use('/api/pronunciation', pronunciationRouter);
-app.use('/api/pronunciation-assessment', legacyPronunciationAssessmentRouter);
+app.use(
+  '/api/pronunciation',
+  pronunciationCorsMiddleware,
+  pronunciationRateLimitMiddleware,
+  pronunciationRouter
+);
+app.use(
+  '/api/pronunciation-assessment',
+  pronunciationCorsMiddleware,
+  pronunciationRateLimitMiddleware,
+  legacyPronunciationAssessmentRouter
+);
 
 // Root route
 app.get('/', (req, res) => {

--- a/src/server/mappers/practiceMapper.ts
+++ b/src/server/mappers/practiceMapper.ts
@@ -14,9 +14,6 @@ export function mapPracticeSessionDocToDto(
 ): PracticeSession {
   const startedAt = doc.startedAt.toISOString();
   const endedAt = doc.endedAt?.toISOString();
-  const durationSeconds = endedAt
-    ? Math.floor((doc.endedAt.getTime() - doc.startedAt.getTime()) / 1000)
-    : undefined;
 
   return {
     id: doc._id.toString(),
@@ -115,4 +112,3 @@ export function mapPronunciationAttemptDocsToDtos(
 ): PronunciationAttempt[] {
   return docs.map(mapPronunciationAttemptDocToDto);
 }
-

--- a/src/server/middleware/pronunciationSecurity.ts
+++ b/src/server/middleware/pronunciationSecurity.ts
@@ -1,0 +1,166 @@
+import type { NextFunction, Request, Response } from 'express';
+import { speechLog } from '../utils/speechDebug';
+
+const DEFAULT_ALLOWED_ORIGINS = [
+  'http://localhost:3000',
+  'http://127.0.0.1:3000',
+  'http://localhost:5173',
+  'http://127.0.0.1:5173',
+];
+
+const DEFAULT_RATE_LIMIT_WINDOW_MS = 5 * 60 * 1000;
+const DEFAULT_RATE_LIMIT_MAX_REQUESTS = 20;
+
+type RateLimitEntry = {
+  count: number;
+  resetAt: number;
+};
+
+const pronunciationRateLimitStore = new Map<string, RateLimitEntry>();
+let lastRateLimitCleanupAt = 0;
+
+function parsePositiveIntEnvValue(rawValue: string | undefined, fallback: number): number {
+  if (!rawValue) {
+    return fallback;
+  }
+
+  const parsed = Number.parseInt(rawValue, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return fallback;
+  }
+
+  return parsed;
+}
+
+function readConfiguredOrigins(): Set<string> {
+  const allowlist = new Set(DEFAULT_ALLOWED_ORIGINS);
+  const rawAllowlist =
+    process.env.SPEECH_CORS_ALLOWED_ORIGINS ||
+    process.env.CORS_ALLOWED_ORIGINS ||
+    process.env.APP_ORIGINS ||
+    '';
+
+  rawAllowlist
+    .split(',')
+    .map((origin) => origin.trim())
+    .filter(Boolean)
+    .forEach((origin) => allowlist.add(origin));
+
+  return allowlist;
+}
+
+function resolveRateLimitKey(req: Request): string {
+  const user = (req as Request & { user?: { id?: string; userId?: string; _id?: string } }).user;
+  const userId = user?.id || user?.userId || user?._id;
+  if (userId) {
+    return `user:${userId}`;
+  }
+
+  const ip = req.ip || req.socket.remoteAddress || 'unknown';
+  return `ip:${ip}`;
+}
+
+function cleanupExpiredRateLimitEntries(now: number): void {
+  if (now - lastRateLimitCleanupAt < 60_000) {
+    return;
+  }
+
+  lastRateLimitCleanupAt = now;
+  for (const [key, entry] of pronunciationRateLimitStore.entries()) {
+    if (entry.resetAt <= now) {
+      pronunciationRateLimitStore.delete(key);
+    }
+  }
+}
+
+export function pronunciationCorsMiddleware(req: Request, res: Response, next: NextFunction): void {
+  const requestId = req.header('x-request-id') || 'unknown';
+  const requestOrigin = req.header('origin');
+  const allowedOrigins = readConfiguredOrigins();
+
+  // Allow requests with no Origin header (CLI/server-to-server/same-origin requests).
+  if (!requestOrigin) {
+    if (req.method === 'OPTIONS') {
+      res.status(204).end();
+      return;
+    }
+    next();
+    return;
+  }
+
+  if (!allowedOrigins.has(requestOrigin)) {
+    speechLog('warn', 'Pronunciation request blocked by CORS policy', {
+      requestId,
+      statusClass: '4xx',
+    });
+    res.status(403).json({
+      error: 'Origin not allowed',
+      message: 'This origin is not allowed to access pronunciation endpoints.',
+      requestId,
+    });
+    return;
+  }
+
+  const requestedHeaders =
+    req.header('access-control-request-headers') || 'Content-Type, Authorization, X-Request-Id';
+  res.setHeader('Access-Control-Allow-Origin', requestOrigin);
+  res.setHeader('Vary', 'Origin');
+  res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', requestedHeaders);
+  res.setHeader('Access-Control-Max-Age', '600');
+
+  if (req.method === 'OPTIONS') {
+    res.status(204).end();
+    return;
+  }
+
+  next();
+}
+
+export function pronunciationRateLimitMiddleware(req: Request, res: Response, next: NextFunction): void {
+  const requestId = req.header('x-request-id') || 'unknown';
+  const windowMs = parsePositiveIntEnvValue(
+    process.env.SPEECH_RATE_LIMIT_WINDOW_MS,
+    DEFAULT_RATE_LIMIT_WINDOW_MS
+  );
+  const maxRequests = parsePositiveIntEnvValue(
+    process.env.SPEECH_RATE_LIMIT_MAX_REQUESTS,
+    DEFAULT_RATE_LIMIT_MAX_REQUESTS
+  );
+
+  const now = Date.now();
+  cleanupExpiredRateLimitEntries(now);
+
+  const key = resolveRateLimitKey(req);
+  const current = pronunciationRateLimitStore.get(key);
+
+  if (!current || current.resetAt <= now) {
+    pronunciationRateLimitStore.set(key, {
+      count: 1,
+      resetAt: now + windowMs,
+    });
+    next();
+    return;
+  }
+
+  if (current.count >= maxRequests) {
+    const retryAfterSeconds = Math.max(1, Math.ceil((current.resetAt - now) / 1000));
+    speechLog('warn', 'Pronunciation request blocked by rate limiter', {
+      requestId,
+      statusClass: '4xx',
+    });
+    res.setHeader('Retry-After', String(retryAfterSeconds));
+    res.status(429).json({
+      error: 'Too many requests',
+      message: 'You have reached the pronunciation request limit. Please wait and try again.',
+      requestId,
+    });
+    return;
+  }
+
+  pronunciationRateLimitStore.set(key, {
+    ...current,
+    count: current.count + 1,
+  });
+  next();
+}

--- a/src/server/routes/auth.ts
+++ b/src/server/routes/auth.ts
@@ -3,7 +3,6 @@ import bcrypt from 'bcrypt';
 import jwt from 'jsonwebtoken';
 import { UserModel } from '../models/UserModel';
 import { mapUserDocToDto } from '../mappers/userMapper';
-import type { User } from '../../shared/types';
 
 const router = Router();
 
@@ -184,4 +183,3 @@ router.post('/login', async (req: Request, res: Response) => {
 });
 
 export default router;
-

--- a/src/server/routes/flashcards.ts
+++ b/src/server/routes/flashcards.ts
@@ -2,7 +2,7 @@ import { Router, Response } from 'express';
 import mongoose from 'mongoose';
 import { requireAuth, type AuthenticatedRequest } from '../middleware/auth';
 import { FlashcardModel } from '../models/FlashcardModel';
-import { ensureFlashcard, updateFlashcardAfterReview, scoreToOutcome } from '../services/flashcardService';
+import { ensureFlashcard, updateFlashcardAfterReview } from '../services/flashcardService';
 import type { ReviewOutcome } from '../models/FlashcardModel';
 
 const router = Router();
@@ -249,4 +249,3 @@ router.post('/ensure', requireAuth, async (req: AuthenticatedRequest, res: Respo
 });
 
 export default router;
-

--- a/src/server/routes/health.ts
+++ b/src/server/routes/health.ts
@@ -8,7 +8,7 @@ const router = Router();
  * 
  * Returns health status of the API and MongoDB connection
  */
-router.get('/', async (req: Request, res: Response) => {
+router.get('/', async (_req: Request, res: Response) => {
   try {
     const mongoStatus = await getMongoStatus();
 
@@ -30,4 +30,3 @@ router.get('/', async (req: Request, res: Response) => {
 });
 
 export default router;
-

--- a/src/server/routes/practice.ts
+++ b/src/server/routes/practice.ts
@@ -9,8 +9,6 @@ import {
   mapPronunciationAttemptDocsToDtos,
 } from '../mappers/practiceMapper';
 import type {
-  PracticeSession,
-  PronunciationAttempt,
   PracticeSessionMode,
 } from '../../shared/types';
 
@@ -324,4 +322,3 @@ router.get('/pronunciation-attempts', requireAuth, async (req: AuthenticatedRequ
 });
 
 export default router;
-

--- a/src/server/routes/pronunciationAssessment.contract.test.ts
+++ b/src/server/routes/pronunciationAssessment.contract.test.ts
@@ -1,0 +1,127 @@
+import type { Request as ExpressRequest, Response as ExpressResponse } from 'express';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import pronunciationRouter, {
+  handlePronunciationAssessmentExpress,
+  legacyPronunciationAssessmentRouter,
+} from './pronunciationAssessment';
+
+const mockAzureResponse = {
+  RecognitionStatus: 'Success',
+  NBest: [
+    {
+      PronunciationAssessment: {
+        AccuracyScore: 88,
+        FluencyScore: 84,
+        CompletenessScore: 90,
+        PronScore: 86,
+      },
+      Words: [
+        {
+          Word: 'ola',
+          PronunciationAssessment: {
+            AccuracyScore: 88,
+            ErrorType: 'None',
+          },
+        },
+      ],
+    },
+  ],
+};
+
+type MockResponse = ExpressResponse & {
+  body: unknown;
+  statusCode: number;
+  headers: Record<string, string>;
+};
+
+function createRequest(): ExpressRequest {
+  return {
+    file: {
+      buffer: Buffer.from([0x52, 0x49, 0x46, 0x46]), // RIFF
+      mimetype: 'audio/wav',
+    },
+    body: {
+      sentenceId: 'sentence-1',
+      referenceText: 'ola mundo',
+      language: 'pt-BR',
+    },
+    header: vi.fn().mockReturnValue(undefined),
+  } as unknown as ExpressRequest;
+}
+
+function createResponse(): MockResponse {
+  const headers: Record<string, string> = {};
+  const response: Partial<MockResponse> = {
+    body: null,
+    statusCode: 200,
+    headers,
+  };
+
+  response.setHeader = vi.fn((name: string, value: string) => {
+    headers[name.toLowerCase()] = String(value);
+    return response as MockResponse;
+  });
+  response.status = vi.fn((code: number) => {
+    response.statusCode = code;
+    return response as MockResponse;
+  });
+  response.json = vi.fn((payload: unknown) => {
+    response.body = payload;
+    return response as MockResponse;
+  });
+
+  return response as MockResponse;
+}
+
+describe('pronunciation assessment endpoint contract', () => {
+  beforeEach(() => {
+    process.env.AZURE_SPEECH_KEY = 'test-key';
+    process.env.AZURE_SPEECH_REGION = 'eastus';
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify(mockAzureResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('POST /api/pronunciation/assessment returns expected shape', async () => {
+    const req = createRequest();
+    const res = createResponse();
+
+    await handlePronunciationAssessmentExpress(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual(
+      expect.objectContaining({
+        rawAzure: expect.any(Object),
+        attemptScore: expect.objectContaining({
+          sentenceId: 'sentence-1',
+          wordScores: expect.any(Array),
+        }),
+      })
+    );
+  });
+
+  it('legacy alias route points to the same POST handler as canonical', () => {
+    const canonicalRouteLayer = (pronunciationRouter as any).stack.find(
+      (layer: any) => layer.route?.path === '/assessment'
+    );
+    const aliasRouteLayer = (legacyPronunciationAssessmentRouter as any).stack.find(
+      (layer: any) => layer.route?.path === '/'
+    );
+
+    expect(canonicalRouteLayer).toBeTruthy();
+    expect(aliasRouteLayer).toBeTruthy();
+    expect(canonicalRouteLayer.route.methods.post).toBe(true);
+    expect(aliasRouteLayer.route.methods.post).toBe(true);
+
+    const canonicalPostHandler = canonicalRouteLayer.route.stack[1].handle;
+    const aliasPostHandler = aliasRouteLayer.route.stack[1].handle;
+    expect(aliasPostHandler).toBe(canonicalPostHandler);
+  });
+});

--- a/src/server/routes/pronunciationAssessment.ts
+++ b/src/server/routes/pronunciationAssessment.ts
@@ -321,6 +321,7 @@ interface AssessmentParams {
   referenceText: string;
   language: string;
   requestId: string;
+  audioMimeType?: string;
 }
 
 interface AssessmentResult {
@@ -331,7 +332,7 @@ interface AssessmentResult {
 async function processPronunciationAssessment(
   params: AssessmentParams
 ): Promise<AssessmentResult> {
-  const { audioBuffer, sentenceId, referenceText, language, requestId } = params;
+  const { audioBuffer, sentenceId, referenceText, language, requestId, audioMimeType } = params;
 
   // Get Azure config
   const { key, region } = getAzureSpeechConfig();
@@ -339,22 +340,31 @@ async function processPronunciationAssessment(
   // Convert webm/opus to WAV format required by Azure
   // Azure Pronunciation Assessment REQUIRES PCM/WAV (16kHz, 16-bit, mono)
   let wavBuffer: Buffer = audioBuffer;
-  let contentType = 'audio/webm; codecs=opus';
-  
-  try {
-    wavBuffer = await convertWebmOpusToWav(audioBuffer);
-    contentType = 'audio/wav';
-  } catch (conversionError) {
-    // Fall back to original format (may not work, but better than failing completely)
-    speechLog('warn', 'Audio conversion failed; using original upload format', { requestId });
-    if (isSpeechDebugEnabled()) {
-      speechLog(
-        'warn',
-        'Audio conversion failure details',
-        { requestId, error: conversionError instanceof Error ? conversionError.message : String(conversionError) },
-        { allowSensitive: true }
-      );
+  const normalizedMimeType = (audioMimeType || '').toLowerCase();
+  const isWavInput =
+    normalizedMimeType.includes('audio/wav') ||
+    normalizedMimeType.includes('audio/x-wav') ||
+    normalizedMimeType.includes('audio/wave');
+  let contentType = isWavInput ? 'audio/wav' : 'audio/webm; codecs=opus';
+
+  if (!isWavInput) {
+    try {
+      wavBuffer = await convertWebmOpusToWav(audioBuffer);
+      contentType = 'audio/wav';
+    } catch (conversionError) {
+      // Fall back to original format (may not work, but better than failing completely)
+      speechLog('warn', 'Audio conversion failed; using original upload format', { requestId });
+      if (isSpeechDebugEnabled()) {
+        speechLog(
+          'warn',
+          'Audio conversion failure details',
+          { requestId, error: conversionError instanceof Error ? conversionError.message : String(conversionError) },
+          { allowSensitive: true }
+        );
+      }
     }
+  } else {
+    contentType = 'audio/wav';
   }
 
   // Build Azure endpoint URL
@@ -479,6 +489,13 @@ export async function handlePronunciationAssessment(
     const sentenceId = formData.get('sentenceId');
     const referenceText = formData.get('referenceText');
     const language = formData.get('language');
+    const audioMimeType =
+      typeof audioFile === 'object' &&
+      audioFile !== null &&
+      'type' in audioFile &&
+      typeof (audioFile as { type?: unknown }).type === 'string'
+        ? (audioFile as { type: string }).type
+        : undefined;
 
     // Validate required fields
     if (!audioFile) {
@@ -551,6 +568,7 @@ export async function handlePronunciationAssessment(
       referenceText,
       language,
       requestId,
+      audioMimeType,
     });
 
     speechLog('info', 'Pronunciation request completed', {
@@ -647,6 +665,7 @@ export async function handlePronunciationAssessmentExpress(req: ExpressRequest, 
       referenceText,
       language,
       requestId,
+      audioMimeType: req.file.mimetype,
     });
 
     speechLog('info', 'Pronunciation request completed', {

--- a/src/server/routes/pronunciationAssessment.ts
+++ b/src/server/routes/pronunciationAssessment.ts
@@ -98,6 +98,11 @@ import { writeFile, readFile, unlink } from 'fs/promises';
 import { existsSync } from 'fs';
 import { Router, Request as ExpressRequest, Response as ExpressResponse } from 'express';
 import multer from 'multer';
+import {
+  isSpeechDebugEnabled,
+  speechLog,
+  writeSpeechDebugDump,
+} from '../utils/speechDebug';
 
 // Web API Request/Response types (available in Node.js 18+)
 // Using global types - no import needed
@@ -105,6 +110,30 @@ type WebRequest = Request;
 type WebResponse = Response;
 
 const execAsync = promisify(exec);
+
+function getStatusClass(statusCode: number): `${number}xx` {
+  return `${Math.floor(statusCode / 100)}xx`;
+}
+
+function buildSafeErrorPayload(statusCode: number, requestId: string): {
+  error: string;
+  message: string;
+  requestId: string;
+} {
+  if (statusCode === 502) {
+    return {
+      error: 'Speech service unavailable',
+      message: 'Pronunciation assessment is temporarily unavailable. Please try again.',
+      requestId,
+    };
+  }
+
+  return {
+    error: 'Internal server error',
+    message: 'Failed to assess pronunciation. Please try again.',
+    requestId,
+  };
+}
 
 /**
  * TODO: Audio Conversion Implementation Summary
@@ -187,11 +216,9 @@ async function convertWebmOpusToWav(webmBuffer: Buffer): Promise<Buffer> {
         ffmpegPath = ffmpegStatic as any;
       }
     }
-  } catch (err) {
+  } catch {
     // ffmpeg-static not installed, use system ffmpeg
-    if (process.env.NODE_ENV !== 'production') {
-      console.warn('[Audio Conversion] ffmpeg-static not found, using system ffmpeg. Install it for better reliability.');
-    }
+    speechLog('warn', 'ffmpeg-static not found, using system ffmpeg');
   }
 
   // Create temporary files for input and output
@@ -235,9 +262,9 @@ async function convertWebmOpusToWav(webmBuffer: Buffer): Promise<Buffer> {
       if (existsSync(outputPath)) await unlink(outputPath).catch(() => {});
     } catch (cleanupErr) {
       // Ignore cleanup errors (non-critical)
-      if (process.env.NODE_ENV !== 'production') {
-        console.warn('[Audio Conversion] Failed to clean up temp files:', cleanupErr);
-      }
+      speechLog('warn', 'Failed to clean up audio conversion temp files', {
+        error: cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr),
+      });
     }
   }
 }
@@ -270,6 +297,7 @@ interface AssessmentParams {
   sentenceId: string;
   referenceText: string;
   language: string;
+  requestId: string;
 }
 
 interface AssessmentResult {
@@ -280,34 +308,29 @@ interface AssessmentResult {
 async function processPronunciationAssessment(
   params: AssessmentParams
 ): Promise<AssessmentResult> {
-  const { audioBuffer, sentenceId, referenceText, language } = params;
+  const { audioBuffer, sentenceId, referenceText, language, requestId } = params;
 
   // Get Azure config
   const { key, region } = getAzureSpeechConfig();
 
   // Convert webm/opus to WAV format required by Azure
   // Azure Pronunciation Assessment REQUIRES PCM/WAV (16kHz, 16-bit, mono)
-  let wavBuffer: Buffer;
-  let contentType: string;
+  let wavBuffer: Buffer = audioBuffer;
+  let contentType = 'audio/webm; codecs=opus';
   
   try {
-    if (process.env.NODE_ENV !== 'production') {
-      console.log('[Pronunciation Assessment] Converting webm/opus to WAV...');
-      const conversionStart = Date.now();
-      wavBuffer = await convertWebmOpusToWav(audioBuffer);
-      const conversionTime = Date.now() - conversionStart;
-      console.log(`[Pronunciation Assessment] Conversion completed in ${conversionTime}ms, output size: ${wavBuffer.length} bytes`);
-    } else {
-      wavBuffer = await convertWebmOpusToWav(audioBuffer);
-    }
+    wavBuffer = await convertWebmOpusToWav(audioBuffer);
     contentType = 'audio/wav';
   } catch (conversionError) {
-    console.error('[Pronunciation Assessment] Audio conversion failed:', conversionError);
     // Fall back to original format (may not work, but better than failing completely)
-    wavBuffer = audioBuffer;
-    contentType = 'audio/webm; codecs=opus';
-    if (process.env.NODE_ENV !== 'production') {
-      console.warn('[Pronunciation Assessment] WARNING: Using original webm/opus format. Azure may not return PronunciationAssessment fields.');
+    speechLog('warn', 'Audio conversion failed; using original upload format', { requestId });
+    if (isSpeechDebugEnabled()) {
+      speechLog(
+        'warn',
+        'Audio conversion failure details',
+        { requestId, error: conversionError instanceof Error ? conversionError.message : String(conversionError) },
+        { allowSensitive: true }
+      );
     }
   }
 
@@ -317,30 +340,11 @@ async function processPronunciationAssessment(
 
   // Build pronunciation assessment header
   const paHeader = buildPronunciationAssessmentHeader(referenceText);
-  
-  // Comprehensive debug logging (development only)
-  if (process.env.NODE_ENV !== 'production') {
-    console.log('[Pronunciation Assessment] ===== REQUEST DEBUG =====');
-    console.log('[Pronunciation Assessment] Endpoint:', azureEndpoint.replace(key, '***'));
-    console.log('[Pronunciation Assessment] Reference text:', referenceText);
-    console.log('[Pronunciation Assessment] Language:', language);
-    console.log('[Pronunciation Assessment] Input audio size:', audioBuffer.length, 'bytes');
-    console.log('[Pronunciation Assessment] Output audio size:', wavBuffer.length, 'bytes');
-    console.log('[Pronunciation Assessment] Content-Type:', contentType);
-    console.log('[Pronunciation Assessment] PA header (base64):', paHeader);
-    // Decode to verify
-    try {
-      const decoded = Buffer.from(paHeader, 'base64').toString('utf-8');
-      console.log('[Pronunciation Assessment] PA header (decoded):', decoded);
-    } catch (e) {
-      console.warn('[Pronunciation Assessment] Failed to decode PA header:', e);
-    }
-    console.log('[Pronunciation Assessment] ========================');
-  }
 
   // Call Azure Speech API
   // Convert Buffer to Uint8Array for fetch compatibility
   const audioBody = new Uint8Array(wavBuffer);
+  const azureStartedAt = Date.now();
   
   const azureResponse = await fetch(azureEndpoint, {
     method: 'POST',
@@ -351,64 +355,37 @@ async function processPronunciationAssessment(
     },
     body: audioBody,
   });
+  const azureLatencyMs = Date.now() - azureStartedAt;
 
   // Handle non-200 responses
   if (!azureResponse.ok) {
     const errorText = await azureResponse.text();
-    console.error('Azure Speech API error:', {
-      status: azureResponse.status,
-      statusText: azureResponse.statusText,
-      body: errorText,
+    speechLog('error', 'Azure Speech API request failed', {
+      requestId,
+      statusClass: getStatusClass(azureResponse.status),
+      azureStatus: azureResponse.status,
+      azureLatencyMs,
     });
-
-    throw new Error(`Azure Speech API request failed: ${azureResponse.status} - ${errorText}`);
+    if (isSpeechDebugEnabled()) {
+      speechLog(
+        'error',
+        'Azure Speech API failure details',
+        {
+          requestId,
+          azureStatusText: azureResponse.statusText,
+          errorBody: errorText,
+        },
+        { allowSensitive: true }
+      );
+    }
+    throw new Error(`Azure Speech API request failed: ${azureResponse.status}`);
   }
 
   // Parse Azure response
   const rawAzure = await azureResponse.json();
-  
-  // Comprehensive debug logging and save response (development only)
-  if (process.env.NODE_ENV !== 'production') {
-    console.log('[Pronunciation Assessment] ===== RESPONSE DEBUG =====');
-    console.log('[Pronunciation Assessment] Response status:', azureResponse.status);
-    console.log('[Pronunciation Assessment] Response structure analysis:');
-    console.log('  - Is array?', Array.isArray(rawAzure));
-    console.log('  - Root keys:', Object.keys(Array.isArray(rawAzure) ? rawAzure[0] || {} : rawAzure || {}));
-    console.log('  - RecognitionStatus:', (Array.isArray(rawAzure) ? rawAzure[0] : rawAzure)?.RecognitionStatus);
-    console.log('  - DisplayText:', (Array.isArray(rawAzure) ? rawAzure[0] : rawAzure)?.DisplayText);
-    
-    const nBest = (Array.isArray(rawAzure) ? rawAzure[0] : rawAzure)?.NBest;
-    if (nBest && nBest[0]) {
-      const firstNBest = nBest[0];
-      console.log('  - NBest[0] keys:', Object.keys(firstNBest));
-      console.log('  - Has PronunciationAssessment?', !!firstNBest.PronunciationAssessment);
-      console.log('  - Direct AccuracyScore?', firstNBest.AccuracyScore !== undefined);
-      console.log('  - Nested AccuracyScore?', firstNBest.PronunciationAssessment?.AccuracyScore !== undefined);
-      console.log('  - Words count:', firstNBest.Words?.length ?? 0);
-      if (firstNBest.Words && firstNBest.Words[0]) {
-        const firstWord = firstNBest.Words[0];
-        console.log('  - First word:', firstWord.Word);
-        console.log('  - First word has PronunciationAssessment?', !!firstWord.PronunciationAssessment);
-        console.log('  - First word direct AccuracyScore?', firstWord.AccuracyScore !== undefined);
-      }
-    }
-    
-    // Save full response to file for detailed inspection
-    const fs = await import('fs/promises');
-    const path = await import('path');
-    const debugDir = path.join(process.cwd(), 'data', 'debug');
+  if (isSpeechDebugEnabled()) {
     const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
-    const filename = `azure_pronunciation_live_sample_${timestamp}.json`;
-    const filepath = path.join(debugDir, filename);
-    try {
-      await fs.mkdir(debugDir, { recursive: true });
-      await fs.writeFile(filepath, JSON.stringify(rawAzure, null, 2));
-      console.log(`[Pronunciation Assessment] Saved full response to: ${filepath}`);
-    } catch (err) {
-      console.warn('[Pronunciation Assessment] Failed to save response:', err);
-    }
-    
-    console.log('[Pronunciation Assessment] ===========================');
+    await writeSpeechDebugDump(`azure_pronunciation_${requestId}_${timestamp}.json`, rawAzure);
   }
 
   // Map to AttemptScore
@@ -422,9 +399,23 @@ async function processPronunciationAssessment(
       undefined // audioUrl - client will attach the blob URL
     );
   } catch (mappingError) {
-    console.error('[Pronunciation Assessment] Error mapping Azure response:', mappingError);
-    console.error('[Pronunciation Assessment] Raw Azure response:', JSON.stringify(rawAzure, null, 2));
-    throw new Error(`Failed to map Azure response: ${mappingError instanceof Error ? mappingError.message : 'Unknown mapping error'}`);
+    speechLog('error', 'Failed to map Azure pronunciation response', {
+      requestId,
+      statusClass: '5xx',
+    });
+    if (isSpeechDebugEnabled()) {
+      speechLog(
+        'error',
+        'Azure pronunciation payload (mapping failure)',
+        {
+          requestId,
+          error: mappingError instanceof Error ? mappingError.message : String(mappingError),
+          rawAzure,
+        },
+        { allowSensitive: true }
+      );
+    }
+    throw new Error('Failed to map Azure response');
   }
 
   return {
@@ -454,6 +445,9 @@ async function processPronunciationAssessment(
 export async function handlePronunciationAssessment(
   request: WebRequest
 ): Promise<WebResponse> {
+  const requestId = request.headers.get('x-request-id') || randomUUID();
+  const startedAt = Date.now();
+
   try {
     // Parse multipart form data
     const formData = await request.formData();
@@ -466,28 +460,28 @@ export async function handlePronunciationAssessment(
     // Validate required fields
     if (!audioFile) {
       return new Response(
-        JSON.stringify({ error: 'Missing audio file' }),
+        JSON.stringify({ error: 'Missing audio file', requestId }),
         { status: 400, headers: { 'Content-Type': 'application/json' } }
       );
     }
 
     if (!sentenceId || typeof sentenceId !== 'string') {
       return new Response(
-        JSON.stringify({ error: 'Missing or invalid sentenceId' }),
+        JSON.stringify({ error: 'Missing or invalid sentenceId', requestId }),
         { status: 400, headers: { 'Content-Type': 'application/json' } }
       );
     }
 
     if (!referenceText || typeof referenceText !== 'string') {
       return new Response(
-        JSON.stringify({ error: 'Missing or invalid referenceText' }),
+        JSON.stringify({ error: 'Missing or invalid referenceText', requestId }),
         { status: 400, headers: { 'Content-Type': 'application/json' } }
       );
     }
 
     if (!language || typeof language !== 'string') {
       return new Response(
-        JSON.stringify({ error: 'Missing or invalid language' }),
+        JSON.stringify({ error: 'Missing or invalid language', requestId }),
         { status: 400, headers: { 'Content-Type': 'application/json' } }
       );
     }
@@ -511,7 +505,7 @@ export async function handlePronunciationAssessment(
       }
     } catch (error) {
       return new Response(
-        JSON.stringify({ error: 'Failed to process audio file', details: error instanceof Error ? error.message : 'Unknown error' }),
+        JSON.stringify({ error: 'Failed to process audio file', requestId }),
         { status: 400, headers: { 'Content-Type': 'application/json' } }
       );
     }
@@ -522,6 +516,13 @@ export async function handlePronunciationAssessment(
       sentenceId,
       referenceText,
       language,
+      requestId,
+    });
+
+    speechLog('info', 'Pronunciation request completed', {
+      requestId,
+      statusClass: '2xx',
+      durationMs: Date.now() - startedAt,
     });
 
     // Return both raw and mapped response
@@ -529,24 +530,37 @@ export async function handlePronunciationAssessment(
       JSON.stringify(result),
       {
         status: 200,
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Request-Id': requestId,
+        },
       }
     );
   } catch (error) {
-    // Log server-side errors
-    console.error('Pronunciation assessment error:', error);
-
-    // Return safe error response
     const errorMessage = error instanceof Error ? error.message : 'Unknown error';
     const statusCode = errorMessage.includes('Azure Speech API request failed') ? 502 : 500;
+    speechLog('error', 'Pronunciation request failed', {
+      requestId,
+      statusClass: getStatusClass(statusCode),
+      durationMs: Date.now() - startedAt,
+    });
+    if (isSpeechDebugEnabled()) {
+      speechLog(
+        'error',
+        'Pronunciation request failure details',
+        { requestId, stack: error instanceof Error ? error.stack : undefined },
+        { allowSensitive: true }
+      );
+    }
+
     return new Response(
-      JSON.stringify({
-        error: 'Internal server error',
-        message: errorMessage,
-      }),
+      JSON.stringify(buildSafeErrorPayload(statusCode, requestId)),
       {
         status: statusCode,
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Request-Id': requestId,
+        },
       }
     );
   }
@@ -563,10 +577,13 @@ const upload = multer({
 export const pronunciationUploadMiddleware = upload.single('audio');
 
 export async function handlePronunciationAssessmentExpress(req: ExpressRequest, res: ExpressResponse): Promise<void> {
+  const requestId = (req.header('x-request-id') || randomUUID()).toString();
+  const startedAt = Date.now();
+
   try {
     // Validate required fields
     if (!req.file) {
-      res.status(400).json({ error: 'Missing audio file' });
+      res.status(400).json({ error: 'Missing audio file', requestId });
       return;
     }
 
@@ -575,17 +592,17 @@ export async function handlePronunciationAssessmentExpress(req: ExpressRequest, 
     const language = req.body.language;
 
     if (!sentenceId || typeof sentenceId !== 'string') {
-      res.status(400).json({ error: 'Missing or invalid sentenceId' });
+      res.status(400).json({ error: 'Missing or invalid sentenceId', requestId });
       return;
     }
 
     if (!referenceText || typeof referenceText !== 'string') {
-      res.status(400).json({ error: 'Missing or invalid referenceText' });
+      res.status(400).json({ error: 'Missing or invalid referenceText', requestId });
       return;
     }
 
     if (!language || typeof language !== 'string') {
-      res.status(400).json({ error: 'Missing or invalid language' });
+      res.status(400).json({ error: 'Missing or invalid language', requestId });
       return;
     }
 
@@ -595,17 +612,36 @@ export async function handlePronunciationAssessmentExpress(req: ExpressRequest, 
       sentenceId,
       referenceText,
       language,
+      requestId,
     });
 
+    speechLog('info', 'Pronunciation request completed', {
+      requestId,
+      statusClass: '2xx',
+      durationMs: Date.now() - startedAt,
+    });
+
+    res.setHeader('X-Request-Id', requestId);
     res.json(result);
   } catch (error) {
-    console.error('Pronunciation assessment error:', error);
     const errorMessage = error instanceof Error ? error.message : 'Unknown error';
     const statusCode = errorMessage.includes('Azure Speech API request failed') ? 502 : 500;
-    res.status(statusCode).json({
-      error: 'Internal server error',
-      message: errorMessage,
+    speechLog('error', 'Pronunciation request failed', {
+      requestId,
+      statusClass: getStatusClass(statusCode),
+      durationMs: Date.now() - startedAt,
     });
+    if (isSpeechDebugEnabled()) {
+      speechLog(
+        'error',
+        'Pronunciation request failure details',
+        { requestId, stack: error instanceof Error ? error.stack : undefined },
+        { allowSensitive: true }
+      );
+    }
+
+    res.setHeader('X-Request-Id', requestId);
+    res.status(statusCode).json(buildSafeErrorPayload(statusCode, requestId));
   }
 }
 

--- a/src/server/routes/pronunciationAssessment.ts
+++ b/src/server/routes/pronunciationAssessment.ts
@@ -260,7 +260,7 @@ async function convertWebmOpusToWav(webmBuffer: Buffer): Promise<Buffer> {
     // -sample_fmt s16: 16-bit signed integer samples
     // -y: Overwrite output file
     // -loglevel error: Only show errors (reduce noise)
-    const { stdout, stderr } = await execAsync(
+    const { stderr } = await execAsync(
       `"${ffmpegPath}" -i "${inputPath}" -f wav -ar 16000 -ac 1 -sample_fmt s16 -loglevel error -y "${outputPath}"`,
       { timeout: 10000 } // 10 second timeout
     );

--- a/src/server/routes/pronunciationAssessment.ts
+++ b/src/server/routes/pronunciationAssessment.ts
@@ -66,7 +66,7 @@
  *   import express from 'express';
  *   import { handlePronunciationAssessment } from './server/routes/pronunciationAssessment';
  *   const app = express();
- *   app.post('/api/pronunciation-assessment', async (req, res) => {
+ *   app.post('/api/pronunciation/assessment', async (req, res) => {
  *     const response = await handlePronunciationAssessment(req);
  *     res.status(response.status);
  *     response.headers.forEach((value, key) => res.setHeader(key, value));
@@ -552,19 +552,6 @@ export async function handlePronunciationAssessment(
   }
 }
 
-/**
- * Express router for pronunciation assessment
- * 
- * POST /api/pronunciation/assessment
- * 
- * Expected multipart/form-data fields:
- * - audio: File (audio recording)
- * - sentenceId: string
- * - referenceText: string
- * - language: string (e.g., "pt-BR")
- */
-const router = Router();
-
 // Configure multer for in-memory file storage
 const upload = multer({
   storage: multer.memoryStorage(),
@@ -573,11 +560,14 @@ const upload = multer({
   },
 });
 
-router.post('/assessment', upload.single('audio'), async (req: ExpressRequest, res: ExpressResponse) => {
+export const pronunciationUploadMiddleware = upload.single('audio');
+
+export async function handlePronunciationAssessmentExpress(req: ExpressRequest, res: ExpressResponse): Promise<void> {
   try {
     // Validate required fields
     if (!req.file) {
-      return res.status(400).json({ error: 'Missing audio file' });
+      res.status(400).json({ error: 'Missing audio file' });
+      return;
     }
 
     const sentenceId = req.body.sentenceId;
@@ -585,15 +575,18 @@ router.post('/assessment', upload.single('audio'), async (req: ExpressRequest, r
     const language = req.body.language;
 
     if (!sentenceId || typeof sentenceId !== 'string') {
-      return res.status(400).json({ error: 'Missing or invalid sentenceId' });
+      res.status(400).json({ error: 'Missing or invalid sentenceId' });
+      return;
     }
 
     if (!referenceText || typeof referenceText !== 'string') {
-      return res.status(400).json({ error: 'Missing or invalid referenceText' });
+      res.status(400).json({ error: 'Missing or invalid referenceText' });
+      return;
     }
 
     if (!language || typeof language !== 'string') {
-      return res.status(400).json({ error: 'Missing or invalid language' });
+      res.status(400).json({ error: 'Missing or invalid language' });
+      return;
     }
 
     // Process assessment
@@ -614,7 +607,20 @@ router.post('/assessment', upload.single('audio'), async (req: ExpressRequest, r
       message: errorMessage,
     });
   }
-});
+}
+
+/**
+ * Canonical pronunciation route.
+ * POST /api/pronunciation/assessment
+ */
+const router = Router();
+router.post('/assessment', pronunciationUploadMiddleware, handlePronunciationAssessmentExpress);
+
+/**
+ * Temporary legacy alias route.
+ * POST /api/pronunciation-assessment
+ */
+export const legacyPronunciationAssessmentRouter = Router();
+legacyPronunciationAssessmentRouter.post('/', pronunciationUploadMiddleware, handlePronunciationAssessmentExpress);
 
 export default router;
-

--- a/src/server/routes/pronunciationAssessment.ts
+++ b/src/server/routes/pronunciationAssessment.ts
@@ -96,7 +96,12 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 import { writeFile, readFile, unlink } from 'fs/promises';
 import { existsSync } from 'fs';
-import { Router, Request as ExpressRequest, Response as ExpressResponse } from 'express';
+import {
+  Router,
+  Request as ExpressRequest,
+  Response as ExpressResponse,
+  NextFunction,
+} from 'express';
 import multer from 'multer';
 import {
   isSpeechDebugEnabled,
@@ -110,6 +115,24 @@ type WebRequest = Request;
 type WebResponse = Response;
 
 const execAsync = promisify(exec);
+
+const DEFAULT_MAX_UPLOAD_BYTES = 10 * 1024 * 1024;
+
+function getMaxPronunciationUploadBytes(): number {
+  const rawValue = process.env.SPEECH_MAX_UPLOAD_BYTES;
+  if (!rawValue) {
+    return DEFAULT_MAX_UPLOAD_BYTES;
+  }
+
+  const parsed = Number.parseInt(rawValue, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return DEFAULT_MAX_UPLOAD_BYTES;
+  }
+
+  return parsed;
+}
+
+const MAX_PRONUNCIATION_UPLOAD_BYTES = getMaxPronunciationUploadBytes();
 
 function getStatusClass(statusCode: number): `${number}xx` {
   return `${Math.floor(statusCode / 100)}xx`;
@@ -510,6 +533,17 @@ export async function handlePronunciationAssessment(
       );
     }
 
+    if (audioBuffer.length > MAX_PRONUNCIATION_UPLOAD_BYTES) {
+      return new Response(
+        JSON.stringify({
+          error: 'Audio file too large',
+          message: `Maximum upload size is ${Math.round(MAX_PRONUNCIATION_UPLOAD_BYTES / (1024 * 1024))}MB.`,
+          requestId,
+        }),
+        { status: 413, headers: { 'Content-Type': 'application/json', 'X-Request-Id': requestId } }
+      );
+    }
+
     // Process assessment
     const result = await processPronunciationAssessment({
       audioBuffer,
@@ -570,7 +604,7 @@ export async function handlePronunciationAssessment(
 const upload = multer({
   storage: multer.memoryStorage(),
   limits: {
-    fileSize: 10 * 1024 * 1024, // 10MB limit
+    fileSize: MAX_PRONUNCIATION_UPLOAD_BYTES,
   },
 });
 
@@ -645,12 +679,37 @@ export async function handlePronunciationAssessmentExpress(req: ExpressRequest, 
   }
 }
 
+export function pronunciationUploadErrorHandler(
+  err: unknown,
+  req: ExpressRequest,
+  res: ExpressResponse,
+  next: NextFunction
+): void {
+  if (err instanceof multer.MulterError && err.code === 'LIMIT_FILE_SIZE') {
+    const requestId = (req.header('x-request-id') || randomUUID()).toString();
+    speechLog('warn', 'Pronunciation upload rejected: payload too large', {
+      requestId,
+      statusClass: '4xx',
+    });
+    res.setHeader('X-Request-Id', requestId);
+    res.status(413).json({
+      error: 'Audio file too large',
+      message: `Maximum upload size is ${Math.round(MAX_PRONUNCIATION_UPLOAD_BYTES / (1024 * 1024))}MB.`,
+      requestId,
+    });
+    return;
+  }
+
+  next(err);
+}
+
 /**
  * Canonical pronunciation route.
  * POST /api/pronunciation/assessment
  */
 const router = Router();
 router.post('/assessment', pronunciationUploadMiddleware, handlePronunciationAssessmentExpress);
+router.use(pronunciationUploadErrorHandler);
 
 /**
  * Temporary legacy alias route.
@@ -658,5 +717,6 @@ router.post('/assessment', pronunciationUploadMiddleware, handlePronunciationAss
  */
 export const legacyPronunciationAssessmentRouter = Router();
 legacyPronunciationAssessmentRouter.post('/', pronunciationUploadMiddleware, handlePronunciationAssessmentExpress);
+legacyPronunciationAssessmentRouter.use(pronunciationUploadErrorHandler);
 
 export default router;

--- a/src/server/utils/speechDebug.ts
+++ b/src/server/utils/speechDebug.ts
@@ -1,0 +1,83 @@
+import { mkdir, writeFile } from 'fs/promises';
+import { join } from 'path';
+
+type SpeechLogLevel = 'info' | 'warn' | 'error';
+
+const SPEECH_DEBUG_VALUES = new Set(['1', 'true', 'yes', 'on']);
+const SENSITIVE_KEY_PARTS = [
+  'reference',
+  'pronunciation',
+  'header',
+  'token',
+  'rawazure',
+  'nbest',
+  'word',
+  'payload',
+];
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isSensitiveKey(key: string): boolean {
+  const normalized = key.toLowerCase();
+  return SENSITIVE_KEY_PARTS.some((part) => normalized.includes(part));
+}
+
+function redactSensitiveValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return `[redacted array:${value.length}]`;
+  }
+
+  if (isPlainObject(value)) {
+    const redacted: Record<string, unknown> = {};
+    for (const [key, nestedValue] of Object.entries(value)) {
+      redacted[key] = isSensitiveKey(key) ? '[redacted]' : redactSensitiveValue(nestedValue);
+    }
+    return redacted;
+  }
+
+  return value;
+}
+
+export function isSpeechDebugEnabled(): boolean {
+  const value = process.env.SPEECH_DEBUG;
+  if (!value) {
+    return false;
+  }
+  return SPEECH_DEBUG_VALUES.has(value.trim().toLowerCase());
+}
+
+export function speechLog(
+  level: SpeechLogLevel,
+  message: string,
+  details?: Record<string, unknown>,
+  options?: { allowSensitive?: boolean }
+): void {
+  const logFn = level === 'error' ? console.error : level === 'warn' ? console.warn : console.log;
+  const shouldAllowSensitive = Boolean(options?.allowSensitive && isSpeechDebugEnabled());
+  const safeDetails = details
+    ? (shouldAllowSensitive ? details : (redactSensitiveValue(details) as Record<string, unknown>))
+    : undefined;
+
+  if (safeDetails && Object.keys(safeDetails).length > 0) {
+    logFn(`[Speech] ${message}`, safeDetails);
+    return;
+  }
+
+  logFn(`[Speech] ${message}`);
+}
+
+export async function writeSpeechDebugDump(filename: string, payload: unknown): Promise<void> {
+  if (!isSpeechDebugEnabled()) {
+    return;
+  }
+
+  const safeFilename = filename.replace(/[^a-zA-Z0-9_.-]/g, '_');
+  const debugDir = join(process.cwd(), 'data', 'debug');
+  const filepath = join(debugDir, safeFilename);
+  await mkdir(debugDir, { recursive: true });
+  await writeFile(filepath, JSON.stringify(payload, null, 2), 'utf-8');
+
+  speechLog('info', 'Speech debug dump written', { file: filepath }, { allowSensitive: true });
+}

--- a/src/shared/types/practice.ts
+++ b/src/shared/types/practice.ts
@@ -3,8 +3,6 @@
  * Used by both frontend and backend
  */
 
-import type { User } from './user';
-
 /**
  * Content type union
  */
@@ -183,4 +181,3 @@ export interface WordPracticeAttempt {
   latencyMs?: number;
   selfRating?: 'know' | 'dont_know';
 }
-

--- a/src/state/practiceLogStore.tsx
+++ b/src/state/practiceLogStore.tsx
@@ -37,7 +37,7 @@ interface PracticeLogStoreState {
 
 interface PracticeLogStore extends PracticeLogStoreState {
   storageError: boolean;
-  startSession: (mode: PracticeSession['mode']) => Promise<string>;
+  startSession: (mode: Exclude<PracticeSession['mode'], 'assessment'>) => Promise<string>;
   endSession: (sessionId: string) => Promise<void>;
   logSentenceAttempt: (
     attempt: Omit<SentencePracticeAttempt, 'attemptId' | 'userId' | 'createdAt'>
@@ -83,6 +83,7 @@ function loadPracticeLogFromStorage(): PracticeLogStoreState {
         sessions: [],
         sentenceAttempts: [],
         wordAttempts: [],
+        serverSessionIds: {},
       };
     }
 
@@ -228,7 +229,7 @@ export function PracticeLogStoreProvider({ children }: { children: ReactNode }) 
   }, [state]);
 
   const startSession = useCallback(
-    async (mode: PracticeSession['mode']): Promise<string> => {
+    async (mode: Exclude<PracticeSession['mode'], 'assessment'>): Promise<string> => {
       const sessionId = generateSessionId();
       const now = new Date().toISOString();
 
@@ -609,6 +610,7 @@ export function PracticeLogStoreProvider({ children }: { children: ReactNode }) 
       sessions: state.sessions,
       sentenceAttempts: state.sentenceAttempts,
       wordAttempts: state.wordAttempts,
+      serverSessionIds: state.serverSessionIds,
       storageError,
       startSession,
       endSession,
@@ -659,4 +661,3 @@ export function usePracticeLogStore(): PracticeLogStore {
   }
   return context;
 }
-

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -11,6 +11,5 @@
     },
     "types": ["node", "vite/client"]
   },
-  "include": ["vite.config.ts", "src/server/**/*.ts", "src/shared/**/*.ts", "src/lib/pronunciationUtils.ts", "src/lib/azurePronunciationNormalizer.ts", "src/lib/types.ts", "src/types/pronunciation.ts", "src/vite-env.d.ts"]
+  "include": ["vite.config.ts"]
 }
-

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,190 +1,10 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
-import path from 'path'
-import type { Plugin } from 'vite'
-import Busboy from 'busboy'
-import { config } from 'dotenv'
-
-// Load environment variables from .env file
-config()
-
-// Plugin to handle API routes in development
-function apiPlugin(): Plugin {
-  return {
-    name: 'api-plugin',
-    configureServer(server) {
-      server.middlewares.use('/api/pronunciation-assessment', async (req, res, next) => {
-        // Only handle POST requests
-        if (req.method !== 'POST') {
-          res.statusCode = 405
-          res.setHeader('Content-Type', 'application/json')
-          res.end(JSON.stringify({ error: 'Method not allowed' }))
-          return
-        }
-
-        try {
-          // Check environment variables early
-          if (!process.env.AZURE_SPEECH_KEY || !process.env.AZURE_SPEECH_REGION) {
-            console.error('Missing Azure credentials:')
-            console.error('  AZURE_SPEECH_KEY:', process.env.AZURE_SPEECH_KEY ? 'SET' : 'MISSING')
-            console.error('  AZURE_SPEECH_REGION:', process.env.AZURE_SPEECH_REGION ? 'SET' : 'MISSING')
-            res.statusCode = 500
-            res.setHeader('Content-Type', 'application/json')
-            res.end(JSON.stringify({ 
-              error: 'Server configuration error',
-              message: 'Missing Azure Speech credentials. Please set AZURE_SPEECH_KEY and AZURE_SPEECH_REGION environment variables.'
-            }))
-            return
-          }
-
-          // Import the handler dynamically (Node.js only)
-          const { handlePronunciationAssessment } = await import('./src/server/routes/pronunciationAssessment')
-          
-          // Parse multipart/form-data using busboy
-          const contentType = req.headers['content-type'] || 'multipart/form-data'
-          const formData = new FormData()
-          
-          await new Promise<void>((resolve, reject) => {
-            try {
-              const busboy = Busboy({ headers: { 'content-type': contentType } })
-              let pendingFiles = 0
-              let finished = false
-              
-              const checkComplete = () => {
-                if (finished && pendingFiles === 0) {
-                  resolve()
-                }
-              }
-              
-              busboy.on('file', (name, file, info) => {
-                const { filename, encoding, mimeType } = info
-                console.log(`[API Plugin] Received file: ${name}, filename: ${filename}, mimeType: ${mimeType}`)
-                pendingFiles++
-                const chunks: Buffer[] = []
-                
-                file.on('data', (chunk: Buffer) => {
-                  chunks.push(chunk)
-                })
-                
-                file.on('end', () => {
-                  const buffer = Buffer.concat(chunks)
-                  console.log(`[API Plugin] File ${name} completed, size: ${buffer.length} bytes`)
-                  const blob = new Blob([buffer], { type: mimeType || 'application/octet-stream' })
-                  formData.append(name, blob, filename)
-                  pendingFiles--
-                  checkComplete()
-                })
-                
-                file.on('error', (err) => {
-                  console.error(`[API Plugin] File ${name} error:`, err)
-                  pendingFiles--
-                  reject(err)
-                })
-              })
-              
-              busboy.on('field', (name, value) => {
-                console.log(`[API Plugin] Received field: ${name} = ${value}`)
-                formData.append(name, value)
-              })
-              
-              busboy.on('finish', () => {
-                console.log('[API Plugin] Busboy finished parsing')
-                finished = true
-                checkComplete()
-              })
-              
-              busboy.on('error', (err) => {
-                console.error('[API Plugin] Busboy error:', err)
-                reject(err)
-              })
-              
-              req.pipe(busboy)
-            } catch (err) {
-              console.error('[API Plugin] Error setting up busboy:', err)
-              reject(err)
-            }
-          })
-          
-          // Log form data fields (check what we have)
-          const formDataEntries: string[] = []
-          // Note: FormData.keys() might not be available in Node.js, so we'll just log that parsing completed
-          console.log('[API Plugin] FormData parsed successfully')
-
-          // Create a Request object with the parsed FormData
-          // Don't set Content-Type header - Request will set it automatically with boundary
-          const url = new URL(req.url || '/api/pronunciation-assessment', `http://${req.headers.host || 'localhost:3000'}`)
-          const headers = new Headers()
-          // Copy headers except Content-Type (FormData will set it)
-          Object.entries(req.headers).forEach(([key, value]) => {
-            if (key.toLowerCase() !== 'content-type' && value) {
-              headers.set(key, Array.isArray(value) ? value[0] : value)
-            }
-          })
-          
-          console.log('[API Plugin] Creating Request object...')
-          const request = new Request(url.toString(), {
-            method: req.method || 'POST',
-            headers,
-            body: formData,
-          })
-
-          console.log('[API Plugin] Calling handlePronunciationAssessment...')
-          // Call the handler
-          const response = await handlePronunciationAssessment(request)
-          console.log('[API Plugin] Handler returned, status:', response.status)
-
-          // Send response back to client
-          res.statusCode = response.status
-          response.headers.forEach((value, key) => {
-            res.setHeader(key, value)
-          })
-          
-          const responseBody = await response.text()
-          
-          // Log response in development for debugging
-          if (process.env.NODE_ENV !== 'production') {
-            try {
-              const parsed = JSON.parse(responseBody)
-              console.log('[API Plugin] Response body (first 500 chars):', JSON.stringify(parsed).substring(0, 500))
-            } catch (e) {
-              console.log('[API Plugin] Response body (first 500 chars):', responseBody.substring(0, 500))
-            }
-          }
-          
-          res.end(responseBody)
-        } catch (error) {
-          // Log detailed error information
-          console.error('API route error:', error)
-          if (error instanceof Error) {
-            console.error('Error name:', error.name)
-            console.error('Error message:', error.message)
-            console.error('Error stack:', error.stack)
-          }
-          
-          res.statusCode = 500
-          res.setHeader('Content-Type', 'application/json')
-          
-          // Provide more detailed error message in development
-          const errorMessage = error instanceof Error ? error.message : 'Unknown error'
-          const isDev = process.env.NODE_ENV !== 'production'
-          
-          res.end(JSON.stringify({ 
-            error: 'Internal server error',
-            message: errorMessage,
-            ...(isDev && error instanceof Error ? {
-              stack: error.stack,
-              name: error.name,
-            } : {})
-          }))
-        }
-      })
-    },
-  }
-}
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import path from 'path';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react(), apiPlugin()],
+  plugins: [react()],
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),
@@ -209,11 +29,9 @@ export default defineConfig({
         },
       },
     },
-    // Optimize chunk size
     chunkSizeWarningLimit: 1000,
   },
-  // Optimize dependencies
   optimizeDeps: {
     include: ['react', 'react-dom', 'react-router-dom'],
   },
-})
+});


### PR DESCRIPTION
## Phase 0/1 Salvage + Hardening

### Summary
This updates the Phase 0/1 branch to be merge-ready from a build/type-safety perspective without reworking the Phase 0/1 feature logic.

### What Changed
- Added verification scripts and build config hygiene:
  - `lint` placeholder script
  - `test:phase01` targeted verification script
  - narrowed `tsconfig.node.json` scope to avoid project overlap
- Fixed baseline TypeScript build blockers across UI/server/store layers:
  - removed strict-mode unused imports/locals
  - resolved prop/type mismatches
  - fixed store type drift (`serverSessionIds`, session mode typing, word score shape)
  - corrected async `startSession` usage in fixtures
  - restored missing dashboard components:
    - `CategoryProgress`
    - `ContinuePracticeCard`
- Preserved existing Phase 0/1 behavior:
  - endpoint unification + alias
  - privacy/debug gating
  - abuse controls
  - audio quality gate
  - lifecycle state machine/cancel/stale protection

### Verification
- ✅ `npm run build` passes (`tsc && vite build`)
- ✅ `npm run test:phase01` passes (targeted Phase 0/1 tests)
- ⚠️ Full `npm test` still has pre-existing unrelated suite failures (`PhonemeChip`, `SentenceFeedback`, `practiceLogStore`)
