### PR TITLE
fix: server never started — 502 Bad Gateway on Railway

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,9 @@ FROM node:22-slim
 
 WORKDIR /app
 
+# Install CA certificates for TLS connections (required for MongoDB Atlas)
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*
+
 # Install production dependencies only
 COPY package.json package-lock.json ./
 RUN npm ci --omit=dev

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -119,13 +119,13 @@ process.on('SIGINT', async () => {
   process.exit(0);
 });
 
-// Start the server when run directly (not imported for testing)
-// Use argv check as fallback since require.main === module can be unreliable with tsx
-const isDirectRun =
-  (typeof require !== 'undefined' && require.main === module) ||
-  process.argv[1]?.replace(/\.ts$/, '').endsWith('server/app');
+// Start the server when run directly (not imported for testing).
+// tsx doesn't reliably set require.main === module, so we detect test
+// environments instead — Vitest sets VITEST=true automatically.
+const isTestImport =
+  process.env.VITEST === 'true' || process.env.NODE_ENV === 'test';
 
-if (isDirectRun) {
+if (!isTestImport) {
   startServer().catch((error) => {
     console.error('[Server] Fatal error:', error);
     process.exit(1);

--- a/src/server/models/UserModel.ts
+++ b/src/server/models/UserModel.ts
@@ -28,7 +28,6 @@ const UserSchema = new Schema<IUserDocument>(
       unique: true,
       lowercase: true,
       trim: true,
-      index: true,
     },
     passwordHash: {
       type: String,
@@ -51,9 +50,6 @@ const UserSchema = new Schema<IUserDocument>(
     timestamps: true, // Adds createdAt and updatedAt automatically
   }
 );
-
-// Indexes
-UserSchema.index({ email: 1 });
 
 /**
  * User model


### PR DESCRIPTION
## Summary
- **Root cause of 502**: `tsx` does not set `require.main === module`, so `startServer()` was never called — the Express server never listened on any port
- Replaced the entry-point guard with a test-environment check: start the server **unless** `VITEST=true` or `NODE_ENV=test`
- Removed duplicate Mongoose index on `User.email` (was declared via both `index: true` and `schema.index()`)

## Test plan
- [x] All 40 phase04 tests pass
- [ ] After merge, Railway deploy should respond on `/api/health` instead of 502

https://claude.ai/code/session_01FTToxAsF6bCZq4gKxi4taa