### PR TITLE
Security audit + abuse-resistance hardening (OWASP ASVS 5.0)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,64 +1,108 @@
 # LusoPronunciation — Environment Variables
-# Copy this file to .env and fill in your actual values
+# Copy this file to .env and fill in your actual values.
+#
+# SECURITY NOTES (read before setting up production):
+#   - NEVER commit .env to git. The .gitignore already blocks it.
+#   - In production, set NODE_ENV=production. Several hardening behaviors
+#     (CORS allowlist strictness, JWT length check, refusal to boot with
+#     ENABLE_DEV_LOGIN, insecure-cookie detection, etc.) only activate when
+#     NODE_ENV=production.
+#   - Prefer secret managers (Railway shared variables, Azure Key Vault with
+#     managed identity, AWS Secrets Manager, Vercel encrypted env) over
+#     plaintext .env files for deployed environments.
+#   - Rotate AZURE_SPEECH_KEY, GEMINI_API_KEY, MONGODB_URI password, and
+#     JWT_SECRET any time a dev machine may have been compromised.
 
 # ──────────────── Azure Speech Service ────────────────
 # Get your key and region from: https://portal.azure.com/
+# Consider using an Azure managed identity + Key Vault in production rather
+# than a long-lived shared key.
 AZURE_SPEECH_KEY=your-azure-speech-key-here
 AZURE_SPEECH_REGION=eastus
 
 # ──────────────── MongoDB ────────────────
-# Connection string for MongoDB (Atlas or local)
 MONGODB_URI=mongodb+srv://<user>:<password>@<cluster>.mongodb.net/lusopronunciation
 
 # ──────────────── Authentication ────────────────
-# Secret for signing JWT tokens (generate with: openssl rand -hex 32)
-JWT_SECRET=your-random-secret-here
+# Secret for signing JWT tokens. REQUIRED >=32 chars in production.
+# Generate with: openssl rand -hex 32
+JWT_SECRET=your-random-secret-here-must-be-at-least-32-chars
 
 # ──────────────── Invite Code Gating ────────────────
-# Set to 'false' to allow open signup for launch.
-# If left as 'true', seed at least one code before launch:
+# 'true' (default) requires an invite code for registration.
+# Seed at least one before launch:
 #   npm run invite:seed -- --code=LAUNCH-ACCESS --maxUses=25
-REQUIRE_INVITE_CODE=false
+REQUIRE_INVITE_CODE=true
 
 # ──────────────── Dev Login ────────────────
-# Set to 'true' to enable passwordless dev quick-login (never enable in production!)
+# SECURITY: Refused at boot if NODE_ENV=production.
 # ENABLE_DEV_LOGIN=true
+# Optional shared token required in the X-Dev-Login-Token header:
+# DEV_LOGIN_TOKEN=some-random-shared-token
 
 # ──────────────── OAuth Providers ────────────────
-# GitHub OAuth App — https://github.com/settings/developers
 GITHUB_CLIENT_ID=
 GITHUB_CLIENT_SECRET=
-
-# LinkedIn OAuth App — https://www.linkedin.com/developers/apps
 LINKEDIN_CLIENT_ID=
 LINKEDIN_CLIENT_SECRET=
 
 # ──────────────── App Origin ────────────────
-# The public URL of your deployed app (used for OAuth redirect URIs)
-# In development this defaults to http://localhost:3000
+# Public URL of your deployed app (used for OAuth redirect URIs and as an
+# implicitly-trusted CORS origin).
 # APP_ORIGIN=https://your-app.up.railway.app
 
 # ──────────────── Server ────────────────
-# Port for the Express server (Railway sets this automatically)
 PORT=4000
+# Set to 'production' to activate production hardening behaviors.
+# NODE_ENV=production
 
 # ──────────────── CORS ────────────────
-# Use one of these to add your deployed domain to the allowlist.
+# Comma-separated allowlist of browser Origins allowed to call /api/pronunciation.
+# In production, the dev-localhost defaults are NOT added automatically — you
+# must list every origin explicitly.
 # APP_ORIGINS=https://your-app.up.railway.app,https://yourdomain.com
 # CORS_ALLOWED_ORIGINS=https://your-app.up.railway.app,https://yourdomain.com
 # SPEECH_CORS_ALLOWED_ORIGINS=https://your-app.up.railway.app,https://yourdomain.com
 
-# ──────────────── Rate Limiting (optional) ────────────────
+# ──────────────── Global API rate limit (per-IP) ────────────────
+# Baseline cap across every /api/* request. Tighten these if you see abuse.
+# GLOBAL_API_WINDOW_MS=60000
+# GLOBAL_API_MAX=120
+
+# ──────────────── Auth rate limits ────────────────
+# Login: per-IP and per-email windows. Defaults: 20 attempts/15min (IP),
+# 10 attempts/15min (email).
+# AUTH_LOGIN_IP_WINDOW_MS=900000
+# AUTH_LOGIN_IP_MAX=20
+# AUTH_LOGIN_EMAIL_WINDOW_MS=900000
+# AUTH_LOGIN_EMAIL_MAX=10
+# Register: per-IP. Default: 10 attempts/hour.
+# AUTH_REGISTER_IP_WINDOW_MS=3600000
+# AUTH_REGISTER_IP_MAX=10
+
+# ──────────────── Pronunciation abuse controls ────────────────
+# Sliding burst limiter. Defaults: 20 requests / 5 min / key.
 # SPEECH_RATE_LIMIT_WINDOW_MS=300000
 # SPEECH_RATE_LIMIT_MAX_REQUESTS=20
+# Hard daily ceiling per authenticated user. Resets at 00:00 UTC. Default 200.
+# SPEECH_DAILY_QUOTA=200
+# Reject uploaded audio whose first bytes do not match a known container
+# signature. Defaults to "on" in production, "off" otherwise.
+# SPEECH_STRICT_AUDIO_SIGNATURE=true
 
-# ──────────────── Upload + Speech Runtime (optional) ────────────────
+# ──────────────── Upload + Speech Runtime ────────────────
 # SPEECH_MAX_UPLOAD_BYTES=10485760
 # AUDIO_CONVERT_TIMEOUT_MS=12000
 # SPEECH_HEALTH_TIMEOUT_MS=5000
 # AUDIO_CONVERT_FFMPEG_PATH=/usr/local/bin/ffmpeg
+# SECURITY: SPEECH_DEBUG dumps full Azure payloads to disk. Keep off unless
+# actively investigating an incident.
 # SPEECH_DEBUG=false
 
-# ──────────────── Frontend Build Flags (optional) ────────────────
+# ──────────────── JSON body limits ────────────────
+# JSON_BODY_LIMIT=128kb
+# MIGRATION_JSON_LIMIT=2mb
+
+# ──────────────── Frontend Build Flags ────────────────
 # VITE_CONTENT_SOURCE=pipeline
 # Leave VITE_ENABLE_DEV_ANALYTICS unset in preview/production

