### PR TITLE
feat(launch): address release-readiness gaps for LinkedIn launch

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,6 +64,12 @@ PORT=4000
 # CORS_ALLOWED_ORIGINS=https://your-app.up.railway.app,https://yourdomain.com
 # SPEECH_CORS_ALLOWED_ORIGINS=https://your-app.up.railway.app,https://yourdomain.com
 
+# ──────────────── Content Security Policy ────────────────
+# Extra origins appended to the Helmet CSP `connect-src` directive. Only needed
+# when the frontend and backend live on different origins (e.g. SPA on Vercel,
+# API on Railway). Same-origin deploys can leave this unset.
+# CSP_CONNECT_SRC=https://api.your-backend.example.com
+
 # ──────────────── Global API rate limit (per-IP) ────────────────
 # Baseline cap across every /api/* request. Tighten these if you see abuse.
 # GLOBAL_API_WINDOW_MS=60000
@@ -90,6 +96,14 @@ PORT=4000
 # signature. Defaults to "on" in production, "off" otherwise.
 # SPEECH_STRICT_AUDIO_SIGNATURE=true
 
+# ──────────────── Launch-safe limits (recommended for public/demo launch) ────────────────
+# Tighter caps for the first weeks post-launch while invite codes are active.
+# Copy these into your deployment env and relax them once traffic patterns
+# are understood.
+# GLOBAL_API_MAX=80
+# SPEECH_RATE_LIMIT_MAX_REQUESTS=8
+# SPEECH_DAILY_QUOTA=30
+
 # ──────────────── Upload + Speech Runtime ────────────────
 # SPEECH_MAX_UPLOAD_BYTES=10485760
 # AUDIO_CONVERT_TIMEOUT_MS=12000
@@ -106,3 +120,8 @@ PORT=4000
 # ──────────────── Frontend Build Flags ────────────────
 # VITE_CONTENT_SOURCE=pipeline
 # Leave VITE_ENABLE_DEV_ANALYTICS unset in preview/production
+#
+# Backend origin for the SPA to call. Leave empty for same-origin deploys
+# (recommended — Express serves the built SPA on one origin). Set to the
+# backend URL (no trailing slash) if you deploy the SPA on a separate origin.
+# VITE_API_BASE_URL=https://api.your-backend.example.com

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -79,3 +79,6 @@ A comprehensive list of what LusoPronounce can do, organized by feature area.
 - **CI/CD** — GitHub Actions pipeline runs on push/PR to `main` and `develop`: install, build, unit tests, and Playwright e2e.
 - **Deployment** — Railway-targeted with static SPA serving and aggressive caching.
 - **Database** — MongoDB via Mongoose with singleton connection, retry logic, and connection health reporting.
+- **Fail-fast Startup** — Production boots refuse to bind the port when required environment variables or the MongoDB connection are missing, so the app never appears "up" with broken core flows.
+- **Readiness Probe** — `/api/health` reports MongoDB and Azure Speech configuration state alongside liveness, making deploy issues observable without calling Azure.
+- **Configurable API Origin** — `VITE_API_BASE_URL` and `CSP_CONNECT_SRC` let the SPA target a separate backend origin when needed; default same-origin deploys remain zero-config.

--- a/README.md
+++ b/README.md
@@ -60,7 +60,14 @@ See [`FEATURES.md`](./FEATURES.md) for the full list.
 
 ## Demo
 
