### PR TITLE
fix(practice): clean up sentence feedback UI and align word details

### DIFF
--- a/src/components/pronunciation/PronunciationFeedbackPanel.tsx
+++ b/src/components/pronunciation/PronunciationFeedbackPanel.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect, useMemo } from 'react';
 import type { AttemptScore } from '@/types/pronunciation';
 import InteractiveSentenceDisplay from '@/components/practice/InteractiveSentenceDisplay';
 import { ChevronDown, ChevronUp } from 'lucide-react';
+import { alignUiTokensToAzureWords } from '@/pipeline/sentenceWordRefs';
 import {
   SentenceAudioControls,
   PhonemePanel,
@@ -157,10 +158,8 @@ export default function PronunciationFeedbackPanel({
     setActiveSentenceType(null);
   };
 
-  const handleInteractiveWordClick = (wordData: any, index: number) => {
-    const normalizedWord: NormalizedWordFeedback | undefined =
-      wordData?.normalizedWord ?? words?.[index];
-
+  const handleInteractiveWordClick = (wordData: any) => {
+    const normalizedWord: NormalizedWordFeedback | undefined = wordData?.normalizedWord;
     if (normalizedWord) {
       handleWordSelected(normalizedWord);
     }
@@ -170,16 +169,14 @@ export default function PronunciationFeedbackPanel({
   // dedicated Practice Words page. See BACKLOG.md for future implementation.
 
   const tokenWordScores = useMemo(() => {
-    const tokens = sentenceText.trim().split(/\s+/);
-    return tokens.map((token, index) => {
+    const { uiTokens, azureIndicesPerToken } = alignUiTokensToAzureWords(sentenceText);
+    return uiTokens.map((token, i) => {
+      const azureIndices = azureIndicesPerToken[i];
+      const firstAzureIndex = azureIndices[0];
       const normalizedWord =
-        words?.find((w) => {
-          if (w.index !== undefined) {
-            return w.index === index;
-          }
-          const parsedIndex = Number.isFinite(Number(w.id)) ? Number(w.id) : undefined;
-          return parsedIndex === index;
-        }) ?? (words ? words[index] : undefined);
+        firstAzureIndex === undefined
+          ? undefined
+          : words?.find((w) => w.index === firstAzureIndex) ?? words?.[firstAzureIndex];
 
       return {
         word: token,

--- a/src/components/pronunciation/ScoringPanel.tsx
+++ b/src/components/pronunciation/ScoringPanel.tsx
@@ -258,7 +258,7 @@ function AllMetricsInfoIcon({ prosodyAvailable = false }: { prosodyAvailable?: b
  * Provides background, text, and border classes for consistent styling.
  */
 export function getScoreColor(score: number): ScoreTheme {
-  if (score >= 90) {
+  if (score >= 80) {
     return {
       bg: 'bg-emerald-500 dark:bg-emerald-600',
       text: 'text-emerald-800 dark:text-emerald-100',
@@ -266,15 +266,7 @@ export function getScoreColor(score: number): ScoreTheme {
     };
   }
 
-  if (score >= 80) {
-    return {
-      bg: 'bg-sky-500 dark:bg-sky-600',
-      text: 'text-sky-800 dark:text-sky-100',
-      border: 'border-sky-300 dark:border-sky-700',
-    };
-  }
-
-  if (score >= 70) {
+  if (score >= 60) {
     return {
       bg: 'bg-amber-500 dark:bg-amber-600',
       text: 'text-amber-800 dark:text-amber-100',

--- a/src/components/pronunciation/shared/PhonemePanel.tsx
+++ b/src/components/pronunciation/shared/PhonemePanel.tsx
@@ -26,35 +26,6 @@ export default function PhonemePanel({ word, onClose }: PhonemePanelProps) {
     );
   }
 
-  const getPhonemeColors = (score: number) => {
-    if (score >= 90) {
-      return {
-        bg: 'bg-emerald-100 dark:bg-emerald-900/30',
-        text: 'text-emerald-800 dark:text-emerald-200',
-        border: 'border-emerald-300 dark:border-emerald-700',
-      };
-    }
-    if (score >= 80) {
-      return {
-        bg: 'bg-sky-100 dark:bg-sky-900/30',
-        text: 'text-sky-800 dark:text-sky-200',
-        border: 'border-sky-300 dark:border-sky-700',
-      };
-    }
-    if (score >= 70) {
-      return {
-        bg: 'bg-amber-100 dark:bg-amber-900/30',
-        text: 'text-amber-800 dark:text-amber-200',
-        border: 'border-amber-300 dark:border-amber-700',
-      };
-    }
-    return {
-      bg: 'bg-rose-100 dark:bg-rose-900/30',
-      text: 'text-rose-800 dark:text-rose-200',
-      border: 'border-rose-300 dark:border-rose-700',
-    };
-  };
-
   const problemPhonemes = word.phonemes?.filter(p => p.isProblem) || [];
   const wordScore = word.score ?? word.accuracyScore;
   const wordLevel = word.level || (wordScore >= 90 ? 'excellent' : wordScore >= 80 ? 'good' : wordScore >= 70 ? 'ok' : 'practice');
@@ -85,48 +56,7 @@ export default function PhonemePanel({ word, onClose }: PhonemePanelProps) {
         )}
       </div>
 
-      {/* Phoneme chips */}
-      {word.phonemes && word.phonemes.length > 0 ? (
-        <div>
-          <h4 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-            Phonemes:
-          </h4>
-          <div className="flex flex-wrap gap-2">
-            {word.phonemes.map((phoneme, index) => {
-              const colors = getPhonemeColors(phoneme.score);
-              const metadata = getPhonemeById(phoneme.symbol);
-              
-              // Build enriched tooltip
-              const desc = metadata?.englishApprox || metadata?.articulation || '';
-              const ptEx = metadata?.exampleWords?.map(w => w.pt).join(', ') || '';
-              const enEx = metadata?.englishExamples?.join(', ') || '';
-
-              let tooltipText = `${phoneme.symbol} • ${phoneme.score}/100`;
-              if (metadata) {
-                tooltipText += ` • ${desc}`;
-                if (ptEx) {
-                  tooltipText += ` • PT: ${ptEx}`;
-                }
-                if (enEx) {
-                  tooltipText += ` • EN: ${enEx}`;
-                }
-              } else if (phoneme.tip) {
-                tooltipText += ` • ${phoneme.tip}`;
-              }
-              
-              return (
-                <span
-                  key={index}
-                  className={`inline-flex items-center px-3 py-1.5 rounded-full text-sm font-medium border transition-transform hover:scale-105 ${colors.bg} ${colors.text} ${colors.border}`}
-                  title={tooltipText}
-                >
-                  {phoneme.symbol}
-                </span>
-              );
-            })}
-          </div>
-        </div>
-      ) : (
+      {(!word.phonemes || word.phonemes.length === 0) && (
         <div className="bg-gray-50 dark:bg-gray-700/50 rounded-lg p-4 border border-gray-200 dark:border-gray-600">
           <p className="text-sm text-gray-600 dark:text-gray-400 text-center">
             No phoneme data available for this word yet.

--- a/src/pipeline/sentenceWordRefs.test.ts
+++ b/src/pipeline/sentenceWordRefs.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { buildWordRefs, computeSentenceWordRefs } from './sentenceWordRefs';
+import {
+  alignUiTokensToAzureWords,
+  buildWordRefs,
+  computeSentenceWordRefs,
+} from './sentenceWordRefs';
 
 describe('sentenceWordRefs', () => {
   it('prefers longest phrase matches over single-token matches', () => {
@@ -69,6 +73,42 @@ describe('sentenceWordRefs', () => {
       { wordId: 'misc_accepts', tokenIndex: 1 },
       { wordId: 'misc_credit_card', tokenIndex: 2 },
     ]);
+  });
+
+  describe('alignUiTokensToAzureWords', () => {
+    it('splits hyphenated UI tokens into two Azure indices', () => {
+      const result = alignUiTokensToAzureWords('Preciso responder uns e-mails agora.');
+
+      expect(result.uiTokens).toEqual(['Preciso', 'responder', 'uns', 'e-mails', 'agora.']);
+      expect(result.azureIndicesPerToken).toEqual([[0], [1], [2], [3, 4], [5]]);
+    });
+
+    it('strips trailing punctuation from the Azure count', () => {
+      const result = alignUiTokensToAzureWords('Olá! Como está?');
+
+      expect(result.uiTokens).toEqual(['Olá!', 'Como', 'está?']);
+      expect(result.azureIndicesPerToken).toEqual([[0], [1], [2]]);
+    });
+
+    it('treats apostrophes as word separators', () => {
+      const result = alignUiTokensToAzureWords("d'água fria");
+
+      expect(result.azureIndicesPerToken).toEqual([[0, 1], [2]]);
+    });
+
+    it('returns an empty bucket for pure-punctuation tokens', () => {
+      const result = alignUiTokensToAzureWords('— bem.');
+
+      expect(result.uiTokens).toEqual(['—', 'bem.']);
+      expect(result.azureIndicesPerToken).toEqual([[], [0]]);
+    });
+
+    it('returns empty arrays for blank input', () => {
+      expect(alignUiTokensToAzureWords('   ')).toEqual({
+        uiTokens: [],
+        azureIndicesPerToken: [],
+      });
+    });
   });
 
   it('matches alternate surface forms to canonical words', () => {

--- a/src/pipeline/sentenceWordRefs.ts
+++ b/src/pipeline/sentenceWordRefs.ts
@@ -171,6 +171,39 @@ export function computeSentenceWordRefs(
 }
 
 /**
+ * Aligns whitespace-delimited UI tokens to the letter/number-delimited words that
+ * Azure Speech returns for the same sentence. The UI keeps punctuation and hyphens
+ * attached to a token (e.g. "e-mails"), while Azure splits on the same regex used
+ * here (/[\p{L}\p{N}]+/gu). For each UI token this returns the zero or more
+ * Azure word indices it spans, in order.
+ *
+ * Example:
+ *   alignUiTokensToAzureWords("Preciso responder uns e-mails agora.")
+ *   → { uiTokens: ["Preciso","responder","uns","e-mails","agora."],
+ *       azureIndicesPerToken: [[0],[1],[2],[3,4],[5]] }
+ */
+export function alignUiTokensToAzureWords(sentenceText: string): {
+  uiTokens: string[];
+  azureIndicesPerToken: number[][];
+} {
+  const trimmed = sentenceText.trim();
+  const uiTokens = trimmed.length === 0 ? [] : trimmed.split(/\s+/);
+  const azureIndicesPerToken: number[][] = [];
+  let azureIndex = 0;
+
+  for (const token of uiTokens) {
+    const indices: number[] = [];
+    for (const _ of token.matchAll(/[\p{L}\p{N}]+/gu)) {
+      indices.push(azureIndex);
+      azureIndex += 1;
+    }
+    azureIndicesPerToken.push(indices);
+  }
+
+  return { uiTokens, azureIndicesPerToken };
+}
+
+/**
  * Builds word references for a sentence by matching tokens to EnrichedWord entries.
  * (Legacy function, kept for backward compatibility)
  * 


### PR DESCRIPTION
- Collapse word underline and metric-bar colors from four tiers to three
  (<60 red, 60-79 yellow, >=80 green); drops the sky-blue 80-89 tier.
- Remove the phoneme pill row and its unused color helper from the Sound
  Details panel; header, per-phoneme cards, and Focus Areas remain.
- Add alignUiTokensToAzureWords in pipeline/sentenceWordRefs and use it in
  PronunciationFeedbackPanel so clicking a UI token like 'e-mails' opens
  the correct Azure-indexed word in the details panel instead of drifting
  to 'mails' / 'agora'.

https://claude.ai/code/session_01JxSaghHGqjvDcuzjZsaiAd