### PR TITLE
feat(auth,ui): add Google OAuth + daily-quota pill

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,6 +45,10 @@ GITHUB_CLIENT_ID=
 GITHUB_CLIENT_SECRET=
 LINKEDIN_CLIENT_ID=
 LINKEDIN_CLIENT_SECRET=
+# Google OAuth — create at https://console.cloud.google.com/apis/credentials
+# Authorized redirect URI: ${APP_ORIGIN}/api/auth/oauth/google/callback
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
 
 # ──────────────── App Origin ────────────────
 # Public URL of your deployed app (used for OAuth redirect URIs and as an

--- a/TODO.md
+++ b/TODO.md
@@ -57,8 +57,19 @@ In each provider's developer console, add the production callback:
   `${APP_ORIGIN}/api/auth/oauth/github/callback`
 - LinkedIn OAuth app → **Redirect URLs**:
   `${APP_ORIGIN}/api/auth/oauth/linkedin/callback`
+- Google Cloud Console → **APIs & Services → Credentials → OAuth 2.0 Client IDs**:
+  - Application type: **Web application**
+  - Authorized JavaScript origins: `${APP_ORIGIN}`
+  - Authorized redirect URI: `${APP_ORIGIN}/api/auth/oauth/google/callback`
+  - On the **OAuth consent screen** page: set user type to **External**, add your email as a test user while the app is in Testing, and request scopes `openid`, `email`, `profile`.
 
-Set `GITHUB_CLIENT_ID` / `GITHUB_CLIENT_SECRET` / `LINKEDIN_CLIENT_ID` / `LINKEDIN_CLIENT_SECRET` in Railway. Skip either provider you don't want to expose.
+Set the corresponding client ID / secret pair in Railway for each provider you want to expose:
+
+- `GITHUB_CLIENT_ID` / `GITHUB_CLIENT_SECRET`
+- `LINKEDIN_CLIENT_ID` / `LINKEDIN_CLIENT_SECRET`
+- `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET`
+
+Buttons only appear on the login page for providers whose env vars are set — skip any provider you don't want live.
 
 ## 6. Update the README demo link
 

--- a/src/components/auth/AuthForm.tsx
+++ b/src/components/auth/AuthForm.tsx
@@ -28,6 +28,29 @@ function LinkedInIcon() {
   );
 }
 