--- a/SECURITY_AUDIT_AND_HARDENING.md
+++ b/SECURITY_AUDIT_AND_HARDENING.md
@@ -1,0 +1,273 @@
+# LusoPronunciation — Security Audit and Hardening
+
+**Branch:** `develop`
+**Auditor:** Claude (Anthropic) acting as security engineer
+**Date:** 2026-04-16
+**Standard:** OWASP ASVS 5.0 + Microsoft Azure guidance on rate limiting, quotas, and managed-identity/Key-Vault secret storage
+
+---
+
+## 1. Executive summary
+
+LusoPronunciation is a single-tenant Brazilian Portuguese pronunciation trainer with a React/Vite SPA and an Express/MongoDB backend that proxies audio recordings to Azure Speech Pronunciation Assessment. The concern driving this audit: even with Azure billing caps in place, the app could plausibly be abused as a public gateway to Azure Speech, and could leak credentials, suffer credential stuffing, or be DoS'd via oversized payloads — any of which would degrade service for the legitimate user (the author) and could hurt recruiter/demo trust.
+
+The pre-existing codebase already had several thoughtful controls (Helmet, a pronunciation-endpoint rate limiter, invite-code gating, JWT auth, bcrypt password hashing, user-scoped MongoDB queries, safe error payloads on the pronunciation route). The most material gaps were:
+
+1. **No rate limiting on `/api/auth/*`** — open to brute force, credential stuffing, and invite-code enumeration.
+2. **No global body-size limit** — `express.json()` used its default, letting `/api/migrate/local-storage` accept arbitrarily large JSON.
+3. **No daily quota on Azure-backed endpoints** — only a sliding 20/5-min burst limit, which an attacker can drift under indefinitely.
+4. **OAuth JWT returned in the URL query** — leaked through Referer, browser history, and logs.
+5. **Verbatim `error.message` returned to clients** on most routes — leaks internal details.
+6. **Weak password policy** (6-char minimum) and bcrypt cost 10.
+7. **Dev-login endpoint** guarded only by `ENABLE_DEV_LOGIN`. A misconfigured env var in production became instant auth bypass.
+8. **12 dependency vulnerabilities** (multer DoS, path-to-regexp ReDoS, vite path traversal, jws signature issue).
+9. **Uploaded audio trusted by MIME type only** — no magic-byte check, no content-length gate.
+10. **Invite-code error responses distinguished** between "unknown", "expired", and "used", enabling silent enumeration.
+
+All of the above have been fixed in this branch. The app now refuses to boot in production with obviously-unsafe configuration (`ENABLE_DEV_LOGIN=true` in prod, short `JWT_SECRET`), enforces multi-layer rate limiting + a daily cost ceiling on Azure calls, rejects uploaded audio that doesn't begin with a known container signature, and strips error detail from client responses. Tests pass (123/123), new tests added for the rate limiter and daily quota, and `npm audit` is clean.
+
+**Production risk rating before changes:** High (cheap proxy-to-Azure potential, credential stuffing open).
+**Production risk rating after changes:** Acceptable for recruiter/demo deployment on a private invite code. Residual items are all operational (key rotation, external WAF/CDN, platform monitoring).
+
+---
+
+## 2. Threat model
+
+| # | Asset | Entry point | Trust boundary | Attacker action | Impact |
+|---|---|---|---|---|---|
+| T1 | Azure Speech key | Server env only (`AZURE_SPEECH_KEY`) | Internet → server | Direct call to `/api/pronunciation/assessment` to drive Azure spend | Billing / service degradation |
+| T2 | Azure quota | `/api/pronunciation/assessment` | Server → Azure | Sustained low-rate calls (below burst limit) to farm assessments | Billing ceiling hit |
+| T3 | MongoDB | `MONGODB_URI` | Server → Mongo Atlas | Exfiltrate connection string via server logs / debug dumps | Data exposure |
+| T4 | User credentials | `/api/auth/login` | Internet → server | Credential stuffing / brute force | Account takeover |
+| T5 | Invite codes | `/api/auth/register` | Internet → server | Enumerate valid codes from distinct error responses | Unauthorized signup |
+| T6 | JWT secret | Server env (`JWT_SECRET`) | Internet → server (side-channel only) | Crack short/weak secret → forge tokens | Full auth bypass |
+| T7 | OAuth JWT | `/api/auth/oauth/*/callback` | Server → browser | Capture token from URL query via Referer / history / logs | Session hijack |
+| T8 | Migration endpoint | `/api/migrate/local-storage` | Internet → server (authed) | POST unbounded JSON arrays | Memory exhaustion / DoS |
+| T9 | Pronunciation audio upload | `/api/pronunciation/assessment` | Internet → server | Upload oversized / non-audio blob → ffmpeg / Azure cost | Resource abuse |
+| T10 | Dev-login bypass | `/api/auth/dev-login` | Internet → server | Toggle `ENABLE_DEV_LOGIN` in prod → instant auth | Full bypass |
+| T11 | Speech debug dump | `/data/debug/*.json` | Filesystem | Capture full Azure payloads if `SPEECH_DEBUG=on` leaked | PII exposure |
+| T12 | Dependency vulns | npm tree | Internet → server | ReDoS, path-traversal, MulterDoS | DoS / RCE vector surface |
+| T13 | Error responses | All routes | Server → Internet | Glean internal structure from `error.message` | Reconnaissance |
+| T14 | CORS policy | `/api/pronunciation*` | Browser | Malicious origin scripts user's browser to call API | CSRF-adjacent |
+| T15 | Client bundle | `dist/assets/*.js` | Build → Internet | Inspect JS for leaked secrets | Credential disclosure |
+| T16 | OAuth callback redirect | `/api/auth/oauth/*/callback` | Server → browser | Open redirect if `APP_ORIGIN` attacker-controlled | Phishing |
+
+---
+
+## 3. Findings by severity
+
+### Critical
+
+| ID | Area | Finding | Status |
+|---|---|---|---|
+| C-1 | Auth | No rate limit on `/api/auth/login`, `/register`, or `/dev-login`. Credential stuffing and invite-code enumeration were wide open. | **Fixed** |
+| C-2 | Cost control | No daily quota on Azure calls. Burst limiter alone allowed ~24,000 requests/day per IP/user — uncapped Azure spend under the account ceiling. | **Fixed** |
+| C-3 | DoS | `express.json()` had no size limit → `/api/migrate/local-storage` accepted unbounded JSON payloads. | **Fixed** |
+| C-4 | OAuth | Token returned in URL query on `/auth/callback?token=...` — logged in access logs, Referer headers, browser history. | **Fixed** |
+| C-5 | Env safety | `ENABLE_DEV_LOGIN=true` in production was a silent auth bypass with no runtime warning. | **Fixed** |
+
+### High
+
+| ID | Area | Finding | Status |
+|---|---|---|---|
+| H-1 | Deps | 12 vulnerabilities from `npm audit`: multer DoS (x3), path-to-regexp ReDoS (x2), vite path traversal (x3), qs DoS (x2), jws signature, jsonwebtoken transitively. | **Fixed** (npm audit fix — 0 remaining) |
+| H-2 | Auth | Password minimum was 6 chars. bcrypt cost was 10 (acceptable, but 12 is better for a small user base). | **Fixed** (min 8, cost 12) |
+| H-3 | Upload | No magic-byte check on uploaded audio — `multer` trusted MIME type alone; no content-length pre-gate. | **Fixed** |
+| H-4 | Enumeration | `/api/auth/register` returned distinct messages for "unknown invite", "expired invite", "used invite". | **Fixed** (unified failure message) |
+| H-5 | Timing | User-enumeration via login timing — bcrypt ran only when user existed. | **Fixed** (dummy-hash bcrypt on miss) |
+| H-6 | JWT | No minimum `JWT_SECRET` length enforced. | **Fixed** (≥32 chars in prod) |
+| H-7 | Reference text | `referenceText` had no length cap → arbitrarily long strings sent to Azure in a header. | **Fixed** (500 char cap) |
+| H-8 | Migration | No upper bound on array counts → attacker could POST millions of session rows. | **Fixed** (5k/50k/50k caps) |
+
+### Medium
+
+| ID | Area | Finding | Status |
+|---|---|---|---|
+| M-1 | Errors | `res.json({ error, message: err.message })` throughout practice / flashcards / migration → raw stack detail leaked. | **Fixed** |
+| M-2 | CORS | In production, `readConfiguredOrigins()` merged dev-localhost defaults into the allowlist even on prod. | **Fixed** (dev defaults gated on non-prod) |
+| M-3 | CORS | `Access-Control-Allow-Headers` reflected `Access-Control-Request-Headers` unconditionally → potential header-whitelist bypass. | **Fixed** (fixed allowlist) |
+| M-4 | Headers | Helmet missing `frameAncestors: 'none'`, `objectSrc: 'none'`, HSTS tuning, `baseUri: 'self'`. | **Fixed** |
+| M-5 | Dev login | Dev endpoint only gated by env var. | **Fixed** (refuse boot in prod, optional shared-token header) |
+| M-6 | x-powered-by | Express fingerprint enabled. | **Fixed** (`app.disable('x-powered-by')`) |
+| M-7 | Global rate | No baseline API rate limit outside pronunciation endpoint. | **Fixed** (120/min/IP baseline) |
+| M-8 | ContentId | `GET /api/pronunciation-attempts?contentId=...` had no length cap. | **Fixed** |
+
+### Low
+
+| ID | Area | Finding | Status |
+|---|---|---|---|
+| L-1 | Invite timing | Invite-code lookup compared with `===`. | **Fixed** (constant-time compare) |
+| L-2 | Debug dumps | `SPEECH_DEBUG=true` writes raw Azure payloads to disk with no retention policy. | **Mitigated** (boot-time warning in prod; docs updated) |
+| L-3 | Logs | Access log didn't correlate `X-Request-Id`. | Left as-is (optional) |
+| L-4 | Health | Health endpoint exposes Mongo host/name — acceptable for ops, called out here for awareness. | Accepted |
+
+---
+
+## 4. Abuse scenarios (and what stops them now)
+
+**"Can someone abuse this app even if Azure spend is capped?"**
+
+| Scenario | Before | After |
+|---|---|---|
+| Script calls `/api/pronunciation/assessment` with a valid invite-code account, rotating IPs | 20/5min burst × 288 windows/day = 5,760 calls/day, no ceiling | Burst limiter (20/5min per user) + **daily quota 200 per user** regardless of IP. Attacker farms their own account, not my Azure budget. |
+| Credential stuffing a known email across IPs | Unlimited | Per-email 10/15min + per-IP 20/15min. Tripping either trips 429. |
+| Invite-code enumeration | Distinct error messages = O(n) scraping | Unified failure message + constant-time compare + 10-req/hour per IP on `/register` |
+| DoS via huge migration payload | Uncapped JSON body | `MIGRATION_JSON_LIMIT=2mb` + array count caps (5k sessions / 50k attempts) |
+| DoS via huge pronunciation upload | 10MB multer cap only (still respected once buffered) | `Content-Length > 2× max` rejected before buffer; strict magic-byte check in prod |
+| "Rename .exe → .wav and upload" | MIME-only trust, ffmpeg chewed on it | MIME allowlist + magic-byte gate on RIFF/WebM/Ogg/MP3/MP4/AAC signatures in prod |
+| OAuth session hijack via referer leak | Token in URL | Token in short-lived HttpOnly cookie, single-use handoff endpoint |
+| Script scrapes `/api/auth/providers` | Unlimited | 60/min per IP |
+| Flip `ENABLE_DEV_LOGIN=true` in Railway env by accident | Silent auth bypass | App refuses to boot in `NODE_ENV=production` with flag set |
+| Attempt to use `/api/auth/dev-login` anyway | None | Refused if `NODE_ENV=production`, 404'd |
+| Automate JWT forgery with a cracked short secret | Accepted | Refuses to boot with `JWT_SECRET` < 32 chars in prod |
+| Read secrets from client bundle | Client bundle scanned — none present before changes | Same; explicitly verified post-build |
+| Abuse `/api/migrate/local-storage` to store junk | Uncapped | Auth'd + bounded + ownership-checked |
+
+**"How could they degrade service, lock out legitimate users, spam logs, leak data, or harm trust?"**
+
+- Lock-out: the per-email login limiter is narrow enough that an attacker *could* lock your email out for 15 minutes. Acceptable trade-off vs. unlimited credential stuffing. Documented.
+- Log spam: structured warn-level log events (`[RateLimit] blocked`, `[DailyQuota] blocked`, `[Auth] invite code rejected`) are bounded — one line per blocked request. No unbounded dump surfaces.
+- Trust: rejected requests get generic messages; internal errors now say "An unexpected error occurred" instead of MongoDB/Azure error strings.
+
+**"How could they use this as a relay into my Azure resources?"**
+
+Only through a logged-in user account that has not yet hit its daily quota, and only through the pronunciation-assessment route (which enforces MIME + magic-byte + size + referenceText-length). Secrets never flow to the client. The `getAzureSpeechConfig()` call is server-only and verified clean in `grep` across the frontend tree.
+
+---
+
+## 5. Implemented fixes
+
+### 5.1 New middleware
+
+| File | Purpose |
+|---|---|
+| `src/server/middleware/rateLimit.ts` | Generic reusable rate limiter with per-IP / per-user / per-arbitrary-key options, structured warn logs on block, X-RateLimit-* headers |
+| `src/server/middleware/dailyQuota.ts` | Per-key daily ceiling that resets at 00:00 UTC. Second layer above the sliding limiter |
+| `src/server/middleware/rateLimit.test.ts` | 6 tests covering bucket separation, block emission, user-id keying, anonymous skip |
+
+### 5.2 Route hardening
+
+| File | Changes |
+|---|---|
+| `src/server/app.ts` | Global `/api` rate limit, JSON body limits (128kb default / 2mb on migration), stricter Helmet directives (`frameAncestors`, `objectSrc`, `baseUri`, `formAction`, HSTS 2y), `app.disable('x-powered-by')`, production refusal-to-boot with `ENABLE_DEV_LOGIN=true`, daily quota wired onto both pronunciation routes, generic 500 error payload |
+| `src/server/routes/auth.ts` | Per-IP + per-email login limiter, per-IP register limiter, bcrypt cost 12, 8–128 char password policy, 254-char email cap, 80-char displayName cap, 64-char invite-code cap, constant-time invite-code compare, unified invite-code failure message, dummy-hash bcrypt on login miss (eliminates user-enumeration timing), JWT secret length check in prod, dev-login refused in prod + optional shared-token header |
+| `src/server/routes/oauth.ts` | OAuth JWT returned via HttpOnly `oauth_handoff` cookie (2-min TTL, `sameSite=lax`, path-scoped) and exchanged on a new `GET /api/auth/oauth/handoff` endpoint — token is never in the URL |
+| `src/server/routes/pronunciationAssessment.ts` | MIME allowlist (`audio/wav`, `audio/webm`, `audio/ogg`, `audio/mpeg`, `audio/mp4`, `audio/x-m4a`, `audio/aac`), magic-byte signature gate (`SPEECH_STRICT_AUDIO_SIGNATURE`, on by default in prod), `referenceText` ≤ 500 chars, `language` must match BCP-47 tag regex, `sentenceId` ≤ 128 chars, content-length pre-gate |
+| `src/server/routes/practice.ts` | Generic 500 messages (no `err.message` leakage); `contentId` length cap on list endpoint |
+| `src/server/routes/migration.ts` | Array count caps (5k sessions / 50k sentence attempts / 50k word attempts) returning 413; generic 500 message |
+| `src/server/routes/flashcards.ts` | Generic 500 messages |
+| `src/server/middleware/pronunciationSecurity.ts` | CORS allowlist no longer merges localhost defaults in production; `APP_ORIGIN` implicitly trusted; pinned `Access-Control-Allow-Headers`; added `pronunciationDailyQuotaMiddleware` export |
+
+### 5.3 Other
+
+| File | Change |
+|---|---|
+| `.env.example` | Documents new knobs (`GLOBAL_API_*`, `AUTH_LOGIN_*`, `AUTH_REGISTER_*`, `SPEECH_DAILY_QUOTA`, `SPEECH_STRICT_AUDIO_SIGNATURE`, `DEV_LOGIN_TOKEN`, `JSON_BODY_LIMIT`, `MIGRATION_JSON_LIMIT`); adds explicit warnings about rotating secrets, production NODE_ENV requirement, and preferring Azure Key Vault/managed identities |
+| `package.json` / `package-lock.json` | `npm audit fix` brought vulnerability count 12 → 0 |
+
+---
+
+## 6. Residual risks
+
+| Area | Risk | Recommended next step |
+|---|---|---|
+| Single-instance rate limiter | The limiter and daily quota are in-memory. If you scale to multiple Railway replicas, each replica gets its own bucket — attacker gets *N×* the limit. | Back the store with Redis/Upstash when scaling beyond 1 replica. The middleware API already isolates this concern. |
+| Secret rotation | You confirmed the secrets in `.env` are already rotated. Going forward, production keys should live in Railway shared variables or Azure Key Vault, fetched at boot. | Migrate to Azure Key Vault + managed identity for AZURE_SPEECH_KEY when moving to Azure-hosted compute. Microsoft guidance is explicit on this. |
+| External bot abuse | App-level rate limits still burn bandwidth on Railway when attackers rotate IPs at scale. | Put Cloudflare in front of Railway for edge WAF + bot detection. Free tier is sufficient. |
+| HSTS preload | `preload: false` — flip when ready to submit to hstspreload.org (irreversible). | After 2+ weeks of stable prod. |
+| Signed refresh tokens | JWT expires in 7 days but there's no revocation. If a token is stolen, it's valid for 7 days. | Shorter expiry + refresh-token rotation if you ever store anything sensitive beyond practice history. |
+| SPEECH_DEBUG disk dumps | If enabled, writes full Azure payloads to `data/debug/`. Boot-time warning now fires in prod; disk retention is not managed. | Add a cron or size-based cleanup, or move dumps to a TTL'd object store. Low priority unless debugging an incident. |
+| Multi-replica invite-code race | `usedCount` is updated with `$inc` which is atomic, but the `maxUses` check is read-then-write. On a 1-replica deploy this is fine; in a race, one extra registration could slip through. | Wrap in a Mongo transaction or `findOneAndUpdate` with conditional update. |
+| Audio file content | We validate container format but not semantic content. Someone could upload a legit-format but semantically hostile audio. | Acceptable — Azure is the ultimate validator. |
+| OAuth callback open-redirect | The callback redirects to `APP_ORIGIN` which comes from env. If env is wrong, redirect is wrong, but not attacker-controllable at request time. | Consider pinning allowed redirect hosts in code rather than env. |
+| DB-backed session revocation | No way to invalidate a live JWT without rotating `JWT_SECRET` (which logs everyone out). | Add a `tokenVersion` field on `User` and include it in the JWT if revocation becomes a need. |
+
+---
+
+## 7. Deployment / security checklist
+
+Run through this before any public-facing deploy:
+
+- [ ] `NODE_ENV=production` is set in the deployment environment
+- [ ] `JWT_SECRET` is ≥32 chars and unique per environment (generate: `openssl rand -hex 32`)
+- [ ] `AZURE_SPEECH_KEY` is a fresh key; the previous key has been rotated in the Azure portal
+- [ ] `MONGODB_URI` uses a dedicated DB user with minimum necessary privileges (readWrite on the app's DB only)
+- [ ] `REQUIRE_INVITE_CODE=true` and at least one invite code has been seeded (`npm run invite:seed -- --code=... --maxUses=...`)
+- [ ] `ENABLE_DEV_LOGIN` is unset (or explicitly `false`) — if set to `true`, the app refuses to boot, but make it unambiguous
+- [ ] `APP_ORIGIN` points at the canonical HTTPS URL (used for OAuth redirect and implicit CORS trust)
+- [ ] `APP_ORIGINS` / `CORS_ALLOWED_ORIGINS` lists every browser origin explicitly (the localhost dev defaults are dropped in production)
+- [ ] Azure Speech has a billing cap configured on the subscription as defense-in-depth
+- [ ] Azure Speech region matches `AZURE_SPEECH_REGION`
+- [ ] Railway (or hosting provider) has `restartPolicyType=ON_FAILURE` and a health-check path of `/api/health`
+- [ ] `SPEECH_DEBUG` is unset in production
+- [ ] `npm audit` returns 0 vulnerabilities
+- [ ] `npm run build` completes and the secret scan on `dist/` comes up empty
+- [ ] Put Cloudflare (or equivalent) in front of the app for edge bot detection before public launch
+- [ ] Rotate `JWT_SECRET` if you ever suspect a leak — note this invalidates all sessions
+- [ ] Monitor `[RateLimit] blocked`, `[DailyQuota] blocked`, `[Auth] invite code rejected` in Railway logs
+
+---
+
+## 8. Recommended next steps (beyond this PR)
+
+Short list, ranked:
+
+1. **Put Cloudflare in front of Railway.** Free plan catches most automated abuse before it reaches the Express layer. The work is DNS + `trust proxy` tuning and takes under an hour.
+2. **Move secrets to Azure Key Vault + managed identity** when you migrate from Railway to any Azure-hosted compute. This is what Microsoft recommends over long-lived shared keys.
+3. **Back the rate limiter with Redis** before scaling past 1 replica. The middleware API makes this a one-file swap.
+4. **Add an admin-only `/api/invite-codes` endpoint** so you can seed/rotate invite codes without SSHing into Railway.
+5. **Implement session revocation** via a `tokenVersion` claim if you store anything more sensitive than practice history.
+6. **Add end-to-end abuse tests in Playwright** — hit each rate limit, verify 429s; that way regressions are caught in CI.
+7. **Consider moving audio blobs to signed URLs** if you ever store raw recordings — right now `recordingDataUrl` could be a base64 blob inline in Mongo, which is fine for a single user but expensive at scale.
+
+---
+
+## 9. Compact findings table
+
+| ID | Severity | Area | Finding | Fix Implemented | Residual Risk |
+|---|---|---|---|---|---|
+| C-1 | Critical | Auth | No rate limit on `/auth/*` | Per-IP + per-email limiters on `/login`, per-IP on `/register`, `/dev-login`, `/providers` | In-memory; multi-replica needs Redis |
+| C-2 | Critical | Cost | No daily quota on Azure calls | `SPEECH_DAILY_QUOTA` (default 200) layered on top of burst limiter | Same in-memory caveat |
+| C-3 | Critical | DoS | Uncapped JSON body | `JSON_BODY_LIMIT=128kb` / `MIGRATION_JSON_LIMIT=2mb` | None |
+| C-4 | Critical | OAuth | JWT in URL query | HttpOnly cookie handoff via `/api/auth/oauth/handoff` | None |
+| C-5 | Critical | Env safety | Dev-login bypass on env flip | Refuse to boot in prod + shared-token header option | Rely on correct `NODE_ENV` |
+| H-1 | High | Deps | 12 npm audit findings | `npm audit fix` — 0 remaining | Ongoing — rerun audit on each deploy |
+| H-2 | High | Auth | Weak password / bcrypt cost | Min 8 chars, bcrypt cost 12 | Users set their own passwords — still need strength feedback |
+| H-3 | High | Upload | MIME-only trust | Content-length pre-gate + MIME allowlist + magic-byte check (prod default) | Semantic audio content not inspected |
+| H-4 | High | Enum | Invite-code messages distinguished cases | Unified failure + constant-time compare | Timing of DB lookup still exists but is much weaker |
+| H-5 | High | Timing | User-enumeration via login timing | Dummy-hash bcrypt on miss | None |
+| H-6 | High | JWT | No secret length check | ≥32 chars enforced in prod | None |
+| H-7 | High | Text | No referenceText cap | 500-char cap | None |
+| H-8 | High | Migration | Unbounded array counts | 5k/50k/50k caps returning 413 | None |
+| M-1 | Medium | Errors | `err.message` leaked to clients | Generic 500 messages; server-side log retains detail | None |
+| M-2 | Medium | CORS | Dev defaults in prod allowlist | Dev defaults skipped when `NODE_ENV=production` | None |
+| M-3 | Medium | CORS | Reflected request-headers | Pinned allowlist | None |
+| M-4 | Medium | Headers | Helmet defaults loose | `frameAncestors: 'none'`, `objectSrc: 'none'`, HSTS 2y, `baseUri: 'self'`, `formAction: 'self'` | None |
+| M-5 | Medium | Dev login | Env-flag-only gate | Boot refusal + shared-token header | None |
+| M-6 | Medium | Fingerprint | `X-Powered-By` leaked | `app.disable('x-powered-by')` | None |
+| M-7 | Medium | Rate | No baseline API limit | `GLOBAL_API_MAX=120` per-IP | None |
+| M-8 | Medium | Input | Unbounded `contentId` query | 128-char cap | None |
+| L-1 | Low | Timing | Invite-code `===` | Constant-time compare | None |
+| L-2 | Low | Disk | `SPEECH_DEBUG` dumps | Boot-time warning in prod; docs call it out | Manual cleanup still needed |
+| L-3 | Low | Logs | Missing request-id correlation | Deferred | Minor ops inconvenience |
+| L-4 | Low | Health | Mongo host/name in health body | Accepted | None |
+
+---
+
+## 10. Verification performed
+
+- `npx tsc --noEmit` — clean
+- `npx vitest run` — **117 pre-existing + 6 new = 123 tests passing**, 0 failing
+- `npm run build` — bundle compiles (5 chunks, 118 kB gzipped JS)
+- `grep -rE "AZURE_SPEECH_KEY|JWT_SECRET|MONGODB_URI|GITHUB_CLIENT_SECRET|LINKEDIN_CLIENT_SECRET|GEMINI_API_KEY" dist/` — **no matches** (no server secrets in client bundle)
+- `npm audit` — **0 vulnerabilities**
+- Manual review of all `/api/*` routes for authentication + authorization + input validation + error-leak posture
+
+Targeted attack simulations performed against the running test suite:
+
+- Synthetic "bad bytes" with `audio/webm` MIME → accepted in non-prod (test fallback path), rejected in prod mode
+- Missing audio buffer → 400
+- Content-Length twice the max → 413 before body buffering
+- Rate-limiter hammering → 429 with `Retry-After` header
+- Daily-quota hammering → 429 with `X-Quota-*` headers
+- Cross-user session fetch → 404 (ownership check preserved)

--- a/package-lock.json
+++ b/package-lock.json
@@ -168,6 +168,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -517,6 +518,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -560,6 +562,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1152,9 +1155,9 @@
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.53.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.53.2.tgz",
-      "integrity": "sha512-yDPzwsgiFO26RJA4nZo8I+xqzh7sJTZIWQOxn+/XOdPE31lAvLIYCKqjV+lNH/vxE2L2iH3plKxDCRK6i+CwhA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
+      "integrity": "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==",
       "cpu": [
         "arm"
       ],
@@ -1166,9 +1169,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.53.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.53.2.tgz",
-      "integrity": "sha512-k8FontTxIE7b0/OGKeSN5B6j25EuppBcWM33Z19JoVT7UTXFSo3D9CdU39wGTeb29NO3XxpMNauh09B+Ibw+9g==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz",
+      "integrity": "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==",
       "cpu": [
         "arm64"
       ],
@@ -1180,9 +1183,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.53.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.53.2.tgz",
-      "integrity": "sha512-A6s4gJpomNBtJ2yioj8bflM2oogDwzUiMl2yNJ2v9E7++sHrSrsQ29fOfn5DM/iCzpWcebNYEdXpaK4tr2RhfQ==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz",
+      "integrity": "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==",
       "cpu": [
         "arm64"
       ],
@@ -1194,9 +1197,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.53.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.53.2.tgz",
-      "integrity": "sha512-e6XqVmXlHrBlG56obu9gDRPW3O3hLxpwHpLsBJvuI8qqnsrtSZ9ERoWUXtPOkY8c78WghyPHZdmPhHLWNdAGEw==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
+      "integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
       "cpu": [
         "x64"
       ],
@@ -1208,9 +1211,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.53.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.53.2.tgz",
-      "integrity": "sha512-v0E9lJW8VsrwPux5Qe5CwmH/CF/2mQs6xU1MF3nmUxmZUCHazCjLgYvToOk+YuuUqLQBio1qkkREhxhc656ViA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz",
+      "integrity": "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==",
       "cpu": [
         "arm64"
       ],
@@ -1222,9 +1225,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.53.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.53.2.tgz",
-      "integrity": "sha512-ClAmAPx3ZCHtp6ysl4XEhWU69GUB1D+s7G9YjHGhIGCSrsg00nEGRRZHmINYxkdoJehde8VIsDC5t9C0gb6yqA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz",
+      "integrity": "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==",
       "cpu": [
         "x64"
       ],
@@ -1236,9 +1239,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.53.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.53.2.tgz",
-      "integrity": "sha512-EPlb95nUsz6Dd9Qy13fI5kUPXNSljaG9FiJ4YUGU1O/Q77i5DYFW5KR8g1OzTcdZUqQQ1KdDqsTohdFVwCwjqg==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz",
+      "integrity": "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==",
       "cpu": [
         "arm"
       ],
@@ -1250,9 +1253,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.53.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.53.2.tgz",
-      "integrity": "sha512-BOmnVW+khAUX+YZvNfa0tGTEMVVEerOxN0pDk2E6N6DsEIa2Ctj48FOMfNDdrwinocKaC7YXUZ1pHlKpnkja/Q==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz",
+      "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
       "cpu": [
         "arm"
       ],
@@ -1264,9 +1267,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.53.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.53.2.tgz",
-      "integrity": "sha512-Xt2byDZ+6OVNuREgBXr4+CZDJtrVso5woFtpKdGPhpTPHcNG7D8YXeQzpNbFRxzTVqJf7kvPMCub/pcGUWgBjA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz",
+      "integrity": "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==",
       "cpu": [
         "arm64"
       ],
@@ -1278,9 +1281,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.53.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.53.2.tgz",
-      "integrity": "sha512-+LdZSldy/I9N8+klim/Y1HsKbJ3BbInHav5qE9Iy77dtHC/pibw1SR/fXlWyAk0ThnpRKoODwnAuSjqxFRDHUQ==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz",
+      "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
       "cpu": [
         "arm64"
       ],
@@ -1292,9 +1295,23 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.53.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.53.2.tgz",
-      "integrity": "sha512-8ms8sjmyc1jWJS6WdNSA23rEfdjWB30LH8Wqj0Cqvv7qSHnvw6kgMMXRdop6hkmGPlyYBdRPkjJnj3KCUHV/uQ==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
+      "integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz",
+      "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
       "cpu": [
         "loong64"
       ],
@@ -1306,9 +1323,23 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.53.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.53.2.tgz",
-      "integrity": "sha512-3HRQLUQbpBDMmzoxPJYd3W6vrVHOo2cVW8RUo87Xz0JPJcBLBr5kZ1pGcQAhdZgX9VV7NbGNipah1omKKe23/g==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz",
+      "integrity": "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
+      "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
       "cpu": [
         "ppc64"
       ],
@@ -1320,9 +1351,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.53.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.53.2.tgz",
-      "integrity": "sha512-fMjKi+ojnmIvhk34gZP94vjogXNNUKMEYs+EDaB/5TG/wUkoeua7p7VCHnE6T2Tx+iaghAqQX8teQzcvrYpaQA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz",
+      "integrity": "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==",
       "cpu": [
         "riscv64"
       ],
@@ -1334,9 +1365,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.53.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.53.2.tgz",
-      "integrity": "sha512-XuGFGU+VwUUV5kLvoAdi0Wz5Xbh2SrjIxCtZj6Wq8MDp4bflb/+ThZsVxokM7n0pcbkEr2h5/pzqzDYI7cCgLQ==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz",
+      "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
       "cpu": [
         "riscv64"
       ],
@@ -1348,9 +1379,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.53.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.53.2.tgz",
-      "integrity": "sha512-w6yjZF0P+NGzWR3AXWX9zc0DNEGdtvykB03uhonSHMRa+oWA6novflo2WaJr6JZakG2ucsyb+rvhrKac6NIy+w==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz",
+      "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
       "cpu": [
         "s390x"
       ],
@@ -1362,9 +1393,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.53.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.53.2.tgz",
-      "integrity": "sha512-yo8d6tdfdeBArzC7T/PnHd7OypfI9cbuZzPnzLJIyKYFhAQ8SvlkKtKBMbXDxe1h03Rcr7u++nFS7tqXz87Gtw==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
       "cpu": [
         "x64"
       ],
@@ -1376,9 +1407,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.53.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.53.2.tgz",
-      "integrity": "sha512-ah59c1YkCxKExPP8O9PwOvs+XRLKwh/mV+3YdKqQ5AMQ0r4M4ZDuOrpWkUaqO7fzAHdINzV9tEVu8vNw48z0lA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz",
+      "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
       "cpu": [
         "x64"
       ],
@@ -1389,10 +1420,24 @@
         "linux"
       ]
     },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz",
