### PR TITLE
Fix trust-breaking pronunciation mapping mismatches in sentence practice

### DIFF
--- a/docs/debugging/lusopronounce-trust-audit.md
+++ b/docs/debugging/lusopronounce-trust-audit.md
@@ -1,0 +1,99 @@
+# LusoPronounce Trust-Breaking Bug Audit (April 22, 2026)
+
+## 1) System Map
+
+End-to-end path audited for sentence practice:
+
+1. **Sentence source / UI sentence selection**
+   - `SentencePractice`/`LivePracticeSection` supplies `sentence.textPt` as the assessment `referenceText` and for UI display.
+2. **Audio capture + submission**
+   - `useLivePronunciationPractice` records client audio and submits multipart payload to `/api/pronunciation/assessment`.
+3. **Server assessment + normalization**
+   - `src/server/routes/pronunciationAssessment.ts` converts audio, calls Azure, then maps response via `mapAzurePronunciationResultToAttemptScore`.
+4. **Attempt model / word scoring**
+   - `src/lib/pronunciationUtils.ts` maps normalized Azure words into `AttemptScore.wordScores`.
+5. **UI feedback adaptation**
+   - `adaptWordScoresToNormalized` and `extractPhonemesFromAzureResponse` enrich words + phonemes for display.
+6. **Rendering / interaction**
+   - `PronunciationFeedbackPanel` aligns sentence UI tokens to Azure-style words and routes selected token into `PhonemePanel`.
+
+## 2) Top Trust-Breaking Risks
+
+### Critical
+
+1. **Stale assessment leakage across sentence changes**
+   - Cause: `useLivePronunciationPractice` attempts persisted across sentence switches; `LivePracticeSection` only reset recording state.
+   - Impact: scores/phonemes from old sentence could appear under new sentence text.
+
+2. **Duplicate-word phoneme extraction ambiguity**
+   - Cause: adapter fallback could text-match duplicate tokens (e.g., repeated words), risking wrong phoneme payload for same surface form.
+   - Impact: user clicks one word occurrence and sees phonemes from another.
+
+### High
+
+3. **Non-deterministic low-score phoneme tips**
+   - Cause: randomized tip selection per render in `mapAzurePhonemeToNormalized`.
+   - Impact: same phoneme could show changing guidance across renders, reducing trust.
+
+### Medium
+
+4. **Limited lineage metadata from server mapping**
+   - Cause: UI had little explicit mapping metadata from Azure word index/reference token index.
+   - Impact: harder to debug misalignment regressions and less reliable downstream matching.
+
+## 3) Reproduction Cases
+
+Recommended matrix cases for manual/dev verification:
+
+- Accented vowels: `Você está ótima hoje.`
+- Nasal + tilde: `Pão e limão são bons.`
+- Digraphs / symbols: `Trabalho com chuva, carro e coração.`
+- Repeated words: `Casa da casa.`
+- Punctuation-adjacent: `Olá, tudo bem?`
+- Hyphen/apostrophe: `E-mails d'água.`
+
+For each case validate:
+
+- sentence text vs `referenceText`
+- token index clicked vs mapped Azure word index
+- phoneme panel symbols
+- native audio preview locale/voice
+- word-level score chip alignment
+
+## 4) Root Causes Found
+
+1. **State-scoping bug:** attempt state not scoped/reset on sentence transitions.
+2. **Mapping lineage gap:** phoneme extraction relied on index/text heuristics without preserved Azure index in `WordScore`.
+3. **Guidance instability:** randomized coaching text for problem phonemes.
+
+## 5) Code Changes Made
+
+- Added explicit mapping lineage fields in `WordScore`:
+  - `azureWordIndex`
+  - `referenceTokenIndex`
+- Updated Azure mapping to populate those lineage fields and use reference token count guard.
+- Updated server route to pass `referenceText` into score mapping.
+- Updated phoneme extraction adapter to prefer `azureWordIndex` and removed random tip generation.
+- Added `clearAssessmentState()` in `useLivePronunciationPractice` and invoked it on sentence change in `LivePracticeSection`.
+
+## 6) Tests Added
+
+- `src/components/pronunciation/shared/adapters.test.ts`
+  - verifies duplicate-word extraction uses `azureWordIndex`
+  - verifies low-score tip is deterministic
+- `src/lib/pronunciationUtils.test.ts`
+  - verifies `azureWordIndex`/`referenceTokenIndex` lineage mapping
+- `src/hooks/useLivePronunciationPractice.test.tsx`
+  - verifies `clearAssessmentState()` removes stale attempts/raw Azure data
+
+## 7) Remaining Risks
+
+1. **Homograph pronunciation nuance** (same spelling, contextual pronunciation) still depends on Azure phoneme output quality.
+2. **Sentence-level native audio vs per-word canonical audio** can still sound different if generated from different voice/style assets.
+3. **No explicit trust gate UI yet** (e.g., hide phoneme panel when mapping confidence low) — currently improved mapping but no confidence badge/fallback state.
+
+## 8) Release Recommendation
+
+**Safe to share with caveats.**
+
+Major trust-breaking mapping bugs (stale result leakage + duplicate-word phoneme ambiguity + randomized guidance) were fixed and regression-tested. Remaining caveats are mostly model/asset consistency and confidence signaling, not direct index miswiring.

