### PR TITLE
feat(ui): implement Phase 3 behavior upgrades — review queue, momentum, completion

### DIFF
--- a/src/components/common/CompletionMoment.tsx
+++ b/src/components/common/CompletionMoment.tsx
@@ -1,0 +1,29 @@
+import { Link } from 'react-router-dom';
+import { CheckCircle } from 'lucide-react';
+
+interface CompletionMomentProps {
+  message: string;
+  metric?: string;
+  action?: { label: string; to: string };
+}
+
+export default function CompletionMoment({ message, metric, action }: CompletionMomentProps) {
+  return (
+    <div className="card text-center py-8 animate-in">
+      <CheckCircle size={48} className="mx-auto text-green-500 dark:text-green-400 mb-4" />
+      <p className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-1">
+        {message}
+      </p>
+      {metric && (
+        <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
+          {metric}
+        </p>
+      )}
+      {action && (
+        <Link to={action.to} className="btn btn-primary btn-sm mt-2">
+          {action.label}
+        </Link>
+      )}
+    </div>
+  );
+}

--- a/src/components/common/MomentumStrip.tsx
+++ b/src/components/common/MomentumStrip.tsx
@@ -1,0 +1,54 @@
+import { Link } from 'react-router-dom';
+import { Flame, Target, ClipboardList } from 'lucide-react';
+
+interface MomentumStripProps {
+  streak: number;
+  todayAttempts: number;
+  dailyTarget?: number;
+  dueCount: number;
+}
+
+export default function MomentumStrip({
+  streak,
+  todayAttempts,
+  dailyTarget = 10,
+  dueCount,
+}: MomentumStripProps) {
+  return (
+    <div className="flex flex-wrap items-center gap-4 text-sm text-gray-600 dark:text-gray-400">
+      {/* Streak */}
+      <div className="flex items-center gap-1.5" title="Current daily streak">
+        <Flame size={16} className={streak > 0 ? 'text-orange-500' : 'text-gray-400 dark:text-gray-500'} />
+        <span className="font-medium text-gray-900 dark:text-gray-100">{streak}</span>
+        <span>day{streak !== 1 ? 's' : ''}</span>
+      </div>
+
+      <span className="text-gray-300 dark:text-gray-600">|</span>
+
+      {/* Today's progress */}
+      <div className="flex items-center gap-1.5" title="Attempts today">
+        <Target size={16} className="text-primary-500" />
+        <span className="font-medium text-gray-900 dark:text-gray-100">
+          {todayAttempts}
+        </span>
+        <span>/ {dailyTarget} today</span>
+      </div>
+
+      {/* Review due badge */}
+      {dueCount > 0 && (
+        <>
+          <span className="text-gray-300 dark:text-gray-600">|</span>
+          <Link
+            to="/review"
+            className="flex items-center gap-1.5 hover:text-primary-600 dark:hover:text-primary-400 transition-colors"
+            title="Items due for review"
+          >
+            <ClipboardList size={16} className="text-yellow-500" />
+            <span className="font-medium text-gray-900 dark:text-gray-100">{dueCount}</span>
+            <span>due</span>
+          </Link>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/lib/practiceAnalytics.ts
+++ b/src/lib/practiceAnalytics.ts
@@ -894,3 +894,96 @@ export function computeUxDiagnostics(
   };
 }
 
+// ---- Review Queue ----
+
+export interface ReviewQueueItem {
+  itemId: string;
+  itemType: 'sentence' | 'word';
+  bestScore: number;
+  lastAttemptAt: string;
+  attemptCount: number;
+  reviewPriority: number;
+}
+
+/**
+ * Build a review queue from low-score attempts, weighted by recency.
+ *
+ * Algorithm:
+ *  1. Group attempts by item (sentence / word).
+ *  2. For each item keep the best score and most recent attempt date.
+ *  3. Compute reviewPriority = (1 - bestScore/100) * recencyWeight,
+ *     where recencyWeight decays logarithmically over `recencyWeightDays`.
+ *  4. Filter to items whose best score < scoreThreshold.
+ *  5. Return top `maxItems` sorted by reviewPriority descending.
+ */
+export function buildReviewQueue(
+  sentenceAttempts: SentencePracticeAttempt[],
+  wordAttempts: WordPracticeAttempt[],
+  options?: {
+    maxItems?: number;
+    recencyWeightDays?: number;
+    scoreThreshold?: number;
+  },
+): ReviewQueueItem[] {
+  const maxItems = options?.maxItems ?? 20;
+  const recencyWeightDays = options?.recencyWeightDays ?? 7;
+  const scoreThreshold = options?.scoreThreshold ?? 80;
+
+  const now = Date.now();
+  const decayMs = recencyWeightDays * 24 * 60 * 60 * 1000;
+
+  // Accumulator keyed by "sentence:<id>" or "word:<id>"
+  const items = new Map<
+    string,
+    { itemId: string; itemType: 'sentence' | 'word'; bestScore: number; lastAttemptAt: number; attemptCount: number }
+  >();
+
+  function ingest(
+    itemId: string,
+    itemType: 'sentence' | 'word',
+    score: number,
+    createdAt: string,
+  ) {
+    const key = `${itemType}:${itemId}`;
+    const ts = new Date(createdAt).getTime();
+    const existing = items.get(key);
+    if (existing) {
+      existing.bestScore = Math.max(existing.bestScore, score);
+      existing.lastAttemptAt = Math.max(existing.lastAttemptAt, ts);
+      existing.attemptCount += 1;
+    } else {
+      items.set(key, { itemId, itemType, bestScore: score, lastAttemptAt: ts, attemptCount: 1 });
+    }
+  }
+
+  for (const a of sentenceAttempts) {
+    ingest(a.sentenceId, 'sentence', a.overallScore, a.createdAt);
+  }
+  for (const a of wordAttempts) {
+    ingest(a.wordId, 'word', a.overallScore, a.createdAt);
+  }
+
+  const queue: ReviewQueueItem[] = [];
+  for (const item of items.values()) {
+    if (item.bestScore >= scoreThreshold) continue;
+
+    const ageFraction = Math.min((now - item.lastAttemptAt) / decayMs, 1);
+    // Higher weight for more recent items (1 = just practiced, approaches 0 as age → decayMs)
+    const recencyWeight = 1 - ageFraction * 0.5; // range [0.5, 1]
+    const scoreFactor = 1 - item.bestScore / 100; // lower score → higher factor
+    const reviewPriority = scoreFactor * recencyWeight;
+
+    queue.push({
+      itemId: item.itemId,
+      itemType: item.itemType,
+      bestScore: item.bestScore,
+      lastAttemptAt: new Date(item.lastAttemptAt).toISOString(),
+      attemptCount: item.attemptCount,
+      reviewPriority,
+    });
+  }
+
+  queue.sort((a, b) => b.reviewPriority - a.reviewPriority);
+  return queue.slice(0, maxItems);
+}
+

--- a/src/pages/PracticePage.tsx
+++ b/src/pages/PracticePage.tsx
@@ -1,6 +1,10 @@
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { AlignLeft, CaseSensitive } from 'lucide-react';
+import { usePracticeLogStore } from '@/state/practiceLogStore';
+import { useProgressStore } from '@/state/progressStore';
+import { computeUserGlobalStats } from '@/lib/practiceAnalytics';
+import MomentumStrip from '@/components/common/MomentumStrip';
 import SentencePractice from './SentencePractice';
 import WordPractice from './WordPractice';
 
@@ -12,6 +16,28 @@ export default function PracticePage() {
   const initialTab: PracticeTab = paramTab === 'words' ? 'words' : 'sentences';
   const [activeTab, setActiveTab] = useState<PracticeTab>(initialTab);
 
+  const { sessions, sentenceAttempts, wordAttempts } = usePracticeLogStore();
+  const { getDueCount } = useProgressStore();
+  const dueCount = getDueCount();
+
+  const streak = useMemo(() => {
+    if (sessions.length === 0) return 0;
+    // Lightweight streak calc — reuse computeUserGlobalStats only when sessions exist
+    const stats = computeUserGlobalStats(sessions, sentenceAttempts, wordAttempts, 0, 0);
+    return stats.currentDailyStreak;
+  }, [sessions, sentenceAttempts, wordAttempts]);
+
+  const todayAttempts = useMemo(() => {
+    const todayStr = new Date().toISOString().split('T')[0];
+    const sentenceCount = sentenceAttempts.filter(
+      (a) => new Date(a.createdAt).toISOString().split('T')[0] === todayStr,
+    ).length;
+    const wordCount = wordAttempts.filter(
+      (a) => new Date(a.createdAt).toISOString().split('T')[0] === todayStr,
+    ).length;
+    return sentenceCount + wordCount;
+  }, [sentenceAttempts, wordAttempts]);
+
   function handleTabChange(tab: PracticeTab) {
     setActiveTab(tab);
     setSearchParams(tab === 'sentences' ? {} : { tab }, { replace: true });
@@ -19,6 +45,15 @@ export default function PracticePage() {
 
   return (
     <div>
+      {/* Momentum strip */}
+      <div className="mb-4">
+        <MomentumStrip
+          streak={streak}
+          todayAttempts={todayAttempts}
+          dueCount={dueCount}
+        />
+      </div>
+
       {/* Tab bar */}
       <div className="flex gap-1 mb-6 border-b border-gray-200 dark:border-gray-700">
         <button

--- a/src/pages/Review.tsx
+++ b/src/pages/Review.tsx
@@ -11,6 +11,7 @@ import DifficultyButtons, { type DifficultyRating } from '@/components/practice/
 import LoadingSpinner from '@/components/common/LoadingSpinner';
 import PageTransition from '@/components/common/PageTransition';
 import PageScaffold from '@/components/common/PageScaffold';
+import CompletionMoment from '@/components/common/CompletionMoment';
 import { stopAllAudio } from '@/hooks/useAudioPlayer';
 
 type ReviewTab = 'queue' | 'recent';
@@ -229,17 +230,11 @@ export default function Review() {
         {activeTab === 'queue' && (
           <>
             {totalDue === 0 ? (
-              <div className="card text-center py-10">
-                <p className="text-gray-600 dark:text-gray-400 text-lg mb-4">
-                  All caught up!
-                </p>
-                <p className="text-gray-500 dark:text-gray-500 mb-6">
-                  No items due for review right now.
-                </p>
-                <Link to="/" className="btn btn-primary">
-                  Practice New Items
-                </Link>
-              </div>
+              <CompletionMoment
+                message="All caught up!"
+                metric="No items due for review right now."
+                action={{ label: 'Practice New Items', to: '/' }}
+              />
             ) : (
               <>
                 {/* Progress bar */}


### PR DESCRIPTION
Add data-driven review queue and motivational UX moments:

buildReviewQueue (src/lib/practiceAnalytics.ts):
- Groups attempts by item, keeps best score and most recent date
- Computes reviewPriority = scoreFactor * recencyWeight
- Filters items with bestScore < threshold (default 80)
- Returns top N items sorted by priority (exported, pure function)

CompletionMoment (src/components/common/CompletionMoment.tsx):
- Animated card with CheckCircle icon, message, optional metric, and action link. Replaces the hand-rolled empty state on Review queue tab.

MomentumStrip (src/components/common/MomentumStrip.tsx):
- Compact horizontal strip showing: streak (Flame icon), today's progress (X / 10 today), and review due count (links to /review).
- Added to PracticePage header above the tab bar.

Page integrations:
- PracticePage: computes streak, todayAttempts, dueCount and renders MomentumStrip above Sentences/Words tabs
- Review: uses CompletionMoment for queue empty state ("All caught up!")

All 117 existing tests pass with no regressions.

https://claude.ai/code/session_01JbeHWMxkiR1eP9o6VPsJgq