### PR TITLE
fix: remove invalid 'npm' nix package from nixpacks config

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,2 +1,2 @@
 [phases.setup]
-nixPkgs = ["nodejs_22", "npm"]
+nixPkgs = ["nodejs_22"]


### PR DESCRIPTION
## Summary
- Removed `npm` from the `nixPkgs` list in `nixpacks.toml` — it's bundled with `nodejs_22` in Nix and is not a separate package
- This was causing `undefined variable 'npm'` error during the Railway Nixpacks build stage

## Test plan
- [ ] Verify Railway build completes successfully after merge

https://claude.ai/code/session_01FTToxAsF6bCZq4gKxi4taa