### PR TITLE
fix(cors): allow same-origin requests in pronunciation middleware

### DIFF
--- a/src/server/middleware/pronunciationSecurity.ts
+++ b/src/server/middleware/pronunciationSecurity.ts
@@ -89,7 +89,14 @@ export function pronunciationCorsMiddleware(req: Request, res: Response, next: N
     return;
   }
 
-  if (!allowedOrigins.has(requestOrigin)) {
+  // Allow same-origin requests: when the app serves both frontend and API
+  // from the same host (e.g. Railway), the Origin will match the Host header.
+  const host = req.header('host');
+  const isSameOrigin =
+    host &&
+    (requestOrigin === `https://${host}` || requestOrigin === `http://${host}`);
+
+  if (!isSameOrigin && !allowedOrigins.has(requestOrigin)) {
     speechLog('warn', 'Pronunciation request blocked by CORS policy', {
       requestId,
       statusClass: '4xx',


### PR DESCRIPTION
## Summary

- Fixes 403 "This origin is not allowed to access pronunciation endpoints" error on Railway production deployment
- Adds same-origin detection to `pronunciationCorsMiddleware` by comparing the request's `Origin` header against the `Host` header
- When frontend and API are served from the same host (as on Railway), requests are now automatically allowed without needing env var configuration

## Root Cause

The pronunciation security middleware (`pronunciationSecurity.ts`) only allowed `localhost` origins by default. In production on Railway (`lusopronunciation-production.up.railway.app`), the browser sends an `Origin` header matching the deployment URL, which wasn't in the allowlist. No `CORS_ALLOWED_ORIGINS` / `SPEECH_CORS_ALLOWED_ORIGINS` / `APP_ORIGINS` env var was set on Railway.

## Test plan

- [ ] Verify pronunciation assessment works on Railway production without 403 errors
- [ ] Verify localhost development still works as before
- [ ] Optionally confirm that cross-origin requests from unknown domains are still blocked

https://claude.ai/code/session_01HpvMh7T2ssifVgp9vV9CNg