+      "integrity": "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.53.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.53.2.tgz",
-      "integrity": "sha512-4VEd19Wmhr+Zy7hbUsFZ6YXEiP48hE//KPLCSVNY5RMGX2/7HZ+QkN55a3atM1C/BZCGIgqN+xrVgtdak2S9+A==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz",
+      "integrity": "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==",
       "cpu": [
         "arm64"
       ],
@@ -1404,9 +1449,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.53.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.53.2.tgz",
-      "integrity": "sha512-IlbHFYc/pQCgew/d5fslcy1KEaYVCJ44G8pajugd8VoOEI8ODhtb/j8XMhLpwHCMB3yk2J07ctup10gpw2nyMA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz",
+      "integrity": "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==",
       "cpu": [
         "arm64"
       ],
@@ -1418,9 +1463,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.53.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.53.2.tgz",
-      "integrity": "sha512-lNlPEGgdUfSzdCWU176ku/dQRnA7W+Gp8d+cWv73jYrb8uT7HTVVxq62DUYxjbaByuf1Yk0RIIAbDzp+CnOTFg==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz",
+      "integrity": "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==",
       "cpu": [
         "ia32"
       ],
@@ -1432,9 +1477,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.53.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.53.2.tgz",
-      "integrity": "sha512-S6YojNVrHybQis2lYov1sd+uj7K0Q05NxHcGktuMMdIQ2VixGwAfbJ23NnlvvVV1bdpR2m5MsNBViHJKcA4ADw==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==",
       "cpu": [
         "x64"
       ],
@@ -1446,9 +1491,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.53.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.53.2.tgz",
-      "integrity": "sha512-k+/Rkcyx//P6fetPoLMb8pBeqJBNGx81uuf7iljX9++yNBVRDQgD04L+SVXmXmh5ZP4/WOp4mWF0kmi06PW2tA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz",
+      "integrity": "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==",
       "cpu": [
         "x64"
       ],
@@ -1561,8 +1606,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -1695,6 +1739,7 @@
       "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
       "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^5.0.0",
@@ -1771,6 +1816,7 @@
       "integrity": "sha512-keKxkZMqnDicuvFoJbzrhbtdLSPhj/rZThDlKWCDbgXmUg0rEUFtRssDXKYmtXluZlIqiC5VqkCgRwzuyLHKHw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -1781,6 +1827,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -1949,6 +1996,7 @@
       "integrity": "sha512-oWtNM89Np+YsQO3ttT5i1Aer/0xbzQzp66NzuJn/U16bB7MnvSzdLKXgk1kkMLYyKSSzA2ajzqMkYheaE9opuQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.0.10",
         "fflate": "^0.8.2",
@@ -2052,9 +2100,9 @@
       }
     },
     "node_modules/anymatch/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2241,9 +2289,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2283,6 +2331,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -2533,12 +2582,16 @@
       "license": "MIT"
     },
     "node_modules/cookie": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
-      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/cookie-parser": {
@@ -2738,8 +2791,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dotenv": {
       "version": "16.6.1",
@@ -3138,9 +3190,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -3612,6 +3664,7 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -3759,12 +3812,12 @@
       }
     },
     "node_modules/jws": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.3.tgz",
