### PR TITLE
fix(auth): require authentication for pronunciation assessment

### DIFF
--- a/e2e/phase04/core-loop.spec.ts
+++ b/e2e/phase04/core-loop.spec.ts
@@ -66,7 +66,14 @@ async function enableE2EMediaScenario(
   }, mediaScenario);
 }
 
+async function seedAuthToken(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    localStorage.setItem('luso_auth_token', 'e2e-test-token');
+  });
+}
+
 async function goToSentencePractice(page: Page): Promise<void> {
+  await seedAuthToken(page);
   await page.goto('/practice/sentence');
   await expect(page.getByRole('heading', { name: 'Sentence Practice' })).toBeVisible();
 }

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -14,6 +14,7 @@ import RecentSessions from '../pages/RecentSessions';
 import AuthPage from '../pages/AuthPage';
 import OAuthCallbackPage from '../pages/OAuthCallbackPage';
 import { isAuthenticated, pingSpeechServiceHealth } from '@/api/auth';
+import RequireAuth from '@/components/auth/RequireAuth';
 
 // Dev-only pages — lazy loaded and tree-shaken from production bundle
 const PronunciationFixtures = lazy(() => import('../pages/dev/pronunciation-fixtures'));
@@ -25,13 +26,13 @@ function AppRoutes() {
     <BrowserRouter>
       <AppLayout>
         <Routes>
-          <Route path="/" element={<UserDashboardPage />} />
+          <Route path="/" element={<RequireAuth><UserDashboardPage /></RequireAuth>} />
           <Route path="/auth" element={<AuthPage />} />
           <Route path="/auth/callback" element={<OAuthCallbackPage />} />
-          <Route path="/practice/sentence" element={<SentencePractice />} />
-          <Route path="/practice/word" element={<WordPractice />} />
-          <Route path="/review" element={<Review />} />
-          <Route path="/sessions" element={<RecentSessions />} />
+          <Route path="/practice/sentence" element={<RequireAuth><SentencePractice /></RequireAuth>} />
+          <Route path="/practice/word" element={<RequireAuth><WordPractice /></RequireAuth>} />
+          <Route path="/review" element={<RequireAuth><Review /></RequireAuth>} />
+          <Route path="/sessions" element={<RequireAuth><RecentSessions /></RequireAuth>} />
           {import.meta.env.DEV && (
             <>
               <Route path="/dev/pronunciation-fixtures" element={<Suspense fallback={null}><PronunciationFixtures /></Suspense>} />

--- a/src/components/auth/RequireAuth.tsx
+++ b/src/components/auth/RequireAuth.tsx
@@ -1,0 +1,9 @@
+import { Navigate } from 'react-router-dom';
+import { isAuthenticated } from '@/api/auth';
+
+export default function RequireAuth({ children }: { children: React.ReactNode }) {
+  if (!isAuthenticated()) {
+    return <Navigate to="/auth" replace />;
+  }
+  return <>{children}</>;
+}

--- a/src/components/practice/SentenceCard.tsx
+++ b/src/components/practice/SentenceCard.tsx
@@ -76,7 +76,10 @@ function SentenceCard({ sentence, currentIndex, totalCount, sessionId }: Sentenc
       // POST to API endpoint
       const headers: Record<string, string> = {};
       const authHeaderValue = getAuthHeader();
-      if (authHeaderValue) headers['Authorization'] = authHeaderValue;
+      if (!authHeaderValue) {
+        throw new Error('Please log in to use pronunciation assessment.');
+      }
+      headers['Authorization'] = authHeaderValue;
 
       const response = await fetch('/api/pronunciation/assessment', {
         method: 'POST',

--- a/src/hooks/useLivePronunciationPractice.telemetry.test.tsx
+++ b/src/hooks/useLivePronunciationPractice.telemetry.test.tsx
@@ -71,6 +71,7 @@ describe('useLivePronunciationPractice telemetry', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     window.localStorage.clear();
+    window.localStorage.setItem('luso_auth_token', 'test-token');
     vi.stubGlobal('fetch', vi.fn());
     vi.mocked(analyzeAudioBlob).mockResolvedValue({
       durationMs: 1200,

--- a/src/hooks/useLivePronunciationPractice.test.tsx
+++ b/src/hooks/useLivePronunciationPractice.test.tsx
@@ -77,6 +77,7 @@ describe('useLivePronunciationPractice lifecycle', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     window.localStorage.clear();
+    window.localStorage.setItem('luso_auth_token', 'test-token');
     vi.stubGlobal('fetch', vi.fn());
     vi.mocked(analyzeAudioBlob).mockResolvedValue({
       durationMs: 1400,

--- a/src/hooks/useLivePronunciationPractice.ts
+++ b/src/hooks/useLivePronunciationPractice.ts
@@ -329,7 +329,10 @@ export function useLivePronunciationPractice(): UseLivePronunciationPracticeResu
       // POST to API endpoint
       const fetchHeaders: Record<string, string> = {};
       const authHeaderValue = getAuthHeader();
-      if (authHeaderValue) fetchHeaders['Authorization'] = authHeaderValue;
+      if (!authHeaderValue) {
+        throw new Error('Please log in to use pronunciation assessment.');
+      }
+      fetchHeaders['Authorization'] = authHeaderValue;
 
       const response = await fetch('/api/pronunciation/assessment', {
         method: 'POST',

--- a/src/lib/wordPronunciation.ts
+++ b/src/lib/wordPronunciation.ts
@@ -32,7 +32,10 @@ export async function scoreWordPronunciation(
   // POST to API endpoint (same endpoint as sentences)
   const headers: Record<string, string> = {};
   const authHeader = getAuthHeader();
-  if (authHeader) headers['Authorization'] = authHeader;
+  if (!authHeader) {
+    throw new Error('Please log in to use pronunciation assessment.');
+  }
+  headers['Authorization'] = authHeader;
 
   const response = await fetch('/api/pronunciation/assessment', {
     method: 'POST',


### PR DESCRIPTION
## Summary
- **Root cause**: No route guards existed, so unauthenticated users could reach practice pages. The client code silently omitted the `Authorization` header when no token was in localStorage, causing the server to return 401 "Missing or invalid authorization header".
- Added a `RequireAuth` component that redirects unauthenticated users to `/auth`
- All three pronunciation API call sites (`useLivePronunciationPractice`, `SentenceCard`, `wordPronunciation`) now throw a clear error instead of silently sending requests without auth

## Test plan
- [ ] Verify unauthenticated users are redirected to `/auth` when visiting `/`, `/practice/sentence`, `/practice/word`, `/review`, `/sessions`
- [ ] Verify logged-in users can access all routes normally
- [ ] Verify pronunciation assessment works after logging in
- [ ] Verify OAuth callback flow still works (redirects to `/` after token is stored)

https://claude.ai/code/session_01AXq2pJUcG7w6TimnmYvkgj