-<!-- TODO: Add the live Railway URL here once deployed, or delete this section -->
+**Live:** _<add your Railway URL here once deployed>_
+**Invite code:** `LAUNCH-ACCESS` (capped — comment on the launch post for a spare)
+
+### Try it in 60 seconds
+
+1. Sign up with the invite code above.
+2. Pick any sentence on the Practice tab and hit record — read the Portuguese line aloud.
+3. Stop recording and watch the per-word + phoneme feedback render in a couple of seconds.
 
 ## Local setup
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,94 @@
+# TODO — Launch Checklist
+
+Manual steps for the LinkedIn / portfolio launch. The code-level gaps from `docs/release-readiness-linkedin-2026-04-17.md` are already addressed in this branch; what remains needs a human, credentials, or a live environment.
+
+Work the list top to bottom.
+
+## 1. Deploy the backend + SPA to Railway
+
+- Create a new Railway project from this repo; Railway will pick up `Dockerfile` + `railway.json` automatically.
+- Attach a MongoDB (Railway plugin, MongoDB Atlas free tier, or equivalent).
+- Confirm the health check at `/api/health` goes green after the first deploy.
+
+## 2. Set production environment variables
+
+In Railway's variables panel, set:
+
+| Variable | Notes |
+|---|---|
+| `NODE_ENV` | `production` |
+| `AZURE_SPEECH_KEY` | Azure Speech resource key |
+| `AZURE_SPEECH_REGION` | e.g. `eastus`, `brazilsouth` |
+| `MONGODB_URI` | full SRV connection string |
+| `JWT_SECRET` | generate with `openssl rand -hex 32` |
+| `APP_ORIGIN` | e.g. `https://lusopronounce.up.railway.app` |
+| `APP_ORIGINS` | same as `APP_ORIGIN` (plus custom domain if any) |
+| `CORS_ALLOWED_ORIGINS` | same list |
+| `SPEECH_CORS_ALLOWED_ORIGINS` | same list |
+| `REQUIRE_INVITE_CODE` | `true` |
+
+Server startup will now exit non-zero if any of `AZURE_SPEECH_KEY`, `AZURE_SPEECH_REGION`, `MONGODB_URI`, or `JWT_SECRET` is missing — if the deploy loops on restart, check these first.
+
+## 3. Apply launch-safe rate limits
+
+Tighter caps while the invite pool is small:
+
+- `GLOBAL_API_MAX=80`
+- `SPEECH_RATE_LIMIT_MAX_REQUESTS=8`
+- `SPEECH_DAILY_QUOTA=30`
+
+Relax these once you see real traffic patterns. Defaults live in `.env.example`.
+
+## 4. Seed at least one invite code
+
+Run once against the production database (Railway shell or locally with prod `MONGODB_URI`):
+
+```bash
+npm run invite:seed -- --code=LAUNCH-ACCESS --maxUses=25
+```
+
+Seed a second one with a small cap (e.g. `--maxUses=5`) for the LinkedIn comment giveaway.
+
+## 5. Configure OAuth callback URLs
+
+In each provider's developer console, add the production callback:
+
+- GitHub OAuth app → **Authorization callback URL**:
+  `${APP_ORIGIN}/api/auth/oauth/github/callback`
+- LinkedIn OAuth app → **Redirect URLs**:
+  `${APP_ORIGIN}/api/auth/oauth/linkedin/callback`
+
+Set `GITHUB_CLIENT_ID` / `GITHUB_CLIENT_SECRET` / `LINKEDIN_CLIENT_ID` / `LINKEDIN_CLIENT_SECRET` in Railway. Skip either provider you don't want to expose.
+
+## 6. Update the README demo link
+
+Edit `README.md` → **Demo** section → replace `_<add your Railway URL here once deployed>_` with the real Railway URL (or custom domain). Commit on `main`.
+
+## 7. External smoke test
+
+From a fresh browser profile (no cached auth):
+
+1. Open the live URL, register with the public invite code.
+2. Record one sentence on Practice → confirm word + phoneme feedback renders.
+3. Kill network mid-recording → confirm the friendly error copy + **Try again** button.
+4. `curl https://<your-domain>/api/health` → verify body includes `"ok": true`, `"mongo.connected": true`, `"speech.configured": true`.
+5. Skim Railway logs for the last 10 minutes — no unhandled errors.
+
+## 8. Draft and publish the LinkedIn post
+
+Use the structure from `docs/release-readiness-linkedin-2026-04-17.md` §9A:
+
+1. Hook — "I built a Portuguese pronunciation coach that gives per-word + phoneme feedback in seconds."
+2. Problem — sentence-level scoring isn't actionable; I wanted sound-level feedback.
+3. Demo proof — a short GIF of one record → score loop.
+4. Tech bullets — React + Express + Azure Speech + deterministic coaching engine.
+5. CTA — "Comment 'demo' for an invite code" (hand out the capped code from §4).
+
+Record the GIF with Loom/Kap before posting; aim for <20s showing the recording → word scores → phoneme expansion flow.
+
+## 9. Optional / later
+
+- Custom domain via Railway (swap `APP_ORIGIN`, update OAuth callbacks, update README).
+- HSTS preload submission (only after you're sure HTTPS is stable long-term; flip `preload: true` in `src/server/app.ts`).
+- Redis-backed rate limiting if the app ever scales beyond a single instance.
+- A proper "Demo Mode" that runs without auth or Azure spend (design sketch lives in §9B of the release-readiness doc).

--- a/src/api/apiUrl.test.ts
+++ b/src/api/apiUrl.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { buildApiUrl, API_BASE_URL } from './apiUrl';
+
+describe('buildApiUrl', () => {
+  it('returns the path unchanged when no base URL is configured', () => {
+    // Default test env leaves VITE_API_BASE_URL unset.
+    expect(API_BASE_URL).toBe('');
+    expect(buildApiUrl('/api/health')).toBe('/api/health');
+  });
+
+  it('rejects paths that do not start with /', () => {
+    expect(() => buildApiUrl('api/health')).toThrow(/must start with/);
+  });
+});

--- a/src/api/apiUrl.ts
+++ b/src/api/apiUrl.ts
@@ -1,0 +1,23 @@
+/**
+ * API URL helper.
+ *
+ * Same-origin deploys (default) leave `VITE_API_BASE_URL` unset and all
+ * requests fire against relative `/api/...` paths. Split deploys set the env
+ * var to the backend origin (e.g. `https://api.example.com`) and every call
+ * is rewritten to absolute URLs.
+ */
+
+const rawBase =
+  (typeof import.meta !== 'undefined'
+    ? (import.meta as unknown as { env?: Record<string, string | undefined> })
+        .env?.VITE_API_BASE_URL
+    : undefined) ?? '';
+
+export const API_BASE_URL = rawBase.replace(/\/+$/, '');
+
+export function buildApiUrl(path: string): string {
+  if (!path.startsWith('/')) {
+    throw new Error(`buildApiUrl: path must start with '/', got '${path}'`);
+  }
+  return `${API_BASE_URL}${path}`;
+}

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -10,6 +10,7 @@ import {
 } from '@/lib/attemptMetrics';
 import { ERROR_CLASS, isErrorClass } from '@/lib/errorTaxonomy';
 import { writeSpeechServiceHealthRecord } from '@/lib/speechServiceHealth';
+import { buildApiUrl } from './apiUrl';
 
 const AUTH_TOKEN_KEY = 'luso_auth_token';
 
@@ -39,7 +40,7 @@ export async function register(
   password: string,
   displayName?: string,
 ): Promise<AuthResponse> {
-  const response = await fetch('/api/auth/register', {
+  const response = await fetch(buildApiUrl('/api/auth/register'), {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -66,7 +67,7 @@ export async function register(
  * Login with email and password
  */
 export async function login(email: string, password: string): Promise<AuthResponse> {
-  const response = await fetch('/api/auth/login', {
+  const response = await fetch(buildApiUrl('/api/auth/login'), {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -173,7 +174,7 @@ export async function pingSpeechServiceHealth(): Promise<void> {
  */
 export async function fetchAuthProviders(): Promise<string[]> {
   try {
-    const response = await fetch('/api/auth/providers');
+    const response = await fetch(buildApiUrl('/api/auth/providers'));
     if (!response.ok) return ['email'];
     const data = await response.json() as { providers: string[] };
     return data.providers;
@@ -186,7 +187,7 @@ export async function fetchAuthProviders(): Promise<string[]> {
  * Dev-mode quick login (non-production only)
  */
 export async function devLogin(): Promise<AuthResponse> {
-  const response = await fetch('/api/auth/dev-login', {
+  const response = await fetch(buildApiUrl('/api/auth/dev-login'), {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
   });
@@ -249,7 +250,8 @@ export function getAuthHeader(): string | null {
 }
 
 /**
- * Fetch wrapper that automatically adds auth header
+ * Fetch wrapper that automatically adds the auth header and rewrites
+ * relative `/api/...` URLs against `VITE_API_BASE_URL` when configured.
  */
 export async function authenticatedFetch(
   url: string,
@@ -262,7 +264,9 @@ export async function authenticatedFetch(
     headers.set('Authorization', authHeader);
   }
 
-  return fetch(url, {
+  const resolvedUrl = url.startsWith('/') ? buildApiUrl(url) : url;
+
+  return fetch(resolvedUrl, {
     ...options,
     headers,
   });

--- a/src/components/practice/LivePracticeSection.tsx
+++ b/src/components/practice/LivePracticeSection.tsx
@@ -426,8 +426,18 @@ export default function LivePracticeSection({
         )}
 
         {error && (
-          <div className="p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded text-sm text-red-800 dark:text-red-200">
-            {error}
+          <div
+            role="alert"
+            className="p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded text-sm text-red-800 dark:text-red-200 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2"
+          >
+            <span>{error}</span>
+            <button
+              type="button"
+              onClick={resetRecording}
+              className="self-start sm:self-auto px-3 py-1.5 rounded-md border border-red-300 dark:border-red-700 text-xs font-medium bg-white/60 dark:bg-red-950/30 hover:bg-white dark:hover:bg-red-950/50 transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500"
+            >
+              Try again
+            </button>
           </div>
         )}
       </div>

--- a/src/components/practice/SentenceCard.tsx
+++ b/src/components/practice/SentenceCard.tsx
@@ -9,6 +9,7 @@ import { usePracticeLogStore } from '@/state/practiceLogStore';
 import { useAudioPlayer } from '@/hooks/useAudioPlayer';
 import PremiumRecordButton from '@/components/common/PremiumRecordButton';
 import { getAuthHeader } from '@/api/auth';
+import { buildApiUrl } from '@/api/apiUrl';
 
 interface SentenceCardProps {
   sentence: Sentence;
@@ -81,7 +82,7 @@ function SentenceCard({ sentence, currentIndex, totalCount, sessionId }: Sentenc
       }
       headers['Authorization'] = authHeaderValue;
 
-      const response = await fetch('/api/pronunciation/assessment', {
+      const response = await fetch(buildApiUrl('/api/pronunciation/assessment'), {
         method: 'POST',
         headers,
         body: formData,

--- a/src/hooks/useLivePronunciationPractice.ts
+++ b/src/hooks/useLivePronunciationPractice.ts
@@ -14,6 +14,7 @@ import {
 import { ERROR_CLASS, isErrorClass } from '@/lib/errorTaxonomy';
 import { writeSpeechServiceHealthRecord } from '@/lib/speechServiceHealth';
 import { getAuthHeader } from '@/api/auth';
+import { buildApiUrl } from '@/api/apiUrl';
 
 /**
  * Response type from the pronunciation assessment API
@@ -330,11 +331,11 @@ export function useLivePronunciationPractice(): UseLivePronunciationPracticeResu
       const fetchHeaders: Record<string, string> = {};
       const authHeaderValue = getAuthHeader();
       if (!authHeaderValue) {
-        throw new Error('Please log in to use pronunciation assessment.');
+        throw new Error('Your session expired. Please sign in again to keep practicing.');
       }
       fetchHeaders['Authorization'] = authHeaderValue;
 
-      const response = await fetch('/api/pronunciation/assessment', {
+      const response = await fetch(buildApiUrl('/api/pronunciation/assessment'), {
         method: 'POST',
         headers: fetchHeaders,
         body: formData,
@@ -382,7 +383,13 @@ export function useLivePronunciationPractice(): UseLivePronunciationPracticeResu
             message: errorPayload.message || errorPayload.error || null,
           });
         }
-        throw new Error(errorPayload.message || errorPayload.error || `HTTP ${response.status}`);
+        const friendlyMessage =
+          response.status === 429
+            ? "You've hit the practice limit for now. Take a breather and try again in a bit."
+            : response.status >= 500
+              ? "Our scoring service is having a moment. Please try again."
+              : errorPayload.message || errorPayload.error || "Something went wrong scoring that attempt. Please try again.";
+        throw new Error(friendlyMessage);
       }
 
       // Parse response with better error handling
@@ -396,7 +403,7 @@ export function useLivePronunciationPractice(): UseLivePronunciationPracticeResu
       } catch (parseError) {
         console.error('Failed to parse response JSON:', parseError);
         // Note: Can't read response.text() again, so we'll use the error message
-        throw new Error(`Invalid response from server: ${parseError instanceof Error ? parseError.message : 'Unknown parsing error'}. The server may have returned invalid JSON.`);
+        throw new Error("We got an unexpected response from the scoring service. Please try again.");
       }
 
       const { rawAzure, attemptScore, telemetry } = responseData;
@@ -404,7 +411,7 @@ export function useLivePronunciationPractice(): UseLivePronunciationPracticeResu
       // Validate response structure
       if (!rawAzure || !attemptScore) {
         console.error('Invalid response structure:', { rawAzure, attemptScore });
-        throw new Error('Invalid response: missing rawAzure or attemptScore');
+        throw new Error("We got an unexpected response from the scoring service. Please try again.");
       }
 
       attemptTelemetry.requestId = telemetry?.requestId ?? attemptTelemetry.requestId;

--- a/src/lib/wordPronunciation.ts
+++ b/src/lib/wordPronunciation.ts
@@ -7,6 +7,7 @@
 
 import type { AttemptScore } from '@/types/pronunciation';
 import { getAuthHeader } from '@/api/auth';
+import { buildApiUrl } from '@/api/apiUrl';
 
 /**
  * Scores word pronunciation using the shared pronunciation assessment API.
@@ -37,7 +38,7 @@ export async function scoreWordPronunciation(
   }
   headers['Authorization'] = authHeader;
 
-  const response = await fetch('/api/pronunciation/assessment', {
+  const response = await fetch(buildApiUrl('/api/pronunciation/assessment'), {
     method: 'POST',
     headers,
     body: formData,

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -38,6 +38,14 @@ app.set('trust proxy', 1);
 app.disable('x-powered-by');
 
 // ──────────────── Security headers (Helmet) ────────────────
+// Extra origins allowed in the CSP connect-src directive. Only needed when the
+// frontend and backend live on different origins (e.g. SPA on Vercel + API on
+// Railway). Same-origin deploys leave CSP_CONNECT_SRC unset.
+const extraConnectSrc = (process.env.CSP_CONNECT_SRC || '')
+  .split(',')
+  .map((origin) => origin.trim())
+  .filter((origin) => origin.length > 0);
+
 app.use(
   helmet({
     contentSecurityPolicy: {
@@ -47,7 +55,7 @@ app.use(
         styleSrc: ["'self'", "'unsafe-inline'"],
         imgSrc: ["'self'", 'data:', 'blob:'],
         mediaSrc: ["'self'", 'blob:'],
-        connectSrc: ["'self'", 'blob:'],
+        connectSrc: ["'self'", 'blob:', ...extraConnectSrc],
         workerSrc: ["'self'", 'blob:'],
         frameAncestors: ["'none'"],
         objectSrc: ["'none'"],
@@ -182,10 +190,11 @@ app.use((err: Error, req: express.Request, res: express.Response, _next: express
  */
 async function startServer(): Promise<void> {
   console.log(`[Server] Starting on port ${PORT} (HOST: 0.0.0.0)...`);
+  const isProduction = process.env.NODE_ENV === 'production';
 
   // Hard-stop on unsafe production configs. We refuse to boot with obvious
   // foot-guns enabled.
-  if (process.env.NODE_ENV === 'production') {
+  if (isProduction) {
     if (process.env.ENABLE_DEV_LOGIN === 'true') {
       console.error(
         '[Server] ENABLE_DEV_LOGIN=true is not allowed in production. Aborting.'
@@ -197,6 +206,18 @@ async function startServer(): Promise<void> {
         '[Server] SPEECH_DEBUG is enabled in production. This dumps full Azure payloads to disk — ' +
         'disable unless actively investigating an incident.'
       );
+    }
+
+    // Fail fast on missing required env vars before binding the port. Stops
+    // the app from appearing "up" while core flows are broken.
+    try {
+      validateRequiredLaunchEnvVars();
+    } catch (error) {
+      console.error(
+        '[Server] Refusing to start:',
+        error instanceof Error ? error.message : error
+      );
+      process.exit(1);
     }
   }
 
@@ -213,7 +234,11 @@ async function startServer(): Promise<void> {
   });
 
   try {
-    validateRequiredLaunchEnvVars();
+    if (!isProduction) {
+      // Dev: tolerate a partially-configured .env so developers can boot the
+      // server without all secrets. Production already validated above.
+      validateRequiredLaunchEnvVars();
+    }
 
     // Connect to MongoDB
     console.log('[Server] Connecting to MongoDB...');
@@ -222,7 +247,12 @@ async function startServer(): Promise<void> {
     await logInviteCodeReadiness();
   } catch (error) {
     console.error('[Server] Failed to connect to MongoDB:', error);
-    // Don't exit — keep the server running so health checks can report the error
+    if (isProduction) {
+      // In production a bad Mongo connection means auth, progress, and invite
+      // gating are all broken — fail loudly so the deploy is retried.
+      process.exit(1);
+    }
+    // Dev: keep the server running so health checks can report the error.
   }
 }
 

--- a/src/server/routes/health.test.ts
+++ b/src/server/routes/health.test.ts
@@ -2,8 +2,11 @@ import { describe, expect, it } from 'vitest';
 import { buildHealthResponse } from './health';
 import type { MongoStatus } from '../db/mongoClient';
 
+const speechOk = () => ({ configured: true });
+const speechMissing = () => ({ configured: false });
+
 describe('buildHealthResponse', () => {
-  it('returns 200 when MongoDB is connected', async () => {
+  it('returns 200 with ok:true when MongoDB and speech are both ready', async () => {
     const mongoStatus: MongoStatus = {
       connected: true,
       readyState: 1,
@@ -11,14 +14,34 @@ describe('buildHealthResponse', () => {
       name: 'lusopronounce',
     };
 
-    const response = await buildHealthResponse(async () => mongoStatus);
+    const response = await buildHealthResponse(async () => mongoStatus, speechOk);
 
     expect(response).toEqual({
       statusCode: 200,
       body: {
         ok: true,
         mongo: mongoStatus,
+        speech: { configured: true },
       },
+    });
+  });
+
+  it('returns ok:false when Mongo is connected but speech is not configured', async () => {
+    const mongoStatus: MongoStatus = {
+      connected: true,
+      readyState: 1,
+      host: 'localhost',
+      name: 'lusopronounce',
+    };
+
+    const response = await buildHealthResponse(async () => mongoStatus, speechMissing);
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toEqual({
+      ok: false,
+      error: 'Azure Speech credentials are not configured.',
+      mongo: mongoStatus,
+      speech: { configured: false },
     });
   });
 
@@ -28,20 +51,21 @@ describe('buildHealthResponse', () => {
       readyState: 0,
     };
 
-    const response = await buildHealthResponse(async () => mongoStatus);
+    const response = await buildHealthResponse(async () => mongoStatus, speechOk);
 
     expect(response.statusCode).toBe(200);
     expect(response.body).toEqual({
       ok: false,
       error: 'MongoDB is not connected.',
       mongo: mongoStatus,
+      speech: { configured: true },
     });
   });
 
   it('returns 200 with error when MongoDB status lookup throws', async () => {
     const response = await buildHealthResponse(async () => {
       throw new Error('status lookup failed');
-    });
+    }, speechOk);
 
     expect(response.statusCode).toBe(200);
     expect(response.body).toEqual({
@@ -51,6 +75,7 @@ describe('buildHealthResponse', () => {
         connected: false,
         readyState: 0,
       },
+      speech: { configured: true },
     });
   });
 });

--- a/src/server/routes/health.ts
+++ b/src/server/routes/health.ts
@@ -3,26 +3,49 @@ import { getMongoStatus, type MongoStatus } from '../db/mongoClient';
 
 const router = Router();
 
+export interface SpeechReadiness {
+  configured: boolean;
+}
+
 export interface HealthResponseBody {
   ok: boolean;
   mongo: MongoStatus;
+  speech: SpeechReadiness;
   error?: string;
 }
 
+function checkSpeechConfigured(env: NodeJS.ProcessEnv = process.env): SpeechReadiness {
+  const hasKey = typeof env.AZURE_SPEECH_KEY === 'string' && env.AZURE_SPEECH_KEY.trim().length > 0;
+  const hasRegion =
+    typeof env.AZURE_SPEECH_REGION === 'string' && env.AZURE_SPEECH_REGION.trim().length > 0;
+  return { configured: hasKey && hasRegion };
+}
+
 export async function buildHealthResponse(
-  getStatus: () => Promise<MongoStatus> = getMongoStatus
+  getStatus: () => Promise<MongoStatus> = getMongoStatus,
+  getSpeech: () => SpeechReadiness = checkSpeechConfigured
 ): Promise<{ statusCode: number; body: HealthResponseBody }> {
+  const speech = getSpeech();
+
   try {
     const mongoStatus = await getStatus();
+    const ok = mongoStatus.connected && speech.configured;
 
     // Always return 200 for liveness (Railway health check).
-    // The response body still reports MongoDB status for observability.
+    // The response body still reports dependency readiness for observability.
+    const errorMessage = !mongoStatus.connected
+      ? 'MongoDB is not connected.'
+      : !speech.configured
+        ? 'Azure Speech credentials are not configured.'
+        : undefined;
+
     return {
       statusCode: 200,
       body: {
-        ok: mongoStatus.connected,
+        ok,
         mongo: mongoStatus,
-        ...(!mongoStatus.connected && { error: 'MongoDB is not connected.' }),
+        speech,
+        ...(errorMessage ? { error: errorMessage } : {}),
       },
     };
   } catch (error) {
@@ -37,6 +60,7 @@ export async function buildHealthResponse(
           connected: false,
           readyState: 0,
         },
+        speech,
       },
     };
   }
@@ -44,8 +68,10 @@ export async function buildHealthResponse(
 
 /**
  * GET /api/health
- * 
- * Returns health status of the API and MongoDB connection
+ *
+ * Returns health status of the API, MongoDB connection, and speech
+ * configuration. Always 200 so upstream health checks treat the process as
+ * alive; the body distinguishes "up" from "ready".
  */
 router.get('/', async (_req: Request, res: Response) => {
   const { statusCode, body } = await buildHealthResponse();


### PR DESCRIPTION
Close the highest-leverage gaps from docs/release-readiness-linkedin-2026-04-17.md
so the app is portfolio-ready without over-engineering:

- Fail-fast env + MongoDB validation in production boot; dev stays lenient.
- CSP_CONNECT_SRC env var so split-origin deploys can extend Helmet connectSrc.
- buildApiUrl helper + VITE_API_BASE_URL; authenticatedFetch routes through it.
- /api/health now reports Azure speech configuration alongside MongoDB.
- Practice-screen error copy is user-facing with a Try again CTA.
- .env.example documents launch-safe rate limits, new env vars.
- README Demo section + TODO.md launch checklist.

https://claude.ai/code/session_01PsZ95ghTy2CyEwMvnZZ4Az