### PR TITLE
fix(deploy): resolve Railway 502 proxy mismatch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,5 @@ COPY data ./data
 # Copy tsconfig files needed by tsx at runtime
 COPY tsconfig.json tsconfig.node.json ./
 
-EXPOSE 4000
-
+# PORT is injected by Railway at runtime (default 8080); do not hardcode EXPOSE
 CMD ["npm", "start"]

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -29,10 +29,23 @@ const app: Express = express();
 const PORT = process.env.PORT || 4000;
 const nonApiSpaRoutePattern = /^(?!\/api(?:\/|$)).*/;
 
+// Trust Railway's reverse proxy (required for correct req.ip, req.protocol)
+app.set('trust proxy', 1);
+
 // Middleware
 app.use(helmet());
 app.use(cookieParser());
 app.use(express.json());
+
+// Request logging (lightweight — method, path, status, duration)
+app.use((req, res, next) => {
+  const start = Date.now();
+  res.on('finish', () => {
+    const duration = Date.now() - start;
+    console.log(`[HTTP] ${req.method} ${req.path} ${res.statusCode} ${duration}ms`);
+  });
+  next();
+});
 
 // Routes
 app.use('/api/health', healthRouter);
@@ -88,6 +101,14 @@ if (existsSync(distPath)) {
     });
   });
 }
+
+// Global error handler — catch middleware/route errors and return 500 instead of crashing
+app.use((err: Error, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
+  console.error('[Server] Unhandled route error:', err.message, err.stack);
+  if (!res.headersSent) {
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
 
 /**
  * Starts the Express server


### PR DESCRIPTION
## Summary

- **Remove hardcoded `EXPOSE 4000`** from Dockerfile — Railway sets `PORT=8080` at runtime, but the `EXPOSE 4000` directive likely caused the domain's target port to be configured as 4000, making Railway's edge proxy route traffic to port 4000 while the server actually listens on 8080 → 502 on all non-healthcheck requests
- **Add `trust proxy`** setting so Express correctly reads client IP/protocol behind Railway's reverse proxy
- **Add request logging middleware** for production observability (method, path, status, duration)
- **Add global error handler** to catch unhandled route errors and return 500 instead of crashing

## Root Cause Analysis

The healthcheck passed because Railway checks it directly against the `PORT` env var (8080). But the public domain's **target port** was likely set to 4000 (matching the Dockerfile `EXPOSE`), so the edge proxy routed external traffic to port 4000 where nothing was listening — resulting in 502 for every request.

## Required Manual Step

After merging, **verify the domain's target port in Railway's service settings**:
1. Go to your Railway service → Settings → Networking/Domains
2. Ensure the target port for `lusopronunciation-production.up.railway.app` is either **empty** (auto-detect) or set to **8080**
3. If it's set to 4000, change it to 8080 or remove it

## Test plan

- [ ] Deploy to Railway and confirm `/` no longer returns 502
- [ ] Check deploy logs for `[HTTP]` request log lines confirming traffic reaches the server
- [ ] Verify `/api/health` still returns 200

https://claude.ai/code/session_01Crpoz2sWNDqij61y84QnFC