--- a/src/components/practice/LivePracticeSection.tsx
+++ b/src/components/practice/LivePracticeSection.tsx
@@ -88,6 +88,7 @@ export default function LivePracticeSection({
     rawAzureResponse,
     submitAttempt,
     cancelAnalysis,
+    clearAssessmentState,
     dailyQuota,
   } = useLivePronunciationPractice();
 
@@ -108,7 +109,8 @@ export default function LivePracticeSection({
   // Reset recording when sentence changes (but preserve it after submission for current sentence)
   useEffect(() => {
     resetRecording();
-  }, [sentence.id, resetRecording]);
+    clearAssessmentState();
+  }, [sentence.id, resetRecording, clearAssessmentState]);
 
   // Handle submit button click
   const handleSubmit = useCallback(async () => {

--- a/src/components/pronunciation/shared/adapters.test.ts
+++ b/src/components/pronunciation/shared/adapters.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { adaptWordScoresToNormalized } from './adapters';
+import type { WordScore } from '@/types/pronunciation';
+
+describe('adaptWordScoresToNormalized', () => {
+  it('uses azureWordIndex to extract phonemes when duplicate words exist', () => {
+    const wordScores: WordScore[] = [
+      { word: 'casa', accuracy: 92, azureWordIndex: 0 },
+      { word: 'casa', accuracy: 71, azureWordIndex: 2 },
+    ];
+
+    const rawAzure = {
+      NBest: [
+        {
+          Words: [
+            {
+              Word: 'casa',
+              Phonemes: [{ Phoneme: 'k', PronunciationAssessment: { AccuracyScore: 95 } }],
+            },
+            {
+              Word: 'de',
+              Phonemes: [{ Phoneme: 'd', PronunciationAssessment: { AccuracyScore: 90 } }],
+            },
+            {
+              Word: 'casa',
+              Phonemes: [{ Phoneme: 'z', PronunciationAssessment: { AccuracyScore: 65 } }],
+            },
+          ],
+        },
+      ],
+    };
+
+    const normalized = adaptWordScoresToNormalized(wordScores, rawAzure);
+
+    expect(normalized[0].phonemes?.[0].symbol).toBe('k');
+    expect(normalized[1].phonemes?.[0].symbol).toBe('z');
+  });
+
+  it('generates deterministic phoneme tips for low-scoring sounds', () => {
+    const wordScores: WordScore[] = [{ word: 'joia', accuracy: 62, azureWordIndex: 0 }];
+    const rawAzure = {
+      NBest: [
+        {
+          Words: [
+            {
+              Word: 'joia',
+              Phonemes: [{ Phoneme: 'ʒ', PronunciationAssessment: { AccuracyScore: 52 } }],
+            },
+          ],
+        },
+      ],
+    };
+
+    const normalized = adaptWordScoresToNormalized(wordScores, rawAzure);
+
+    expect(normalized[0].phonemes?.[0].tip).toBe(
+      'Focus on the ʒ sound and slow down slightly for clarity.'
+    );
+  });
+});

--- a/src/components/pronunciation/shared/adapters.ts
+++ b/src/components/pronunciation/shared/adapters.ts
@@ -35,12 +35,7 @@ function mapAzurePhonemeToNormalized(
   
   let tip: string | undefined;
   if (isProblem) {
-    const tips = [
-      `Focus on the ${symbol} sound - try to make it clearer`,
-      `The ${symbol} sound needs more precision`,
-      `Practice the ${symbol} sound more slowly`,
-    ];
-    tip = tips[Math.floor(Math.random() * tips.length)];
+    tip = `Focus on the ${symbol} sound and slow down slightly for clarity.`;
   }
   
   return {
@@ -62,14 +57,19 @@ function mapAzurePhonemeToNormalized(
 function extractPhonemesFromAzureResponse(
   rawAzure: any,
   wordIndex: number,
-  wordText: string
+  wordText: string,
+  azureWordIndex?: number
 ): NormalizedWordFeedback['phonemes'] | undefined {
   const bestHypothesis = rawAzure?.NBest?.[0];
   const words = bestHypothesis?.Words || [];
   
-  // Prefer index lookup as wordScores are derived directly from this array.
-  // Fallback to text match if index is out of bounds (unlikely).
-  let wordData = words[wordIndex];
+  // First choice: explicit Azure index preserved in WordScore mapping.
+  // Second choice: positional fallback.
+  // Last resort: normalized text match.
+  let wordData =
+    typeof azureWordIndex === 'number'
+      ? words[azureWordIndex]
+      : words[wordIndex];
 
   if (!wordData) {
     // Fallback to text matching if index failed
@@ -141,7 +141,12 @@ export function adaptWordScoresToNormalized(
     // Extract phonemes from Azure response if available
     let phonemes: NormalizedWordFeedback['phonemes'] | undefined;
     if (rawAzure) {
-      phonemes = extractPhonemesFromAzureResponse(rawAzure, index, wordScore.word);
+      phonemes = extractPhonemesFromAzureResponse(
+        rawAzure,
+        index,
+        wordScore.word,
+        wordScore.azureWordIndex
+      );
     }
 
     return {
@@ -272,4 +277,3 @@ export function enrichWordsWithCanonicalData(
     };
   });
 }
-

--- a/src/hooks/useLivePronunciationPractice.test.tsx
+++ b/src/hooks/useLivePronunciationPractice.test.tsx
@@ -168,4 +168,29 @@ describe('useLivePronunciationPractice lifecycle', () => {
       expect(result.current.currentAttempt?.attemptId).toBe('attempt_new');
     });
   });
+
+  it('clears attempts and raw azure mapping when assessment state is reset', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(buildAssessmentResponse('attempt_to_clear'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { result } = renderHook(() => useLivePronunciationPractice());
+
+    await act(async () => {
+      await result.current.submitAttempt('sentence-1', 'ola mundo');
+    });
+
+    await waitFor(() => {
+      expect(result.current.currentAttempt?.attemptId).toBe('attempt_to_clear');
+      expect(result.current.rawAzureResponse).toBeTruthy();
+    });
+
+    act(() => {
+      result.current.clearAssessmentState();
+    });
+
+    expect(result.current.currentAttempt).toBeNull();
+    expect(result.current.attempts).toHaveLength(0);
+    expect(result.current.rawAzureResponse).toBeNull();
+    expect(['idle', 'recorded']).toContain(result.current.attemptState);
+  });
 });

--- a/src/hooks/useLivePronunciationPractice.ts
+++ b/src/hooks/useLivePronunciationPractice.ts
@@ -138,6 +138,7 @@ export type UseLivePronunciationPracticeResult = {
     logParams?: LogAttemptParams | null
   ) => Promise<void>;
   cancelAnalysis: () => void;
+  clearAssessmentState: () => void;
 };
 
 /**
@@ -234,6 +235,19 @@ export function useLivePronunciationPractice(): UseLivePronunciationPracticeResu
     setSubmitting(false);
     setError(null);
     setAttemptState('canceled');
+  }, []);
+
+  const clearAssessmentState = useCallback(() => {
+    setAttempts([]);
+    setAllRawAzureResponses(new Map());
+    setError(null);
+    setSubmitting(false);
+    setAttemptState('idle');
+    activeRequestIdRef.current = null;
+    if (abortControllerRef.current) {
+      abortControllerRef.current.abort();
+      abortControllerRef.current = null;
+    }
   }, []);
 
   /**
@@ -670,5 +684,6 @@ export function useLivePronunciationPractice(): UseLivePronunciationPracticeResu
     // Actions
     submitAttempt,
     cancelAnalysis,
+    clearAssessmentState,
   };
 }

--- a/src/lib/pronunciationUtils.test.ts
+++ b/src/lib/pronunciationUtils.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { mapAzurePronunciationResultToAttemptScore } from './pronunciationUtils';
+
+describe('mapAzurePronunciationResultToAttemptScore', () => {
+  it('preserves azureWordIndex and referenceTokenIndex for word mapping lineage', () => {
+    const rawAzure = {
+      RecognitionStatus: 'Success',
+      NBest: [
+        {
+          PronunciationAssessment: {
+            AccuracyScore: 84,
+          },
+          Words: [
+            { Word: 'Olá', PronunciationAssessment: { AccuracyScore: 80 } },
+            { Word: 'mundo', PronunciationAssessment: { AccuracyScore: 88 } },
+            { Word: 'agora', PronunciationAssessment: { AccuracyScore: 79 } },
+          ],
+        },
+      ],
+    };
+
+    const attempt = mapAzurePronunciationResultToAttemptScore(
+      rawAzure,
+      'sentence-1',
+      'attempt-1',
+      undefined,
+      'Olá, mundo!'
+    );
+
+    expect(attempt.wordScores[0]).toMatchObject({
+      azureWordIndex: 0,
+      referenceTokenIndex: 0,
+    });
+    expect(attempt.wordScores[1]).toMatchObject({
+      azureWordIndex: 1,
+      referenceTokenIndex: 1,
+    });
+    expect(attempt.wordScores[2]).toMatchObject({
+      azureWordIndex: 2,
+      referenceTokenIndex: undefined,
+    });
+  });
+});

--- a/src/lib/pronunciationUtils.ts
+++ b/src/lib/pronunciationUtils.ts
@@ -32,7 +32,8 @@ export function mapAzurePronunciationResultToAttemptScore(
   raw: any,
   sentenceId: string,
   attemptId: string,
-  audioUrl?: string
+  audioUrl?: string,
+  referenceText?: string
 ): AttemptScore {
   // Normalize the Azure response to a consistent format
   const normalized = normalizeAzurePronunciationResponse(raw);
@@ -68,16 +69,21 @@ export function mapAzurePronunciationResultToAttemptScore(
   const completeness = pronunciationAssessment.completenessScore;
   const prosody = pronunciationAssessment.prosodyScore;
 
+  const referenceTokenCount = Array.from(referenceText?.matchAll(/[\p{L}\p{N}]+/gu) ?? []).length;
+
   // Map word-level scores from normalized structure
-  const wordScores: WordScore[] = words.map((wordItem) => {
+  const wordScores: WordScore[] = words.map((wordItem, wordIndex) => {
     const wordText = wordItem.word || '';
     const wordAccuracy = wordItem.pronunciationAssessment.accuracyScore ?? 0;
     const errorType = mapAzureErrorType(wordItem.pronunciationAssessment.errorType);
+    const referenceTokenIndex = wordIndex < referenceTokenCount ? wordIndex : undefined;
 
     return {
       word: wordText,
       accuracy: wordAccuracy,
       errorType: errorType !== 'none' ? errorType : undefined,
+      azureWordIndex: wordIndex,
+      referenceTokenIndex,
     };
   });
 
@@ -93,4 +99,3 @@ export function mapAzurePronunciationResultToAttemptScore(
     audioUrl,
   };
 }
-

--- a/src/server/routes/pronunciationAssessment.ts
+++ b/src/server/routes/pronunciationAssessment.ts
@@ -573,7 +573,8 @@ async function processPronunciationAssessment(
         rawAzure,
         sentenceId,
         attemptId,
-        undefined // audioUrl - client will attach the blob URL
+        undefined, // audioUrl - client will attach the blob URL
+        referenceText
       );
     } catch (mappingError) {
       speechLog('error', 'Failed to map Azure pronunciation response', {

--- a/src/types/pronunciation.ts
+++ b/src/types/pronunciation.ts
@@ -4,6 +4,16 @@ export type WordScore = {
   word: string;
   accuracy: number; // 0-100
   errorType?: ErrorType;
+  /**
+   * Index of the word in Azure's NBest[0].Words array.
+   * Preserved to avoid re-matching by text when extracting phoneme details.
+   */
+  azureWordIndex?: number;
+  /**
+   * Index of the word-like token in the reference sentence text.
+   * Useful for mapping assessment data back to UI tokens.
+   */
+  referenceTokenIndex?: number;
   // future: startTimeMs?: number;
   // future: endTimeMs?: number;
 };
@@ -20,4 +30,3 @@ export type AttemptScore = {
   audioUrl?: string; // local blob URL for playback
   latencyMs?: number; // round-trip time for the Azure API call (ms)
 };
-


### PR DESCRIPTION
### Motivation

- Users reported phoneme guidance, native audio, and word scores could be misaligned which breaks trust in the pronunciation feedback pipeline. 
- The audit aimed to eliminate stale assessment leakage, ambiguous duplicate-word phoneme mapping, and nondeterministic guidance that could make the UI show phonemes from the wrong word or change tips between renders. 

### Description

- Add explicit lineage metadata to the assessment model by extending `WordScore` with `azureWordIndex` and `referenceTokenIndex` so server results can be traced to Azure word positions and UI tokens. 
- Populate lineage fields in `mapAzurePronunciationResultToAttemptScore` (server mapping) and wire the route to pass `referenceText` into the mapping for robust token counting. 
- Harden phoneme extraction in adapters by preferring the preserved `azureWordIndex` over text-only fallback matching, and replace randomized low-score phoneme tips with a deterministic tip message. 
- Prevent stale feedback from leaking across sentence changes by adding `clearAssessmentState()` to the `useLivePronunciationPractice` hook and invoking it when `sentence.id` changes in `LivePracticeSection`. 
- Add regression tests and an audit document at `docs/debugging/lusopronounce-trust-audit.md` describing findings, repro cases, and release guidance. 

### Testing

- Ran the focused unit/regression suite with `vitest` for the changed areas: `adapters.test.ts`, `pronunciationUtils.test.ts`, `useLivePronunciationPractice.test.tsx`, and `sentenceWordRefs.test.ts`, and all tests passed (14 tests total passed). 
- Built the client with `npm run build` to validate compilation and bundling, and the build completed successfully. 
- New tests added: `src/components/pronunciation/shared/adapters.test.ts`, `src/lib/pronunciationUtils.test.ts`, and an updated `src/hooks/useLivePronunciationPractice.test.tsx` covering clearing assessment state, duplicate-word phoneme extraction, deterministic tips, and lineage preservation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e84d95a2ac83218682c9a9e4ddbdd7)