+      "integrity": "sha512-byiJ0FLRdLdSVSReO/U4E7RoEyOCKnEnEPMjq3HxWtvzLsV08/i5RQKsFVNkCldrCaPr2vDNAOMsfs8T/Hze7g==",
       "license": "MIT",
       "dependencies": {
-        "jwa": "^1.4.1",
+        "jwa": "^1.4.2",
         "safe-buffer": "^5.0.1"
       }
     },
@@ -3864,7 +3917,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -3947,9 +3999,9 @@
       }
     },
     "node_modules/micromatch/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4009,28 +4061,19 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/minipass": {
@@ -4041,18 +4084,6 @@
       "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
       }
     },
     "node_modules/mongodb": {
@@ -4204,21 +4235,22 @@
       "license": "MIT"
     },
     "node_modules/multer": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/multer/-/multer-2.0.2.tgz",
-      "integrity": "sha512-u7f2xaZ/UG8oLXHvtF/oWTRvT44p9ecwBBqTwgJVq0+4BW1g8OW01TyMEGWBHbyMOYVHXslaut7qEQ1meATXgw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.1.1.tgz",
+      "integrity": "sha512-mo+QTzKlx8R7E5ylSXxWzGoXoZbOsRMpyitcht8By2KHvMbf3tjwosZ/Mu/XYU6UuJ3VZnODIrak5ZrPiPyB6A==",
       "license": "MIT",
       "dependencies": {
         "append-field": "^1.0.0",
         "busboy": "^1.6.0",
         "concat-stream": "^2.0.0",
-        "mkdirp": "^0.5.6",
-        "object-assign": "^4.1.1",
-        "type-is": "^1.6.18",
-        "xtend": "^4.0.2"
+        "type-is": "^1.6.18"
       },
       "engines": {
         "node": ">= 10.16.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/multer/node_modules/media-typer": {
@@ -4479,9 +4511,9 @@
       "license": "ISC"
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -4503,11 +4535,12 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4602,6 +4635,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -4751,7 +4785,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -4767,7 +4800,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -4778,7 +4810,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -4818,9 +4849,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -4898,6 +4929,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4907,6 +4939,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
       "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -4919,8 +4952,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
@@ -4933,9 +4965,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.9.6",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.9.6.tgz",
-      "integrity": "sha512-Y1tUp8clYRXpfPITyuifmSoE2vncSME18uVLgaqyxh9H35JWpIfzHo+9y3Fzh5odk/jxPW29IgLgzcdwxGqyNA==",
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.14.1.tgz",
+      "integrity": "sha512-5BCvFskyAAVumqhEKh/iPhLOIkfxcEUz8WqFIARCkMg8hZZzDYX9CtwxXA0e+qT8zAxmMC0x3Ckb9iMONwc5jg==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -4955,12 +4987,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.9.6",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.9.6.tgz",
-      "integrity": "sha512-2MkC2XSXq6HjGcihnx1s0DBWQETI4mlis4Ux7YTLvP67xnGxCvq+BcCQSO81qQHVUTM1V53tl4iVVaY5sReCOA==",
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.14.1.tgz",
+      "integrity": "sha512-ZkrQuwwhGibjQLqH1eCdyiZyLWglPxzxdl5tgwgKEyCSGC76vmAjleGocRe3J/MLfzMUIKwaFJWpFVJhK3d2xA==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.9.6"
+        "react-router": "7.14.1"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -5008,9 +5040,9 @@
       }
     },
     "node_modules/readdirp/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5086,9 +5118,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.53.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.53.2.tgz",
-      "integrity": "sha512-MHngMYwGJVi6Fmnk6ISmnk7JAHRNF0UkuucA0CUW3N3a4KnONPEZz+vUanQP/ZC/iY1Qkf3bwPWzyY84wEks1g==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
+      "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5102,28 +5134,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.53.2",
-        "@rollup/rollup-android-arm64": "4.53.2",
-        "@rollup/rollup-darwin-arm64": "4.53.2",
-        "@rollup/rollup-darwin-x64": "4.53.2",
-        "@rollup/rollup-freebsd-arm64": "4.53.2",
-        "@rollup/rollup-freebsd-x64": "4.53.2",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.53.2",
-        "@rollup/rollup-linux-arm-musleabihf": "4.53.2",
-        "@rollup/rollup-linux-arm64-gnu": "4.53.2",
-        "@rollup/rollup-linux-arm64-musl": "4.53.2",
-        "@rollup/rollup-linux-loong64-gnu": "4.53.2",
-        "@rollup/rollup-linux-ppc64-gnu": "4.53.2",
-        "@rollup/rollup-linux-riscv64-gnu": "4.53.2",
-        "@rollup/rollup-linux-riscv64-musl": "4.53.2",
-        "@rollup/rollup-linux-s390x-gnu": "4.53.2",
-        "@rollup/rollup-linux-x64-gnu": "4.53.2",
-        "@rollup/rollup-linux-x64-musl": "4.53.2",
-        "@rollup/rollup-openharmony-arm64": "4.53.2",
-        "@rollup/rollup-win32-arm64-msvc": "4.53.2",
-        "@rollup/rollup-win32-ia32-msvc": "4.53.2",
-        "@rollup/rollup-win32-x64-gnu": "4.53.2",
-        "@rollup/rollup-win32-x64-msvc": "4.53.2",
+        "@rollup/rollup-android-arm-eabi": "4.60.1",
+        "@rollup/rollup-android-arm64": "4.60.1",
+        "@rollup/rollup-darwin-arm64": "4.60.1",
+        "@rollup/rollup-darwin-x64": "4.60.1",
+        "@rollup/rollup-freebsd-arm64": "4.60.1",
+        "@rollup/rollup-freebsd-x64": "4.60.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.1",
+        "@rollup/rollup-linux-arm64-musl": "4.60.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.1",
+        "@rollup/rollup-linux-loong64-musl": "4.60.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-musl": "4.60.1",
+        "@rollup/rollup-openbsd-x64": "4.60.1",
+        "@rollup/rollup-openharmony-arm64": "4.60.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.1",
+        "@rollup/rollup-win32-x64-gnu": "4.60.1",
+        "@rollup/rollup-win32-x64-msvc": "4.60.1",
         "fsevents": "~2.3.2"
       }
     },
@@ -5818,6 +5853,7 @@
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.6.tgz",
       "integrity": "sha512-ytQKuwgmrrkDTFP4LjR0ToE2nqgy886GpvRSpU0JAnrdBYppuY5rLkRUYPU1yCryb24SsKBTL/hlDQAEFVwtZg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.25.0",
         "get-tsconfig": "^4.7.5"
@@ -5941,13 +5977,14 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.2.2.tgz",
-      "integrity": "sha512-BxAKBWmIbrDgrokdGZH1IgkIk/5mMHDreLDmCJ0qpyJaAteP8NvMhkwr/ZCQNqNH97bw/dANTE9PDzqwJghfMQ==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "esbuild": "^0.25.0",
+        "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
         "picomatch": "^4.0.3",
         "postcss": "^8.5.6",
@@ -6015,12 +6052,497 @@
         }
       }
     },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
     "node_modules/vitest": {
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.10.tgz",
       "integrity": "sha512-2Fqty3MM9CDwOVet/jaQalYlbcjATZwPYGcqpiYQqgQ/dLC7GuHdISKgTYIVF/kaishKxLzleKWWfbSDklyIKg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.10",
         "@vitest/mocker": "4.0.10",
@@ -6327,15 +6849,6 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/xtend": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4"
-      }
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -15,8 +15,10 @@ import flashcardsRouter from './routes/flashcards';
 import {
   pronunciationCorsMiddleware,
   pronunciationRateLimitMiddleware,
+  pronunciationDailyQuotaMiddleware,
 } from './middleware/pronunciationSecurity';
 import { requireAuth } from './middleware/auth';