+function GoogleIcon() {
+  return (
+    <svg className="w-5 h-5" viewBox="0 0 20 20" aria-hidden="true">
+      <path
+        fill="#EA4335"
+        d="M10 4.167c1.475 0 2.798.508 3.84 1.5l2.875-2.875C14.95 1.133 12.625.167 10 .167 6.133.167 2.8 2.383 1.175 5.617l3.35 2.6C5.308 5.842 7.458 4.167 10 4.167z"
+      />
+      <path
+        fill="#4285F4"
+        d="M19.608 10.217c0-.7-.058-1.375-.167-2.017H10v3.833h5.383c-.233 1.25-.942 2.308-2.008 3.017l3.25 2.517c1.9-1.758 2.983-4.342 2.983-7.35z"
+      />
+      <path
+        fill="#FBBC05"
+        d="M4.525 11.783A5.986 5.986 0 014.167 10c0-.617.108-1.217.3-1.783l-3.35-2.6A9.957 9.957 0 00.167 10c0 1.617.383 3.142 1.05 4.492l3.308-2.709z"
+      />
+      <path
+        fill="#34A853"
+        d="M10 19.833c2.7 0 4.967-.892 6.625-2.425l-3.25-2.517c-.9.6-2.058.958-3.375.958-2.542 0-4.692-1.675-5.475-3.95l-3.308 2.709C2.8 17.617 6.133 19.833 10 19.833z"
+      />
+    </svg>
+  );
+}
+
 export default function AuthForm({ onSuccess, initialMode = 'login', oauthError }: AuthFormProps) {
   const [mode, setMode] = useState<'login' | 'register'>(initialMode);
   const [email, setEmail] = useState('');
@@ -102,8 +125,20 @@ export default function AuthForm({ onSuccess, initialMode = 'login', oauthError 
       )}
 
       {/* OAuth Buttons */}
-      {(providers.includes('github') || providers.includes('linkedin')) && (
+      {(providers.includes('github') ||
+        providers.includes('linkedin') ||
+        providers.includes('google')) && (
         <div className="space-y-3 mb-6">
+          {providers.includes('google') && (
+            <a
+              href="/api/auth/oauth/google"
+              className="w-full flex items-center justify-center gap-3 py-2.5 px-4 bg-white text-gray-800 border border-gray-300 rounded-md hover:bg-gray-50 transition-colors"
+            >
+              <GoogleIcon />
+              Continue with Google
+            </a>
+          )}
+
           {providers.includes('github') && (
             <a
               href="/api/auth/oauth/github"

--- a/src/components/practice/LivePracticeSection.tsx
+++ b/src/components/practice/LivePracticeSection.tsx
@@ -88,6 +88,7 @@ export default function LivePracticeSection({
     rawAzureResponse,
     submitAttempt,
     cancelAnalysis,
+    dailyQuota,
   } = useLivePronunciationPractice();
 
   // Notify parent of current attempt changes
@@ -288,17 +289,45 @@ export default function LivePracticeSection({
     resetRecording();
   }, [coachingSuggestion, resetRecording]);
 
+  const quotaExhausted = Boolean(dailyQuota) && dailyQuota!.remaining <= 0;
+  const quotaLow =
+    Boolean(dailyQuota) && dailyQuota!.remaining > 0 && dailyQuota!.remaining <= 5;
+
   return (
     <div className="space-y-6">
       {/* Dynamic Recording Controls */}
       <div className="space-y-4">
+        {dailyQuota && (
+          <div className="flex justify-center">
+            <span
+              className={`inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-medium border ${
+                quotaExhausted
+                  ? 'bg-red-50 dark:bg-red-900/20 border-red-200 dark:border-red-800 text-red-800 dark:text-red-200'
+                  : quotaLow
+                    ? 'bg-amber-50 dark:bg-amber-900/20 border-amber-200 dark:border-amber-800 text-amber-800 dark:text-amber-200'
+                    : 'bg-gray-50 dark:bg-gray-800/60 border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-300'
+              }`}
+              title={`Daily limit resets at 00:00 UTC. Limit: ${dailyQuota.limit}.`}
+            >
+              <span
+                className={`w-1.5 h-1.5 rounded-full ${
+                  quotaExhausted ? 'bg-red-500' : quotaLow ? 'bg-amber-500' : 'bg-emerald-500'
+                }`}
+                aria-hidden="true"
+              />
+              {quotaExhausted
+                ? 'Daily limit reached — resets at 00:00 UTC'
+                : `${dailyQuota.remaining} of ${dailyQuota.limit} attempts left today`}
+            </span>
+          </div>
+        )}
         <div className="flex items-center justify-center gap-4">
           {/* State 1: Ready to Record - Single large red mic button */}
           {isReadyToRecord && (
             <PremiumRecordButton
               isRecording={false}
               onClick={startRecording}
-              disabled={submitting}
+              disabled={submitting || quotaExhausted}
               size="lg"
             />
           )}

--- a/src/hooks/useLivePronunciationPractice.ts
+++ b/src/hooks/useLivePronunciationPractice.ts
@@ -128,6 +128,9 @@ export type UseLivePronunciationPracticeResult = {
   rawAzureResponse: any | null; // raw response for currentAttempt
   allRawAzureResponses: Map<string, any>; // all raw responses keyed by attempt id
 
+  // Daily quota (read from X-Quota-* response headers; null until first call)
+  dailyQuota: { limit: number; remaining: number } | null;
+
   // Actions
   submitAttempt: (
     sentenceId: string,
@@ -167,6 +170,7 @@ export function useLivePronunciationPractice(): UseLivePronunciationPracticeResu
   const [attemptState, setAttemptState] = useState<AttemptLifecycleState>('idle');
   const [attempts, setAttempts] = useState<AttemptScore[]>([]);
   const [allRawAzureResponses, setAllRawAzureResponses] = useState<Map<string, any>>(new Map());
+  const [dailyQuota, setDailyQuota] = useState<{ limit: number; remaining: number } | null>(null);
 
   // AbortController for canceling in-flight requests
   const abortControllerRef = useRef<AbortController | null>(null);
@@ -345,6 +349,18 @@ export function useLivePronunciationPractice(): UseLivePronunciationPracticeResu
       const latencyMs = Math.max(0, Math.round(responseReceivedAt - submitStartedAt));
       attemptTelemetry.clientTimingsMs.submitToResponseMs = latencyMs;
       attemptTelemetry.requestId = response.headers.get('X-Request-Id');
+
+      // Capture daily-quota headers emitted by the dailyQuota middleware.
+      // Present on both successful and rate-limited responses.
+      const quotaLimitHeader = response.headers.get('X-Quota-Limit');
+      const quotaRemainingHeader = response.headers.get('X-Quota-Remaining');
+      if (quotaLimitHeader && quotaRemainingHeader) {
+        const limit = Number(quotaLimitHeader);
+        const remaining = Number(quotaRemainingHeader);
+        if (Number.isFinite(limit) && Number.isFinite(remaining)) {
+          setDailyQuota({ limit, remaining: Math.max(0, remaining) });
+        }
+      }
 
       // Check if request was aborted
       if (abortController.signal.aborted || activeRequestIdRef.current !== requestId) {
@@ -647,6 +663,9 @@ export function useLivePronunciationPractice(): UseLivePronunciationPracticeResu
     currentAttempt,
     rawAzureResponse,
     allRawAzureResponses,
+
+    // Daily quota (from X-Quota-* response headers, null until first call)
+    dailyQuota,
 
     // Actions
     submitAttempt,

--- a/src/server/models/UserModel.ts
+++ b/src/server/models/UserModel.ts
@@ -8,7 +8,7 @@ export interface IUserDocument extends Document {
   email: string;
   passwordHash?: string;
   displayName?: string;
-  oauthProvider?: 'github' | 'linkedin';
+  oauthProvider?: 'github' | 'linkedin' | 'google';
   oauthId?: string;
   avatarUrl?: string;
   settings?: {
@@ -42,7 +42,7 @@ const UserSchema = new Schema<IUserDocument>(
     },
     oauthProvider: {
       type: String,
-      enum: ['github', 'linkedin'],
+      enum: ['github', 'linkedin', 'google'],
     },
     oauthId: {
       type: String,

--- a/src/server/routes/auth.ts
+++ b/src/server/routes/auth.ts
@@ -329,6 +329,9 @@ router.get('/providers', providersLimit, (_req: Request, res: Response) => {
   if (process.env.LINKEDIN_CLIENT_ID && process.env.LINKEDIN_CLIENT_SECRET) {
     providers.push('linkedin');
   }
+  if (process.env.GOOGLE_CLIENT_ID && process.env.GOOGLE_CLIENT_SECRET) {
+    providers.push('google');
+  }
   // Dev login is only advertised in non-production, even if the flag is set.
   if (process.env.ENABLE_DEV_LOGIN === 'true' && process.env.NODE_ENV !== 'production') {
     providers.push('dev');

--- a/src/server/routes/oauth.ts
+++ b/src/server/routes/oauth.ts
@@ -305,6 +305,127 @@ router.get('/linkedin/callback', async (req: Request, res: Response) => {
   }
 });
 
+// ──────────────── Google OAuth ────────────────
+
+router.get('/google', (_req: Request, res: Response) => {
+  const clientId = process.env.GOOGLE_CLIENT_ID;
+  if (!clientId) {
+    return res.status(500).json({ error: 'Google OAuth not configured' });
+  }
+
+  const appOrigin = getAppOrigin();
+  const state = setStateCookie(res, 'google');
+  const redirectUri = `${appOrigin}/api/auth/oauth/google/callback`;
+  const params = new URLSearchParams({
+    response_type: 'code',
+    client_id: clientId,
+    redirect_uri: redirectUri,
+    scope: 'openid email profile',
+    state,
+    // Always show the account chooser so a user switching between Google
+    // accounts doesn't get silently logged in as the wrong one.
+    prompt: 'select_account',
+  });
+
+  res.redirect(`https://accounts.google.com/o/oauth2/v2/auth?${params.toString()}`);
+});
+
+router.get('/google/callback', async (req: Request, res: Response) => {
+  const { code } = req.query;
+  const appOrigin = getAppOrigin();
+
+  if (!validateState(req, res, 'google')) {
+    return res.redirect(`${appOrigin}/auth?error=invalid_state`);
+  }
+
+  if (!code || typeof code !== 'string') {
+    return res.redirect(`${appOrigin}/auth?error=missing_code`);
+  }
+
+  try {
+    const redirectUri = `${appOrigin}/api/auth/oauth/google/callback`;
+
+    const tokenResponse = await fetch('https://oauth2.googleapis.com/token', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        grant_type: 'authorization_code',
+        code,
+        redirect_uri: redirectUri,
+        client_id: process.env.GOOGLE_CLIENT_ID!,
+        client_secret: process.env.GOOGLE_CLIENT_SECRET!,
+      }),
+    });
+
+    const tokenData = (await tokenResponse.json()) as {
+      access_token?: string;
+      error?: string;
+    };
+    if (!tokenData.access_token) {
+      console.error('[OAuth] Google token exchange failed:', tokenData.error);
+      return res.redirect(`${appOrigin}/auth?error=token_exchange_failed`);
+    }
+
+    const userInfoResponse = await fetch(
+      'https://openidconnect.googleapis.com/v1/userinfo',
+      {
+        headers: { Authorization: `Bearer ${tokenData.access_token}` },
+      }
+    );
+    const googleUser = (await userInfoResponse.json()) as {
+      sub: string;
+      email?: string;
+      email_verified?: boolean;
+      name?: string;
+      picture?: string;
+    };
+
+    // Only accept verified Google accounts. Unverified means the user could
+    // have signed up with an email they don't actually control.
+    if (!googleUser.email || googleUser.email_verified === false) {
+      return res.redirect(`${appOrigin}/auth?error=no_email`);
+    }
+    const email = googleUser.email;
+
+    let userDoc = await UserModel.findOne({
+      $or: [
+        { oauthProvider: 'google', oauthId: googleUser.sub },
+        { email: email.toLowerCase() },
+      ],
+    });
+
+    if (userDoc) {
+      if (!userDoc.oauthProvider) {
+        userDoc.oauthProvider = 'google';
+        userDoc.oauthId = googleUser.sub;
+        userDoc.avatarUrl = googleUser.picture || undefined;
+        await userDoc.save();
+      }
+    } else {
+      userDoc = await UserModel.create({
+        email: email.toLowerCase(),
+        oauthProvider: 'google',
+        oauthId: googleUser.sub,
+        displayName: googleUser.name || undefined,
+        avatarUrl: googleUser.picture || undefined,
+      });
+    }
+
+    const token = generateToken(userDoc._id.toString(), userDoc.email);
+    res.cookie('oauth_handoff', token, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+      maxAge: 2 * 60 * 1000,
+      path: '/api/auth/oauth/handoff',
+    });
+    res.redirect(`${appOrigin}/auth/callback`);
+  } catch (error) {
+    console.error('[OAuth] Google callback error:', error);
+    res.redirect(`${appOrigin}/auth?error=server_error`);
+  }
+});
+
 // ──────────────── Token handoff ────────────────
 //
 // Single-use endpoint: the SPA fetches this on /auth/callback to retrieve the

--- a/src/shared/types/user.ts
+++ b/src/shared/types/user.ts
@@ -8,7 +8,7 @@ export interface User {
   email: string;
   displayName?: string;
   avatarUrl?: string;
-  oauthProvider?: 'github' | 'linkedin';
+  oauthProvider?: 'github' | 'linkedin' | 'google';
   createdAt: string; // ISO timestamp
   settings?: UserSettings;
 }


### PR DESCRIPTION
- Add Google OAuth provider mirroring GitHub/LinkedIn flows (state cookie,
  cookie-handoff). Requires GOOGLE_CLIENT_ID/SECRET env vars; button only
  renders on the auth page when both are set.
- Widen oauthProvider enum + shared User type to include 'google'.
- Capture X-Quota-Limit / X-Quota-Remaining response headers in the
  pronunciation hook and surface as dailyQuota.
- Render a daily-attempts pill above the record button; warning style under
  5 left, error + disabled record at 0 (resets at 00:00 UTC).
- Update .env.example and TODO.md with Google OAuth setup steps for manual
  configuration in the Google Cloud Console.

https://claude.ai/code/session_01PsZ95ghTy2CyEwMvnZZ4Az