### PR TITLE
fix: make server startup resilient for Railway health checks

### DIFF
--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -85,9 +85,15 @@ if (existsSync(distPath)) {
 
 /**
  * Starts the Express server
- * Connects to MongoDB first, then starts listening
+ * Starts listening first (so health checks can respond), then connects to MongoDB
  */
 async function startServer(): Promise<void> {
+  // Start listening immediately so Railway health checks can reach the server
+  app.listen(PORT, () => {
+    console.log(`[Server] Server running on http://localhost:${PORT}`);
+    console.log(`[Server] Health check: http://localhost:${PORT}/api/health`);
+  });
+
   try {
     validateRequiredLaunchEnvVars();
 
@@ -96,15 +102,9 @@ async function startServer(): Promise<void> {
     await connectMongo();
     console.log('[Server] MongoDB connected successfully');
     await logInviteCodeReadiness();
-
-    // Start listening
-    app.listen(PORT, () => {
-      console.log(`[Server] Server running on http://localhost:${PORT}`);
-      console.log(`[Server] Health check: http://localhost:${PORT}/api/health`);
-    });
   } catch (error) {
-    console.error('[Server] Failed to start server:', error);
-    process.exit(1);
+    console.error('[Server] Failed to connect to MongoDB:', error);
+    // Don't exit — keep the server running so health checks can report the error
   }
 }
 
@@ -119,8 +119,13 @@ process.on('SIGINT', async () => {
   process.exit(0);
 });
 
-// Start the server
-if (require.main === module) {
+// Start the server when run directly (not imported for testing)
+// Use argv check as fallback since require.main === module can be unreliable with tsx
+const isDirectRun =
+  (typeof require !== 'undefined' && require.main === module) ||
+  process.argv[1]?.replace(/\.ts$/, '').endsWith('server/app');
+
+if (isDirectRun) {
   startServer().catch((error) => {
     console.error('[Server] Fatal error:', error);
     process.exit(1);

--- a/src/server/routes/health.test.ts
+++ b/src/server/routes/health.test.ts
@@ -22,7 +22,7 @@ describe('buildHealthResponse', () => {
     });
   });
 
-  it('returns 503 when MongoDB is disconnected', async () => {
+  it('returns 200 with ok:false when MongoDB is disconnected', async () => {
     const mongoStatus: MongoStatus = {
       connected: false,
       readyState: 0,
@@ -30,7 +30,7 @@ describe('buildHealthResponse', () => {
 
     const response = await buildHealthResponse(async () => mongoStatus);
 
-    expect(response.statusCode).toBe(503);
+    expect(response.statusCode).toBe(200);
     expect(response.body).toEqual({
       ok: false,
       error: 'MongoDB is not connected.',
@@ -38,12 +38,12 @@ describe('buildHealthResponse', () => {
     });
   });
 
-  it('returns 500 when MongoDB status lookup throws', async () => {
+  it('returns 200 with error when MongoDB status lookup throws', async () => {
     const response = await buildHealthResponse(async () => {
       throw new Error('status lookup failed');
     });
 
-    expect(response.statusCode).toBe(500);
+    expect(response.statusCode).toBe(200);
     expect(response.body).toEqual({
       ok: false,
       error: 'status lookup failed',

--- a/src/server/routes/health.ts
+++ b/src/server/routes/health.ts
@@ -15,28 +15,21 @@ export async function buildHealthResponse(
   try {
     const mongoStatus = await getStatus();
 
-    if (!mongoStatus.connected) {
-      return {
-        statusCode: 503,
-        body: {
-          ok: false,
-          error: 'MongoDB is not connected.',
-          mongo: mongoStatus,
-        },
-      };
-    }
-
+    // Always return 200 for liveness (Railway health check).
+    // The response body still reports MongoDB status for observability.
     return {
       statusCode: 200,
       body: {
-        ok: true,
+        ok: mongoStatus.connected,
         mongo: mongoStatus,
+        ...(!mongoStatus.connected && { error: 'MongoDB is not connected.' }),
       },
     };
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+    // Still return 200 so the deploy isn't killed — report the error in the body
     return {
-      statusCode: 500,
+      statusCode: 200,
       body: {
         ok: false,
         error: errorMessage,


### PR DESCRIPTION
## Summary
- Server now starts listening **before** connecting to MongoDB, so Railway's health check has a port to probe immediately
- Health endpoint always returns **HTTP 200** (with `ok: true/false` in the body), preventing Railway from killing the container when MongoDB is slow or unavailable
- Added `process.argv` fallback for entry point detection, since `require.main === module` can be unreliable with `tsx`

## Test plan
- [x] All 40 phase04 tests pass (including updated health check tests)
- [ ] Railway deploy passes health check after merge
- [ ] Verify `GET /api/health` returns `{ ok: true, mongo: { connected: true, ... } }` when MongoDB is connected

https://claude.ai/code/session_01FTToxAsF6bCZq4gKxi4taa