+import { createRateLimit, parsePositiveIntEnv } from './middleware/rateLimit';
 import {
   logInviteCodeReadiness,
   validateRequiredLaunchEnvVars,
@@ -32,7 +34,10 @@ const nonApiSpaRoutePattern = /^(?!\/api(?:\/|$)).*/;
 // Trust Railway's reverse proxy (required for correct req.ip, req.protocol)
 app.set('trust proxy', 1);
 
-// Middleware
+// Disable the X-Powered-By header (helmet also does this, belt-and-suspenders).
+app.disable('x-powered-by');
+
+// ──────────────── Security headers (Helmet) ────────────────
 app.use(
   helmet({
     contentSecurityPolicy: {
@@ -40,16 +45,48 @@ app.use(
         defaultSrc: ["'self'"],
         scriptSrc: ["'self'"],
         styleSrc: ["'self'", "'unsafe-inline'"],
-        imgSrc: ["'self'", "data:", "blob:"],
-        mediaSrc: ["'self'", "blob:"],
-        connectSrc: ["'self'", "blob:"],
-        workerSrc: ["'self'", "blob:"],
+        imgSrc: ["'self'", 'data:', 'blob:'],
+        mediaSrc: ["'self'", 'blob:'],
+        connectSrc: ["'self'", 'blob:'],
+        workerSrc: ["'self'", 'blob:'],
+        frameAncestors: ["'none'"],
+        objectSrc: ["'none'"],
+        baseUri: ["'self'"],
+        formAction: ["'self'"],
       },
+    },
+    crossOriginEmbedderPolicy: false, // MediaRecorder/WAV blobs need this off
+    referrerPolicy: { policy: 'strict-origin-when-cross-origin' },
+    strictTransportSecurity: {
+      maxAge: 63072000, // 2 years
+      includeSubDomains: true,
+      preload: false, // flip to true only if you intend to submit to the HSTS preload list
     },
   })
 );
 app.use(cookieParser());
-app.use(express.json());
+
+// ──────────────── Body size limits ────────────────
+//
+// Explicit limits prevent "JSON bomb" DoS. We keep defaults tight; the
+// migration endpoint gets a larger override configured at its own route.
+const GLOBAL_JSON_LIMIT = process.env.JSON_BODY_LIMIT || '128kb';
+const MIGRATION_JSON_LIMIT = process.env.MIGRATION_JSON_LIMIT || '2mb';
+app.use(express.json({ limit: GLOBAL_JSON_LIMIT }));
+app.use(express.urlencoded({ extended: false, limit: GLOBAL_JSON_LIMIT }));
+
+// ──────────────── Global per-IP rate limit ────────────────
+//
+// Baseline limit applied to every `/api/*` request. Route-specific limiters
+// still run on top. This exists so that routes that *aren't* individually
+// limited can't be spammed without bound.
+const globalApiLimit = createRateLimit({
+  name: 'api:global',
+  windowMs: parsePositiveIntEnv(process.env.GLOBAL_API_WINDOW_MS, 60 * 1000),
+  max: parsePositiveIntEnv(process.env.GLOBAL_API_MAX, 120),
+  message: 'Too many requests. Please slow down.',
+});
+app.use('/api', globalApiLimit);
 
 // Request logging (lightweight — method, path, status, duration)
 app.use((req, res, next) => {
@@ -61,18 +98,24 @@ app.use((req, res, next) => {
   next();
 });
 
-// Routes
+// ──────────────── Routes ────────────────
 app.use('/api/health', healthRouter);
 app.use('/api/auth', authRouter);
 app.use('/api/auth/oauth', oauthRouter);
 app.use('/api', practiceRouter);
-app.use('/api/migrate', migrationRouter);
+// Migration endpoint: auth enforced by route handlers; override JSON limit here.
+app.use(
+  '/api/migrate',
+  express.json({ limit: MIGRATION_JSON_LIMIT }),
+  migrationRouter
+);
 app.use('/api/flashcards', flashcardsRouter);
 app.use(
   '/api/pronunciation',
   pronunciationCorsMiddleware,
   requireAuth,
   pronunciationRateLimitMiddleware,
+  pronunciationDailyQuotaMiddleware,
   pronunciationRouter
 );
 app.use(
@@ -80,6 +123,7 @@ app.use(
   pronunciationCorsMiddleware,
   requireAuth,
   pronunciationRateLimitMiddleware,
+  pronunciationDailyQuotaMiddleware,
   legacyPronunciationAssessmentRouter
 );
 
@@ -116,11 +160,19 @@ if (existsSync(distPath)) {
   });
 }
 
-// Global error handler — catch middleware/route errors and return 500 instead of crashing
-app.use((err: Error, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
+// ──────────────── Global error handler ────────────────
+//
+// Never leak stack traces or raw error.message to the client. Log server-side,
+// return a generic message. Request ID can be correlated in logs.
+app.use((err: Error, req: express.Request, res: express.Response, _next: express.NextFunction) => {
+  const requestId = (req.header('x-request-id') || '').toString();
   console.error('[Server] Unhandled route error:', err.message, err.stack);
   if (!res.headersSent) {
-    res.status(500).json({ error: 'Internal server error' });
+    res.status(500).json({
+      error: 'Internal server error',
+      message: 'An unexpected error occurred.',
+      ...(requestId ? { requestId } : {}),
+    });
   }
 });
 
@@ -130,6 +182,23 @@ app.use((err: Error, _req: express.Request, res: express.Response, _next: expres
  */
 async function startServer(): Promise<void> {
   console.log(`[Server] Starting on port ${PORT} (HOST: 0.0.0.0)...`);
+
+  // Hard-stop on unsafe production configs. We refuse to boot with obvious
+  // foot-guns enabled.
+  if (process.env.NODE_ENV === 'production') {
+    if (process.env.ENABLE_DEV_LOGIN === 'true') {
+      console.error(
+        '[Server] ENABLE_DEV_LOGIN=true is not allowed in production. Aborting.'
+      );
+      process.exit(1);
+    }
+    if (process.env.SPEECH_DEBUG && /^(1|true|yes|on)$/i.test(process.env.SPEECH_DEBUG)) {
+      console.warn(
+        '[Server] SPEECH_DEBUG is enabled in production. This dumps full Azure payloads to disk — ' +
+        'disable unless actively investigating an incident.'
+      );
+    }
+  }
 
   // Start listening immediately so Railway health checks can reach the server
   // Explicitly bind to 0.0.0.0 — required for Railway's proxy to reach the app

--- a/src/server/middleware/dailyQuota.ts
+++ b/src/server/middleware/dailyQuota.ts
@@ -1,0 +1,111 @@
+/**
+ * Daily quota middleware — a second layer on top of the sliding-window rate
+ * limiter. Where the rate limiter caps burst traffic, the daily quota caps
+ * total backend spend per key per UTC day. This is the primary control that
+ * keeps the app from being abused as a free gateway to Azure even if an
+ * attacker paces their requests slowly.
+ *
+ * Tracks counts in an in-memory Map keyed by `${key}:${utcDay}`.
+ *
+ * NOTE: this resets on process restart. For a durable quota in production
+ * with multiple replicas, back this by Redis or persist to Mongo with an
+ * indexed `(key, day)` collection. For single-instance Railway, memory is
+ * acceptable — an attacker who can reliably trigger restarts is a separate
+ * problem.
+ */
+import type { NextFunction, Request, Response } from 'express';
+
+export interface DailyQuotaOptions {
+  name: string;
+  /** Max requests per key per UTC day. */
+  max: number;
+  /** Optional key function. Defaults to user id then IP. */
+  keyBy?: (req: Request) => string;
+  /** Skip unauthenticated requests? Default false. */
+  skipIfAnonymous?: boolean;
+  /** Human-facing message included in the 429 response. */
+  message?: string;
+}
+
+interface QuotaEntry {
+  count: number;
+  day: string;
+}
+
+const stores: Map<string, Map<string, QuotaEntry>> = new Map();
+
+function getStore(name: string): Map<string, QuotaEntry> {
+  let store = stores.get(name);
+  if (!store) {
+    store = new Map();
+    stores.set(name, store);
+  }
+  return store;
+}
+
+function currentUtcDay(): string {
+  const d = new Date();
+  return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}-${String(
+    d.getUTCDate()
+  ).padStart(2, '0')}`;
+}
+
+function defaultKeyBy(req: Request): string {
+  const user = (req as Request & { user?: { id?: string } }).user;
+  if (user?.id) return `u:${user.id}`;
+  const ip = req.ip || req.socket.remoteAddress || 'unknown';
+  return `ip:${ip}`;
+}
+
+export function createDailyQuota(opts: DailyQuotaOptions) {
+  const { name, max, keyBy = defaultKeyBy, skipIfAnonymous = false, message } = opts;
+  const store = getStore(name);
+
+  return function dailyQuotaMiddleware(req: Request, res: Response, next: NextFunction): void {
+    const user = (req as Request & { user?: unknown }).user;
+    if (skipIfAnonymous && !user) {
+      next();
+      return;
+    }
+
+    const key = keyBy(req);
+    const day = currentUtcDay();
+    const storeKey = `${key}:${day}`;
+    const entry = store.get(storeKey);
+
+    // Opportunistic cleanup: when creating a new entry, scrub entries from
+    // previous days belonging to the same key. This keeps the store bounded.
+    if (!entry) {
+      for (const existingKey of store.keys()) {
+        if (existingKey.startsWith(`${key}:`) && !existingKey.endsWith(`:${day}`)) {
+          store.delete(existingKey);
+        }
+      }
+      store.set(storeKey, { count: 1, day });
+      res.setHeader('X-Quota-Limit', String(max));
+      res.setHeader('X-Quota-Remaining', String(max - 1));
+      next();
+      return;
+    }
+
+    if (entry.count >= max) {
+      console.warn(
+        `[DailyQuota] blocked name=${name} key=${key} day=${day} max=${max} path=${req.path}`
+      );
+      res.setHeader('X-Quota-Limit', String(max));
+      res.setHeader('X-Quota-Remaining', '0');
+      res.status(429).json({
+        error: 'Daily quota exceeded',
+        message:
+          message ||
+          'You have reached the daily request limit. The quota resets at 00:00 UTC.',
+      });
+      return;
+    }
+
+    entry.count += 1;
+    res.setHeader('X-Quota-Limit', String(max));
+    res.setHeader('X-Quota-Remaining', String(Math.max(0, max - entry.count)));
+    next();
+  };
+}

--- a/src/server/middleware/pronunciationSecurity.ts
+++ b/src/server/middleware/pronunciationSecurity.ts
@@ -1,6 +1,8 @@
 import type { NextFunction, Request, Response } from 'express';
 import { ERROR_CLASS } from '../../lib/errorTaxonomy';
 import { speechLog } from '../utils/speechDebug';
+import { createDailyQuota } from './dailyQuota';
+import { parsePositiveIntEnv } from './rateLimit';
 
 const DEFAULT_ALLOWED_ORIGINS = [
   'http://localhost:3000',
@@ -12,6 +14,11 @@ const DEFAULT_ALLOWED_ORIGINS = [
 const DEFAULT_RATE_LIMIT_WINDOW_MS = 5 * 60 * 1000;
 const DEFAULT_RATE_LIMIT_MAX_REQUESTS = 20;
 
+// Daily quota ceiling — the big one. Caps how much Azure spend a single
+// principal (user or IP) can drive per UTC day, regardless of how they pace
+// their requests.
+const DEFAULT_DAILY_QUOTA = 200;
+
 type RateLimitEntry = {
   count: number;
   resetAt: number;
@@ -20,21 +27,8 @@ type RateLimitEntry = {
 const pronunciationRateLimitStore = new Map<string, RateLimitEntry>();
 let lastRateLimitCleanupAt = 0;
 
-function parsePositiveIntEnvValue(rawValue: string | undefined, fallback: number): number {
-  if (!rawValue) {
-    return fallback;
-  }
-
-  const parsed = Number.parseInt(rawValue, 10);
-  if (!Number.isFinite(parsed) || parsed <= 0) {
-    return fallback;
-  }
-
-  return parsed;
-}
-
 function readConfiguredOrigins(): Set<string> {
-  const allowlist = new Set(DEFAULT_ALLOWED_ORIGINS);
+  const allowlist = new Set<string>();
   const rawAllowlist =
     process.env.SPEECH_CORS_ALLOWED_ORIGINS ||
     process.env.CORS_ALLOWED_ORIGINS ||
@@ -46,6 +40,17 @@ function readConfiguredOrigins(): Set<string> {
     .map((origin) => origin.trim())
     .filter(Boolean)
     .forEach((origin) => allowlist.add(origin));
+
+  // Only add the dev defaults when not in production, so prod can never
+  // accidentally accept requests from localhost origins.
+  if (process.env.NODE_ENV !== 'production') {
+    DEFAULT_ALLOWED_ORIGINS.forEach((o) => allowlist.add(o));
+  }
+
+  // APP_ORIGIN (used by OAuth) is implicitly trusted.
+  if (process.env.APP_ORIGIN) {
+    allowlist.add(process.env.APP_ORIGIN.trim());
+  }
 
   return allowlist;
 }
@@ -80,6 +85,9 @@ export function pronunciationCorsMiddleware(req: Request, res: Response, next: N
   const allowedOrigins = readConfiguredOrigins();
 
   // Allow requests with no Origin header (CLI/server-to-server/same-origin requests).
+  // Browsers always send Origin for cross-origin; absence typically means
+  // same-origin fetch, curl, or the Vite preview. This does not weaken CORS
+  // policy — it just skips setting CORS headers.
   if (!requestOrigin) {
     if (req.method === 'OPTIONS') {
       res.status(204).end();
@@ -89,8 +97,7 @@ export function pronunciationCorsMiddleware(req: Request, res: Response, next: N
     return;
   }
 
-  // Allow same-origin requests: when the app serves both frontend and API
-  // from the same host (e.g. Railway), the Origin will match the Host header.
+  // Same-origin: the browser sends Origin matching Host.
   const host = req.header('host');
   const isSameOrigin =
     host &&
@@ -109,12 +116,12 @@ export function pronunciationCorsMiddleware(req: Request, res: Response, next: N
     return;
   }
 
-  const requestedHeaders =
-    req.header('access-control-request-headers') || 'Content-Type, Authorization, X-Request-Id';
+  // Pin Access-Control-Allow-Headers to a known list — never reflect the
+  // browser's Access-Control-Request-Headers unconditionally.
   res.setHeader('Access-Control-Allow-Origin', requestOrigin);
   res.setHeader('Vary', 'Origin');
   res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
-  res.setHeader('Access-Control-Allow-Headers', requestedHeaders);
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization, X-Request-Id');
   res.setHeader('Access-Control-Max-Age', '600');
 
   if (req.method === 'OPTIONS') {
@@ -127,11 +134,11 @@ export function pronunciationCorsMiddleware(req: Request, res: Response, next: N
 
 export function pronunciationRateLimitMiddleware(req: Request, res: Response, next: NextFunction): void {
   const requestId = req.header('x-request-id') || 'unknown';
-  const windowMs = parsePositiveIntEnvValue(
+  const windowMs = parsePositiveIntEnv(
     process.env.SPEECH_RATE_LIMIT_WINDOW_MS,
     DEFAULT_RATE_LIMIT_WINDOW_MS
   );
-  const maxRequests = parsePositiveIntEnvValue(
+  const maxRequests = parsePositiveIntEnv(
     process.env.SPEECH_RATE_LIMIT_MAX_REQUESTS,
     DEFAULT_RATE_LIMIT_MAX_REQUESTS
   );
@@ -173,3 +180,15 @@ export function pronunciationRateLimitMiddleware(req: Request, res: Response, ne
   });
   next();
 }
+
+/**
+ * Daily quota gate. Runs AFTER requireAuth so it keys on user id. This is the
+ * cost ceiling that matters most: an attacker with unlimited IPs still can't
+ * drive unlimited Azure spend through any one account.
+ */
+export const pronunciationDailyQuotaMiddleware = createDailyQuota({
+  name: 'pronunciation:daily',
+  max: parsePositiveIntEnv(process.env.SPEECH_DAILY_QUOTA, DEFAULT_DAILY_QUOTA),
+  message:
+    'You have reached the daily pronunciation assessment limit. The quota resets at 00:00 UTC.',
+});

--- a/src/server/middleware/rateLimit.test.ts
+++ b/src/server/middleware/rateLimit.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Request, Response, NextFunction } from 'express';
+import { createRateLimit } from './rateLimit';
+import { createDailyQuota } from './dailyQuota';
+
+function mockReq(ip = '1.2.3.4', user?: { id: string }): Request {
+  return {
+    ip,
+    socket: { remoteAddress: ip },
+    user,
+    path: '/test',
+    method: 'POST',
+    body: {},
+  } as unknown as Request;
+}
+
+function mockRes(): Response & { statusCode: number; body?: unknown; headers: Record<string, string> } {
+  const headers: Record<string, string> = {};
+  const res = {
+    statusCode: 200,
+    headers,
+    setHeader(name: string, value: string) {
+      headers[name.toLowerCase()] = value;
+      return res;
+    },
+    status(code: number) {
+      res.statusCode = code;
+      return res;
+    },
+    json(body: unknown) {
+      res.body = body;
+      return res;
+    },
+  } as unknown as Response & { statusCode: number; body?: unknown; headers: Record<string, string> };
+  return res;
+}
+
+describe('createRateLimit', () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('allows requests under the limit and blocks once exceeded', () => {
+    const limiter = createRateLimit({ name: 'test:underover', windowMs: 60_000, max: 3 });
+    const next = vi.fn() as unknown as NextFunction;
+
+    for (let i = 0; i < 3; i++) {
+      const res = mockRes();
+      limiter(mockReq('9.9.9.9'), res, next);
+    }
+    expect((next as unknown as { mock: { calls: unknown[] } }).mock.calls).toHaveLength(3);
+
+    const blockedRes = mockRes();
+    const blockedNext = vi.fn() as unknown as NextFunction;
+    limiter(mockReq('9.9.9.9'), blockedRes, blockedNext);
+    expect(blockedRes.statusCode).toBe(429);
+    expect(blockedRes.headers['retry-after']).toBeDefined();
+    expect(blockedNext).not.toHaveBeenCalled();
+  });
+
+  it('separates buckets by IP', () => {
+    const limiter = createRateLimit({ name: 'test:perip', windowMs: 60_000, max: 1 });
+    const next = vi.fn() as unknown as NextFunction;
+
+    const res1 = mockRes();
+    limiter(mockReq('1.1.1.1'), res1, next);
+    const res2 = mockRes();
+    limiter(mockReq('2.2.2.2'), res2, next);
+
+    expect(res1.statusCode).toBe(200);
+    expect(res2.statusCode).toBe(200);
+    expect((next as unknown as { mock: { calls: unknown[] } }).mock.calls).toHaveLength(2);
+  });
+
+  it('keys on authenticated user id when available', () => {
+    const limiter = createRateLimit({ name: 'test:user', windowMs: 60_000, max: 1 });
+    const next = vi.fn() as unknown as NextFunction;
+
+    // Different IPs, same user — should count as one bucket.
+    const res1 = mockRes();
+    limiter(mockReq('1.1.1.1', { id: 'user-x' }), res1, next);
+    const res2 = mockRes();
+    limiter(mockReq('2.2.2.2', { id: 'user-x' }), res2, next);
+
+    expect(res1.statusCode).toBe(200);
+    expect(res2.statusCode).toBe(429);
+  });
+});
+
+describe('createDailyQuota', () => {
+  it('enforces per-user daily max and exposes quota headers', () => {
+    const quota = createDailyQuota({ name: 'test:daily', max: 2 });
+    const next = vi.fn() as unknown as NextFunction;
+
+    const r1 = mockRes();
+    quota(mockReq('1.1.1.1', { id: 'u1' }), r1, next);
+    expect(r1.statusCode).toBe(200);
+    expect(r1.headers['x-quota-limit']).toBe('2');
+    expect(r1.headers['x-quota-remaining']).toBe('1');
+
+    const r2 = mockRes();
+    quota(mockReq('1.1.1.1', { id: 'u1' }), r2, next);
+    expect(r2.statusCode).toBe(200);
+    expect(r2.headers['x-quota-remaining']).toBe('0');
+
+    const r3 = mockRes();
+    const blockedNext = vi.fn() as unknown as NextFunction;
+    quota(mockReq('1.1.1.1', { id: 'u1' }), r3, blockedNext);
+    expect(r3.statusCode).toBe(429);
+    expect(blockedNext).not.toHaveBeenCalled();
+  });
+
+  it('keys different users separately', () => {
+    const quota = createDailyQuota({ name: 'test:daily-multi', max: 1 });
+    const next = vi.fn() as unknown as NextFunction;
+
+    const r1 = mockRes();
+    quota(mockReq('1.1.1.1', { id: 'alpha' }), r1, next);
+    const r2 = mockRes();
+    quota(mockReq('1.1.1.1', { id: 'beta' }), r2, next);
+
+    expect(r1.statusCode).toBe(200);
+    expect(r2.statusCode).toBe(200);
+  });
+
+  it('optionally skips anonymous traffic', () => {
+    const quota = createDailyQuota({ name: 'test:daily-skip', max: 1, skipIfAnonymous: true });
+    const next = vi.fn() as unknown as NextFunction;
+
+    const r1 = mockRes();
+    quota(mockReq('1.1.1.1'), r1, next);
+    const r2 = mockRes();
+    quota(mockReq('1.1.1.1'), r2, next);
+
+    expect(r1.statusCode).toBe(200);
+    expect(r2.statusCode).toBe(200); // anonymous passthrough
+  });
+});

--- a/src/server/middleware/rateLimit.ts
+++ b/src/server/middleware/rateLimit.ts
@@ -1,0 +1,116 @@
+/**
+ * Generic in-memory rate limiter for Express routes.
+ *
+ * Designed for single-instance deployments (Railway). If this app scales to
+ * multiple instances, swap the backing store for Redis/Upstash or rely on a
+ * platform-layer rate limiter (e.g., Cloudflare, Vercel Firewall).
+ *
+ * Layers supported:
+ *   - Per-IP (default): keys by req.ip
+ *   - Per-user: keys by req.user.id when authenticated
+ *   - Per-key (arbitrary): keyBy(req) => string
+ *
+ * Emits structured logs on block events for abuse monitoring.
+ */
+import type { NextFunction, Request, Response } from 'express';
+
+export interface RateLimitOptions {
+  /** Unique identifier used in logs and store namespacing. */
+  name: string;
+  /** Sliding window length in milliseconds. */
+  windowMs: number;
+  /** Maximum requests per window per key. */
+  max: number;
+  /** Optional custom key function. Defaults to IP. */
+  keyBy?: (req: Request) => string;
+  /** Optional hook called every time a request is blocked. */
+  onBlock?: (req: Request, key: string) => void;
+  /** Human-facing message included in the 429 response. */
+  message?: string;
+}
+
+interface RateLimitEntry {
+  count: number;
+  resetAt: number;
+}
+
+const stores: Map<string, Map<string, RateLimitEntry>> = new Map();
+const cleanupWatermark: Map<string, number> = new Map();
+const CLEANUP_INTERVAL_MS = 60_000;
+
+function getStore(name: string): Map<string, RateLimitEntry> {
+  let store = stores.get(name);
+  if (!store) {
+    store = new Map();
+    stores.set(name, store);
+  }
+  return store;
+}
+
+function maybeCleanup(name: string, store: Map<string, RateLimitEntry>, now: number): void {
+  const last = cleanupWatermark.get(name) ?? 0;
+  if (now - last < CLEANUP_INTERVAL_MS) return;
+  cleanupWatermark.set(name, now);
+  for (const [key, entry] of store.entries()) {
+    if (entry.resetAt <= now) store.delete(key);
+  }
+}
+
+function defaultKeyBy(req: Request): string {
+  // Prefer authenticated user id if available
+  const user = (req as Request & { user?: { id?: string } }).user;
+  if (user?.id) return `u:${user.id}`;
+  const ip = req.ip || req.socket.remoteAddress || 'unknown';
+  return `ip:${ip}`;
+}
+
+export function createRateLimit(opts: RateLimitOptions) {
+  const { name, windowMs, max, keyBy = defaultKeyBy, onBlock, message } = opts;
+  const store = getStore(name);
+
+  return function rateLimitMiddleware(req: Request, res: Response, next: NextFunction): void {
+    const now = Date.now();
+    maybeCleanup(name, store, now);
+
+    const key = keyBy(req);
+    const entry = store.get(key);
+
+    if (!entry || entry.resetAt <= now) {
+      store.set(key, { count: 1, resetAt: now + windowMs });
+      res.setHeader('X-RateLimit-Limit', String(max));
+      res.setHeader('X-RateLimit-Remaining', String(max - 1));
+      next();
+      return;
+    }
+
+    if (entry.count >= max) {
+      const retryAfter = Math.max(1, Math.ceil((entry.resetAt - now) / 1000));
+      res.setHeader('Retry-After', String(retryAfter));
+      res.setHeader('X-RateLimit-Limit', String(max));
+      res.setHeader('X-RateLimit-Remaining', '0');
+      onBlock?.(req, key);
+      console.warn(
+        `[RateLimit] blocked name=${name} key=${key} path=${req.path} method=${req.method} retryAfter=${retryAfter}s`
+      );
+      res.status(429).json({
+        error: 'Too many requests',
+        message: message || 'You have reached the request limit. Please wait and try again.',
+      });
+      return;
+    }
+
+    entry.count += 1;
+    res.setHeader('X-RateLimit-Limit', String(max));
+    res.setHeader('X-RateLimit-Remaining', String(Math.max(0, max - entry.count)));
+    next();
+  };
+}
+
+/**
+ * Parse a positive int env var with fallback.
+ */
+export function parsePositiveIntEnv(raw: string | undefined, fallback: number): number {
+  if (!raw) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}

--- a/src/server/routes/auth.ts
+++ b/src/server/routes/auth.ts
@@ -4,6 +4,7 @@ import jwt from 'jsonwebtoken';
 import { UserModel } from '../models/UserModel';
 import { InviteCodeModel } from '../models/InviteCodeModel';
 import { mapUserDocToDto } from '../mappers/userMapper';
+import { createRateLimit, parsePositiveIntEnv } from '../middleware/rateLimit';
 
 const router = Router();
 
@@ -16,64 +17,138 @@ interface JWTPayload {
 }
 
 /**
- * Get JWT secret from environment
+ * Minimum enforced password length. Short passwords are one of the biggest
+ * abuse vectors — 8 chars is the NIST floor and what we require.
+ */
+const MIN_PASSWORD_LENGTH = 8;
+const MAX_PASSWORD_LENGTH = 128;
+const MAX_EMAIL_LENGTH = 254;
+const MAX_DISPLAY_NAME_LENGTH = 80;
+const MAX_INVITE_CODE_LENGTH = 64;
+
+/**
+ * bcrypt cost factor. Raised from 10 to 12 — ~4x stronger against offline
+ * attack, still well under 100ms on modern hardware.
+ */
+const BCRYPT_ROUNDS = 12;
+
+/**
+ * Get JWT secret from environment with a minimum-entropy check. We require
+ * >=32 characters to refuse obviously-weak secrets in production.
  */
 function getJWTSecret(): string {
   const secret = process.env.JWT_SECRET;
   if (!secret || typeof secret !== 'string' || secret.trim() === '') {
     throw new Error(
       'Missing required environment variable: JWT_SECRET\n' +
-      'Please set JWT_SECRET in your server environment.'
+      'Please set JWT_SECRET in your server environment. Generate with: openssl rand -hex 32'
+    );
+  }
+  if (secret.trim().length < 32 && process.env.NODE_ENV === 'production') {
+    throw new Error(
+      'JWT_SECRET must be at least 32 characters long in production. ' +
+      'Generate with: openssl rand -hex 32'
     );
   }
   return secret;
 }
 
-/**
- * Generate JWT token for user
- */
 function generateToken(userId: string, email: string): string {
   const secret = getJWTSecret();
-  const payload: JWTPayload = {
-    userId,
-    email,
-  };
-  
+  const payload: JWTPayload = { userId, email };
   return jwt.sign(payload, secret, {
     expiresIn: '7d', // 7 days
   });
 }
 
-/**
- * Validate email format (basic check)
- */
 function isValidEmail(email: string): boolean {
+  if (email.length > MAX_EMAIL_LENGTH) return false;
   const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
   return emailRegex.test(email);
 }
 
 /**
- * POST /api/auth/register
- *
- * Body: { email, password, displayName?, inviteCode? }
- * Returns: { token, user: { id, email, displayName } }
+ * Constant-time string comparison to avoid timing leaks on invite-code lookup.
  */
-router.post('/register', async (req: Request, res: Response) => {
-  try {
-    const { email, password, displayName, inviteCode } = req.body;
+function constantTimeEquals(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) {
+    diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return diff === 0;
+}
 
-    // Validate input
-    if (!email || typeof email !== 'string' || !isValidEmail(email)) {
+// ──────────────── Rate limits on auth endpoints ────────────────
+//
+// Auth is the classic target for brute-force, credential stuffing, and
+// invite-code enumeration. We apply both per-IP and per-email windows.
+// These limits are tight by design — legitimate humans never hit them.
+
+const loginIpLimit = createRateLimit({
+  name: 'auth:login:ip',
+  windowMs: parsePositiveIntEnv(process.env.AUTH_LOGIN_IP_WINDOW_MS, 15 * 60 * 1000),
+  max: parsePositiveIntEnv(process.env.AUTH_LOGIN_IP_MAX, 20),
+  message: 'Too many login attempts from this network. Try again later.',
+});
+
+const registerIpLimit = createRateLimit({
+  name: 'auth:register:ip',
+  windowMs: parsePositiveIntEnv(process.env.AUTH_REGISTER_IP_WINDOW_MS, 60 * 60 * 1000),
+  max: parsePositiveIntEnv(process.env.AUTH_REGISTER_IP_MAX, 10),
+  message: 'Too many sign-up attempts from this network. Try again later.',
+});
+
+const devLoginLimit = createRateLimit({
+  name: 'auth:dev-login:ip',
+  windowMs: 60 * 60 * 1000,
+  max: 30,
+});
+
+const providersLimit = createRateLimit({
+  name: 'auth:providers:ip',
+  windowMs: 60 * 1000,
+  max: 60,
+});
+
+/**
+ * POST /api/auth/register
+ */
+router.post('/register', registerIpLimit, async (req: Request, res: Response) => {
+  try {
+    const { email, password, displayName, inviteCode } = req.body ?? {};
+
+    if (
+      !email ||
+      typeof email !== 'string' ||
+      !isValidEmail(email) ||
+      email.length > MAX_EMAIL_LENGTH
+    ) {
       return res.status(400).json({
         error: 'Invalid email',
         message: 'Please provide a valid email address',
       });
     }
 
-    if (!password || typeof password !== 'string' || password.length < 6) {
+    if (
+      !password ||
+      typeof password !== 'string' ||
+      password.length < MIN_PASSWORD_LENGTH ||
+      password.length > MAX_PASSWORD_LENGTH
+    ) {
       return res.status(400).json({
         error: 'Invalid password',
-        message: 'Password must be at least 6 characters long',
+        message: `Password must be between ${MIN_PASSWORD_LENGTH} and ${MAX_PASSWORD_LENGTH} characters.`,
+      });
+    }
+
+    if (
+      displayName !== undefined &&
+      (typeof displayName !== 'string' || displayName.length > MAX_DISPLAY_NAME_LENGTH)
+    ) {
+      return res.status(400).json({
+        error: 'Invalid displayName',
+        message: `displayName must be a string up to ${MAX_DISPLAY_NAME_LENGTH} characters.`,
       });
     }
 
@@ -81,7 +156,12 @@ router.post('/register', async (req: Request, res: Response) => {
     const requireInvite = process.env.REQUIRE_INVITE_CODE !== 'false';
 
     if (requireInvite) {
-      if (!inviteCode || typeof inviteCode !== 'string' || inviteCode.trim() === '') {
+      if (
+        !inviteCode ||
+        typeof inviteCode !== 'string' ||
+        inviteCode.trim() === '' ||
+        inviteCode.length > MAX_INVITE_CODE_LENGTH
+      ) {
         return res.status(403).json({
           error: 'Invite code required',
           message: 'An invite code is required to register. Contact the app owner for access.',
@@ -91,25 +171,31 @@ router.post('/register', async (req: Request, res: Response) => {
       const normalizedCode = inviteCode.trim().toUpperCase();
       const invite = await InviteCodeModel.findOne({ code: normalizedCode });
 
-      if (!invite || !invite.isActive) {
+      // Unified failure message to reduce invite-code enumeration — an
+      // attacker can no longer distinguish between "does not exist",
+      // "expired", and "used" from the error text.
+      const inviteFailure = () => {
+        console.warn(
+          `[Auth] invite code rejected ip=${req.ip} codeLen=${normalizedCode.length}`
+        );
         return res.status(403).json({
           error: 'Invalid invite code',
-          message: 'This invite code is not valid.',
+          message: 'This invite code is not valid or has expired.',
         });
-      }
+      };
 
+      if (!invite || !invite.isActive) {
+        return inviteFailure();
+      }
+      // Constant-time compare to make timing enumeration harder.
+      if (!constantTimeEquals(invite.code, normalizedCode)) {
+        return inviteFailure();
+      }
       if (invite.expiresAt && invite.expiresAt < new Date()) {
-        return res.status(403).json({
-          error: 'Expired invite code',
-          message: 'This invite code has expired.',
-        });
+        return inviteFailure();
       }
-
       if (invite.usedCount >= invite.maxUses) {
-        return res.status(403).json({
-          error: 'Invite code used',
-          message: 'This invite code has reached its usage limit.',
-        });
+        return inviteFailure();
       }
     }
 
@@ -123,14 +209,13 @@ router.post('/register', async (req: Request, res: Response) => {
     }
 
     // Hash password
-    const saltRounds = 10;
-    const passwordHash = await bcrypt.hash(password, saltRounds);
+    const passwordHash = await bcrypt.hash(password, BCRYPT_ROUNDS);
 
     // Create user
     const userDoc = new UserModel({
       email: email.toLowerCase(),
       passwordHash,
-      displayName: displayName?.trim() || undefined,
+      displayName: typeof displayName === 'string' ? displayName.trim() || undefined : undefined,
     });
 
     await userDoc.save();
@@ -147,104 +232,95 @@ router.post('/register', async (req: Request, res: Response) => {
       );
     }
 
-    // Generate token
     const token = generateToken(userDoc._id.toString(), userDoc.email);
-
-    // Map to DTO
     const user = mapUserDocToDto(userDoc);
 
-    res.status(201).json({
-      token,
-      user,
-    });
+    res.status(201).json({ token, user });
   } catch (error) {
-    console.error('[Auth] Registration error:', error);
-    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+    console.error('[Auth] Registration error:', error instanceof Error ? error.message : error);
     res.status(500).json({
       error: 'Registration failed',
-      message: errorMessage,
+      message: 'An unexpected error occurred. Please try again.',
     });
   }
 });
 
 /**
- * POST /api/auth/login
- * 
- * Body: { email, password }
- * Returns: { token, user: { id, email, displayName } }
+ * Per-email login limit (on top of per-IP). Blunts credential-stuffing
+ * targeted at a single known account even across rotating IPs.
  */
-router.post('/login', async (req: Request, res: Response) => {
-  try {
-    const { email, password } = req.body;
+const loginEmailLimit = createRateLimit({
+  name: 'auth:login:email',
+  windowMs: parsePositiveIntEnv(process.env.AUTH_LOGIN_EMAIL_WINDOW_MS, 15 * 60 * 1000),
+  max: parsePositiveIntEnv(process.env.AUTH_LOGIN_EMAIL_MAX, 10),
+  keyBy: (req) => {
+    const email =
+      typeof req.body?.email === 'string' ? req.body.email.toLowerCase().slice(0, MAX_EMAIL_LENGTH) : '';
+    return `email:${email || 'unknown'}`;
+  },
+  message: 'Too many login attempts for this account. Try again later.',
+});
 
-    // Validate input
-    if (!email || typeof email !== 'string') {
+/**
+ * POST /api/auth/login
+ */
+router.post('/login', loginIpLimit, loginEmailLimit, async (req: Request, res: Response) => {
+  try {
+    const { email, password } = req.body ?? {};
+
+    if (!email || typeof email !== 'string' || email.length > MAX_EMAIL_LENGTH) {
       return res.status(400).json({
         error: 'Invalid email',
         message: 'Please provide an email address',
       });
     }
 
-    if (!password || typeof password !== 'string') {
+    if (
+      !password ||
+      typeof password !== 'string' ||
+      password.length === 0 ||
+      password.length > MAX_PASSWORD_LENGTH
+    ) {
       return res.status(400).json({
         error: 'Invalid password',
         message: 'Please provide a password',
       });
     }
 
-    // Find user by email
     const userDoc = await UserModel.findOne({ email: email.toLowerCase() });
-    if (!userDoc) {
-      // Don't reveal whether user exists or not (security best practice)
+
+    // Run bcrypt either way to equalize timing between "user exists" and
+    // "user does not exist". Without this, response time leaks user existence.
+    // The dummy hash corresponds to a password that will never match.
+    const dummyHash =
+      '$2b$12$CwTycUXWue0Thq9StjUM0uJ8gF2G2l2Sg4zV7yk1hN2v9eF1lQv5C';
+    const hashToCompare = userDoc?.passwordHash || dummyHash;
+    const isPasswordValid = await bcrypt.compare(password, hashToCompare);
+
+    if (!userDoc || !userDoc.passwordHash || !isPasswordValid) {
       return res.status(401).json({
         error: 'Invalid credentials',
         message: 'Invalid email or password',
       });
     }
 
-    // OAuth-only users cannot log in with email/password
-    if (!userDoc.passwordHash) {
-      return res.status(401).json({
-        error: 'OAuth account',
-        message: `This account uses ${userDoc.oauthProvider || 'social'} login. Please sign in with that provider.`,
-      });
-    }
-
-    // Compare password
-    const isPasswordValid = await bcrypt.compare(password, userDoc.passwordHash);
-    if (!isPasswordValid) {
-      return res.status(401).json({
-        error: 'Invalid credentials',
-        message: 'Invalid email or password',
-      });
-    }
-
-    // Generate token
     const token = generateToken(userDoc._id.toString(), userDoc.email);
-
-    // Map to DTO
     const user = mapUserDocToDto(userDoc);
 
-    res.json({
-      token,
-      user,
-    });
+    res.json({ token, user });
   } catch (error) {
-    console.error('[Auth] Login error:', error);
-    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+    console.error('[Auth] Login error:', error instanceof Error ? error.message : error);
     res.status(500).json({
       error: 'Login failed',
-      message: errorMessage,
+      message: 'An unexpected error occurred. Please try again.',
     });
   }
 });
 
 /**
  * GET /api/auth/providers
- *
- * Returns which auth providers are available (OAuth configured, dev login, etc.)
  */
-router.get('/providers', (_req: Request, res: Response) => {
+router.get('/providers', providersLimit, (_req: Request, res: Response) => {
   const providers: string[] = ['email'];
 
   if (process.env.GITHUB_CLIENT_ID && process.env.GITHUB_CLIENT_SECRET) {
@@ -253,7 +329,8 @@ router.get('/providers', (_req: Request, res: Response) => {
   if (process.env.LINKEDIN_CLIENT_ID && process.env.LINKEDIN_CLIENT_SECRET) {
     providers.push('linkedin');
   }
-  if (process.env.ENABLE_DEV_LOGIN === 'true') {
+  // Dev login is only advertised in non-production, even if the flag is set.
+  if (process.env.ENABLE_DEV_LOGIN === 'true' && process.env.NODE_ENV !== 'production') {
     providers.push('dev');
   }
 
@@ -263,12 +340,26 @@ router.get('/providers', (_req: Request, res: Response) => {
 /**
  * POST /api/auth/dev-login
  *
- * Quick-login for development/testing — creates or finds a dev user and returns a token.
- * Requires ENABLE_DEV_LOGIN=true to be explicitly set.
+ * Hard-gated:
+ *   1. NODE_ENV must NOT be "production".
+ *   2. ENABLE_DEV_LOGIN must be "true".
+ *   3. Requires a shared DEV_LOGIN_TOKEN header if set (adds friction so that
+ *      flipping the flag accidentally in prod is not an instant bypass).
  */
-router.post('/dev-login', async (_req: Request, res: Response) => {
+router.post('/dev-login', devLoginLimit, async (req: Request, res: Response) => {
+  if (process.env.NODE_ENV === 'production') {
+    return res.status(404).json({ error: 'Not found' });
+  }
   if (process.env.ENABLE_DEV_LOGIN !== 'true') {
     return res.status(404).json({ error: 'Not found' });
+  }
+
+  const requiredToken = process.env.DEV_LOGIN_TOKEN;
+  if (requiredToken) {
+    const provided = req.header('x-dev-login-token') || '';
+    if (provided.length !== requiredToken.length || !constantTimeEquals(provided, requiredToken)) {
+      return res.status(401).json({ error: 'Unauthorized' });
+    }
   }
 
   try {
@@ -279,7 +370,7 @@ router.post('/dev-login', async (_req: Request, res: Response) => {
       userDoc = await UserModel.create({
         email: devEmail,
         displayName: 'Dev User',
-        passwordHash: await bcrypt.hash('devdev', 10),
+        passwordHash: await bcrypt.hash('dev-local-no-prod', BCRYPT_ROUNDS),
       });
     }
 
@@ -288,7 +379,7 @@ router.post('/dev-login', async (_req: Request, res: Response) => {
 
     res.json({ token, user });
   } catch (error) {
-    console.error('[Auth] Dev login error:', error);
+    console.error('[Auth] Dev login error:', error instanceof Error ? error.message : error);
     res.status(500).json({ error: 'Dev login failed' });
   }
 });

--- a/src/server/routes/flashcards.ts
+++ b/src/server/routes/flashcards.ts
@@ -76,7 +76,7 @@ router.get('/due', requireAuth, async (req: AuthenticatedRequest, res: Response)
     res.json(dtos);
   } catch (error) {
     console.error('[Flashcards] Error fetching due cards:', error);
-    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+    const errorMessage = 'An unexpected error occurred.';
     res.status(500).json({
       error: 'Failed to fetch due flashcards',
       message: errorMessage,
@@ -173,7 +173,7 @@ router.post('/review', requireAuth, async (req: AuthenticatedRequest, res: Respo
     res.json(dto);
   } catch (error) {
     console.error('[Flashcards] Error reviewing card:', error);
-    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+    const errorMessage = 'An unexpected error occurred.';
     res.status(500).json({
       error: 'Failed to review flashcard',
       message: errorMessage,
@@ -240,7 +240,7 @@ router.post('/ensure', requireAuth, async (req: AuthenticatedRequest, res: Respo
     res.json(dto);
   } catch (error) {
     console.error('[Flashcards] Error ensuring flashcard:', error);
-    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+    const errorMessage = 'An unexpected error occurred.';
     res.status(500).json({
       error: 'Failed to ensure flashcard',
       message: errorMessage,

--- a/src/server/routes/migration.ts
+++ b/src/server/routes/migration.ts
@@ -230,6 +230,14 @@ function convertLegacyWordAttempt(
  * 
  * Returns: { importedSessions, importedAttempts, skippedSessions, skippedAttempts, errors }
  */
+// Bound the migration payload. A real user migrating their local history will
+// always be well below these numbers. Anything larger is either corrupt data
+// or abuse. Keep these conservative — the route writes once per user per
+// device, there is no legitimate reason to raise them without a case.
+const MAX_MIGRATION_SESSIONS = 5_000;
+const MAX_MIGRATION_SENTENCE_ATTEMPTS = 50_000;
+const MAX_MIGRATION_WORD_ATTEMPTS = 50_000;
+
 router.post('/local-storage', requireAuth, async (req: AuthenticatedRequest, res: Response) => {
   try {
     const userId = req.user!.id;
@@ -263,6 +271,20 @@ router.post('/local-storage', requireAuth, async (req: AuthenticatedRequest, res
       return res.status(400).json({
         error: 'Invalid payload',
         message: 'wordAttempts must be an array',
+      });
+    }
+
+    if (
+      payload.sessions.length > MAX_MIGRATION_SESSIONS ||
+      payload.sentenceAttempts.length > MAX_MIGRATION_SENTENCE_ATTEMPTS ||
+      payload.wordAttempts.length > MAX_MIGRATION_WORD_ATTEMPTS
+    ) {
+      console.warn(
+        `[Migration] Rejected oversized payload user=${userId} sessions=${payload.sessions.length} sentences=${payload.sentenceAttempts.length} words=${payload.wordAttempts.length}`
+      );
+      return res.status(413).json({
+        error: 'Payload too large',
+        message: 'Migration payload exceeds allowed item counts.',
       });
     }
 
@@ -372,11 +394,10 @@ router.post('/local-storage', requireAuth, async (req: AuthenticatedRequest, res
 
     res.json(result);
   } catch (error) {
-    console.error('[Migration] Migration error:', error);
-    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+    console.error('[Migration] Migration error:', error instanceof Error ? error.message : error);
     res.status(500).json({
       error: 'Migration failed',
-      message: errorMessage,
+      message: 'An unexpected error occurred during migration.',
     });
   }
 });

--- a/src/server/routes/oauth.ts
+++ b/src/server/routes/oauth.ts
@@ -168,7 +168,19 @@ router.get('/github/callback', async (req: Request, res: Response) => {
     }
 
     const token = generateToken(userDoc._id.toString(), userDoc.email);
-    res.redirect(`${appOrigin}/auth/callback?token=${encodeURIComponent(token)}`);
+    // Hand the token to the SPA via a short-lived HttpOnly cookie instead of
+    // embedding it in the redirect URL. Putting a JWT in a query string leaks
+    // it through Referer headers, server logs, and browser history. The SPA
+    // reads the cookie on /auth/callback via a single same-origin fetch that
+    // returns the token in the response body and then clears the cookie.
+    res.cookie('oauth_handoff', token, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+      maxAge: 2 * 60 * 1000, // 2 minutes — just enough for the SPA to pick it up
+      path: '/api/auth/oauth/handoff',
+    });
+    res.redirect(`${appOrigin}/auth/callback`);
   } catch (error) {
     console.error('[OAuth] GitHub callback error:', error);
     res.redirect(`${appOrigin}/auth?error=server_error`);
@@ -274,11 +286,38 @@ router.get('/linkedin/callback', async (req: Request, res: Response) => {
     }
 
     const token = generateToken(userDoc._id.toString(), userDoc.email);
-    res.redirect(`${appOrigin}/auth/callback?token=${encodeURIComponent(token)}`);
+    // Hand the token to the SPA via a short-lived HttpOnly cookie instead of
+    // embedding it in the redirect URL. Putting a JWT in a query string leaks
+    // it through Referer headers, server logs, and browser history. The SPA
+    // reads the cookie on /auth/callback via a single same-origin fetch that
+    // returns the token in the response body and then clears the cookie.
+    res.cookie('oauth_handoff', token, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+      maxAge: 2 * 60 * 1000, // 2 minutes — just enough for the SPA to pick it up
+      path: '/api/auth/oauth/handoff',
+    });
+    res.redirect(`${appOrigin}/auth/callback`);
   } catch (error) {
     console.error('[OAuth] LinkedIn callback error:', error);
     res.redirect(`${appOrigin}/auth?error=server_error`);
   }
+});
+
+// ──────────────── Token handoff ────────────────
+//
+// Single-use endpoint: the SPA fetches this on /auth/callback to retrieve the
+// token that OAuth deposited in an HttpOnly cookie, then the server clears
+// the cookie. This keeps the JWT out of URLs/Referer/history while still
+// letting client JS store it in localStorage for subsequent API calls.
+router.get('/handoff', (req: Request, res: Response) => {
+  const token = req.cookies?.oauth_handoff;
+  res.clearCookie('oauth_handoff', { path: '/api/auth/oauth/handoff' });
+  if (!token || typeof token !== 'string') {
+    return res.status(401).json({ error: 'No pending OAuth session' });
+  }
+  res.json({ token });
 });
 
 export default router;

--- a/src/server/routes/practice.ts
+++ b/src/server/routes/practice.ts
@@ -48,11 +48,10 @@ router.post('/practice-sessions', requireAuth, async (req: AuthenticatedRequest,
     const session = mapPracticeSessionDocToDto(sessionDoc);
     res.status(201).json(session);
   } catch (error) {
-    console.error('[Practice] Error creating session:', error);
-    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+    console.error('[Practice] Error creating session:', error instanceof Error ? error.message : error);
     res.status(500).json({
       error: 'Failed to create practice session',
-      message: errorMessage,
+      message: 'An unexpected error occurred.',
     });
   }
 });
@@ -104,11 +103,10 @@ router.patch(
       const session = mapPracticeSessionDocToDto(sessionDoc);
       res.json(session);
     } catch (error) {
-      console.error('[Practice] Error completing session:', error);
-      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+      console.error('[Practice] Error completing session:', error instanceof Error ? error.message : error);
       res.status(500).json({
         error: 'Failed to complete practice session',
-        message: errorMessage,
+        message: 'An unexpected error occurred.',
       });
     }
   }
@@ -255,11 +253,10 @@ router.post('/pronunciation-attempts', requireAuth, async (req: AuthenticatedReq
     const attempt = mapPronunciationAttemptDocToDto(attemptDoc);
     res.status(201).json(attempt);
   } catch (error) {
-    console.error('[Practice] Error creating attempt:', error);
-    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+    console.error('[Practice] Error creating attempt:', error instanceof Error ? error.message : error);
     res.status(500).json({
       error: 'Failed to create pronunciation attempt',
-      message: errorMessage,
+      message: 'An unexpected error occurred.',
     });
   }
 });
@@ -290,6 +287,9 @@ router.get('/pronunciation-attempts', requireAuth, async (req: AuthenticatedRequ
     };
 
     if (contentId) {
+      if (typeof contentId !== 'string' || contentId.length > 128) {
+        return res.status(400).json({ error: 'Invalid contentId' });
+      }
       query.contentId = contentId;
     }
 
@@ -312,11 +312,10 @@ router.get('/pronunciation-attempts', requireAuth, async (req: AuthenticatedRequ
       offset,
     });
   } catch (error) {
-    console.error('[Practice] Error fetching attempts:', error);
-    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+    console.error('[Practice] Error fetching attempts:', error instanceof Error ? error.message : error);
     res.status(500).json({
       error: 'Failed to fetch pronunciation attempts',
-      message: errorMessage,
+      message: 'An unexpected error occurred.',
     });
   }
 });

--- a/src/server/routes/pronunciationAssessment.ts
+++ b/src/server/routes/pronunciationAssessment.ts
@@ -813,6 +813,46 @@ const upload = multer({
 
 export const pronunciationUploadMiddleware = upload.single('audio');
 
+const ALLOWED_AUDIO_MIME_TYPES = new Set<string>([
+  'audio/wav',
+  'audio/wave',
+  'audio/x-wav',
+  'audio/webm',
+  'audio/ogg',
+  'audio/mpeg', // mp3
+  'audio/mp4',
+  'audio/x-m4a',
+  'audio/aac',
+  'application/octet-stream', // some browsers ship MediaRecorder blobs this way
+]);
+
+/**
+ * Magic-byte sniff. Prevents trivial "rename .exe to .wav" abuse and catches
+ * payloads where the MIME header lies. We accept a short list of real audio
+ * container signatures — anything else is rejected before we spawn ffmpeg or
+ * call Azure.
+ */
+function looksLikeAudioBuffer(buf: Buffer): boolean {
+  if (buf.length < 12) return false;
+  // RIFF....WAVE
+  if (buf.slice(0, 4).toString('ascii') === 'RIFF' && buf.slice(8, 12).toString('ascii') === 'WAVE') {
+    return true;
+  }
+  // WebM / Matroska: EBML header 0x1A 0x45 0xDF 0xA3
+  if (buf[0] === 0x1a && buf[1] === 0x45 && buf[2] === 0xdf && buf[3] === 0xa3) return true;
+  // Ogg
+  if (buf.slice(0, 4).toString('ascii') === 'OggS') return true;
+  // ID3 (mp3)
+  if (buf.slice(0, 3).toString('ascii') === 'ID3') return true;
+  // MP3 frame sync
+  if (buf[0] === 0xff && (buf[1] & 0xe0) === 0xe0) return true;
+  // ISO BMFF (mp4/m4a): "....ftyp"
+  if (buf.slice(4, 8).toString('ascii') === 'ftyp') return true;
+  // AAC ADTS sync: 0xFFF
+  if (buf[0] === 0xff && (buf[1] & 0xf0) === 0xf0) return true;
+  return false;
+}
+
 export async function handlePronunciationAssessmentExpress(req: ExpressRequest, res: ExpressResponse): Promise<void> {
   const requestId = (req.header('x-request-id') || randomUUID()).toString();
   const startedAt = Date.now();
@@ -820,6 +860,24 @@ export async function handlePronunciationAssessmentExpress(req: ExpressRequest, 
   const convertTimeoutMs = getAudioConvertTimeoutMs();
   let clientDisconnected = false;
   let killActiveConversion: (() => void) | null = null;
+
+  // Pre-gate on content-length: reject obviously-oversized uploads before
+  // multer buffers the whole thing into memory.
+  const declaredLengthHeader = req.header('content-length');
+  if (declaredLengthHeader) {
+    const declaredLength = Number.parseInt(declaredLengthHeader, 10);
+    if (Number.isFinite(declaredLength) && declaredLength > MAX_PRONUNCIATION_UPLOAD_BYTES * 2) {
+      speechLog('warn', 'Pronunciation upload rejected: content-length too large', {
+        requestId,
+        statusClass: '4xx',
+      });
+      res.setHeader('X-Request-Id', requestId);
+      res.status(413).json(
+        buildSafeErrorPayload(413, requestId, ERROR_CLASS.serverPayloadTooLarge)
+      );
+      return;
+    }
+  }
 
   const markClientDisconnected = (): void => {
     if (res.writableEnded) {
@@ -848,7 +906,13 @@ export async function handlePronunciationAssessmentExpress(req: ExpressRequest, 
     const referenceText = req.body.referenceText;
     const language = req.body.language;
 
-    if (!sentenceId || typeof sentenceId !== 'string') {
+    // Reject unknown/oversized text fields up front — these are echoed back to
+    // Azure in a header and in the URL, so they have a real cost if abused.
+    const MAX_SENTENCE_ID_LENGTH = 128;
+    const MAX_REFERENCE_TEXT_LENGTH = 500;
+    const MAX_LANGUAGE_LENGTH = 16;
+
+    if (!sentenceId || typeof sentenceId !== 'string' || sentenceId.length > MAX_SENTENCE_ID_LENGTH) {
       res.status(400).json({
         error: 'Missing or invalid sentenceId',
         message: 'sentenceId is required.',
@@ -858,20 +922,69 @@ export async function handlePronunciationAssessmentExpress(req: ExpressRequest, 
       return;
     }
 
-    if (!referenceText || typeof referenceText !== 'string') {
+    if (
+      !referenceText ||
+      typeof referenceText !== 'string' ||
+      referenceText.length > MAX_REFERENCE_TEXT_LENGTH
+    ) {
       res.status(400).json({
         error: 'Missing or invalid referenceText',
-        message: 'referenceText is required.',
+        message: 'referenceText is required and must be under 500 characters.',
         requestId,
         errorClass: ERROR_CLASS.serverUnknown,
       });
       return;
     }
 
-    if (!language || typeof language !== 'string') {
+    if (
+      !language ||
+      typeof language !== 'string' ||
+      language.length > MAX_LANGUAGE_LENGTH ||
+      !/^[a-zA-Z]{2,3}(-[a-zA-Z0-9]{2,8})?$/.test(language)
+    ) {
       res.status(400).json({
         error: 'Missing or invalid language',
-        message: 'language is required.',
+        message: 'language is required (BCP-47 tag, e.g. "pt-BR").',
+        requestId,
+        errorClass: ERROR_CLASS.serverUnknown,
+      });
+      return;
+    }
+
+    // MIME + magic-byte gate. Don't hand ffmpeg a file we can't verify as an
+    // audio container of a known type.
+    const uploadedMime = (req.file.mimetype || '').toLowerCase().split(';')[0].trim();
+    if (uploadedMime && !ALLOWED_AUDIO_MIME_TYPES.has(uploadedMime)) {
+      speechLog('warn', 'Pronunciation upload rejected: unsupported MIME type', {
+        requestId,
+        statusClass: '4xx',
+      });
+      res.setHeader('X-Request-Id', requestId);
+      res.status(415).json({
+        error: 'Unsupported audio type',
+        message: 'Audio upload must be a supported audio format.',
+        requestId,
+        errorClass: ERROR_CLASS.serverUnknown,
+      });
+      return;
+    }
+
+    // Strict magic-byte check. Default-on in production; opt-in in dev so
+    // unit tests can exercise the "synthesized bad bytes fall through to
+    // Azure fallback" codepath without hitting this gate.
+    const strictSignatureCheck =
+      process.env.SPEECH_STRICT_AUDIO_SIGNATURE === 'true' ||
+      (process.env.NODE_ENV === 'production' &&
+        process.env.SPEECH_STRICT_AUDIO_SIGNATURE !== 'false');
+    if (strictSignatureCheck && !looksLikeAudioBuffer(req.file.buffer)) {
+      speechLog('warn', 'Pronunciation upload rejected: bytes do not match known audio signature', {
+        requestId,
+        statusClass: '4xx',
+      });
+      res.setHeader('X-Request-Id', requestId);
+      res.status(415).json({
+        error: 'Unsupported audio type',
+        message: 'Uploaded file does not appear to be a valid audio recording.',
         requestId,
         errorClass: ERROR_CLASS.serverUnknown,
       });


### PR DESCRIPTION
## Summary

Full security audit of LusoPronunciation against OWASP ASVS 5.0, plus remediation for everything found. The goal was to make the app safe enough for public recruiter/demo access — specifically to prevent it from being abused as a free gateway to Azure Speech, resist credential stuffing / invite-code enumeration, and ship safe deployment defaults.

Full threat model, findings table, and deployment checklist live in [`SECURITY_AUDIT_AND_HARDENING.md`](SECURITY_AUDIT_AND_HARDENING.md).

## What changed

### Critical

- **Rate-limit `/api/auth/*`** — per-IP + per-email on `/login`, per-IP on `/register` / `/dev-login` / `/providers`. Blunts credential stuffing and invite-code enumeration.
- **Daily Azure-cost quota** — new `SPEECH_DAILY_QUOTA` (default 200/day/user, resets 00:00 UTC) stacked on top of the existing 20/5-min burst limiter. Caps worst-case Azure spend per account regardless of request pacing.
- **JSON body limits** — `JSON_BODY_LIMIT=128kb` globally, `MIGRATION_JSON_LIMIT=2mb` carve-out on `/api/migrate`; array-count caps (5k/50k/50k) on migration payload.
- **OAuth JWT out of URL** — redirects no longer embed the token in a query string. It's handed off via an `HttpOnly` cookie and exchanged via a new single-use `GET /api/auth/oauth/handoff` endpoint.
- **Prod boot guards** — refuses to start with `NODE_ENV=production` + `ENABLE_DEV_LOGIN=true`; enforces `JWT_SECRET` ≥ 32 chars in prod.

### High

- `npm audit fix`: **12 vulnerabilities → 0** (multer DoS, vite path traversal, path-to-regexp ReDoS, qs DoS, jws signature, jsonwebtoken).
- Password policy: min 6 → 8 chars, bcrypt cost 10 → 12.
- Audio uploads: MIME allowlist + magic-byte signature check (RIFF/WebM/Ogg/MP3/MP4/AAC) + `Content-Length` pre-gate before multer buffers.
- Unified invite-code failure message + constant-time compare — no more "unknown" vs "expired" vs "used" distinction.
- Dummy-hash bcrypt on login miss — kills user-enumeration via response timing.
- Input length caps: `referenceText` 500, `sentenceId` 128, `contentId` 128, email 254, displayName 80, inviteCode 64; `language` validated as BCP-47.

### Medium

- Generic `message: 'An unexpected error occurred.'` everywhere the client sees a 500 — server-side logs retain full detail.
- CORS: dev-localhost defaults dropped in production; pinned `Access-Control-Allow-Headers` (no more reflection).
- Helmet: added `frameAncestors 'none'`, `objectSrc 'none'`, `baseUri 'self'`, `formAction 'self'`, HSTS 2y; disabled `X-Powered-By`.
- Baseline global `/api` rate limit (120/min per IP).
- Optional `DEV_LOGIN_TOKEN` shared-header secret on `/dev-login`.

## New infrastructure

- `src/server/middleware/rateLimit.ts` — generic reusable per-IP / per-user / per-key limiter with structured warn logs and `X-RateLimit-*` headers.
- `src/server/middleware/dailyQuota.ts` — UTC-day ceiling, exposed as `X-Quota-*` headers.
- `src/server/middleware/rateLimit.test.ts` — 6 tests covering bucket separation, block emission, user-id keying, anonymous skip.

## Verification

- `npx tsc --noEmit` — clean
- `npx vitest run` — **123 / 123 tests pass** (117 pre-existing + 6 new)
- `npm run build` — bundle compiles; grep for `AZURE_SPEECH_KEY | JWT_SECRET | MONGODB_URI | *_CLIENT_SECRET | GEMINI_API_KEY` on `dist/` returns zero matches
- `npm audit` — 0 vulnerabilities

## Test plan

- [ ] Pull this branch, set `.env` with `NODE_ENV=production` and try to start with `ENABLE_DEV_LOGIN=true` — server should refuse to boot
- [ ] Try logging in with a nonexistent email — response time should be close to the time for a real user (approx. bcrypt cost, no fast-path leak)
- [ ] POST `/api/auth/login` 25 times in a row from one IP — 429 after the configured cap
- [ ] POST `/api/auth/register` with a bogus invite code 12 times from one IP — 429 after the register cap
- [ ] Upload a non-audio file to `/api/pronunciation/assessment` in prod mode (or set `SPEECH_STRICT_AUDIO_SIGNATURE=true`) — 415
- [ ] POST an oversized JSON body to `/api/migrate/local-storage` — 413
- [ ] Complete GitHub OAuth flow — `/auth/callback` should load with no token in the URL; calling `/api/auth/oauth/handoff` once returns the JWT, a second call returns 401

## Reviewer notes

- The rate limiter and daily quota are **in-memory** — single Railway replica only. Swap to Redis before scaling out. Documented in `SECURITY_AUDIT_AND_HARDENING.md` §6.
- `SPEECH_STRICT_AUDIO_SIGNATURE` defaults to on in prod, off otherwise, so existing fallback-path tests that use synthetic bytes continue to run.
- Several existing tests already cover pronunciation-route behavior; they all pass unmodified.
- `.env.example` now documents every new knob with safe-default guidance and an up-front security-notes block.

## Required manual setup (post-merge)

- Set `NODE_ENV=production` in Railway shared variables
- Generate a strong `JWT_SECRET` (`openssl rand -hex 32`) and set it in Railway env
- Set `APP_ORIGINS` / `APP_ORIGIN` to the canonical HTTPS URL(s)
- Seed at least one invite code: `npm run invite:seed -- --code=YOUR-CODE --maxUses=N`
- Confirm Azure Speech key rotation in the Azure portal
- Put Cloudflare (free tier) in front of Railway before public launch

🤖 Generated with [Claude Code](https://claude.com/claude-code)
