### PR TITLE
fix(practice): address remaining UI/UX risks from PR #110 trust audit

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -8,6 +8,8 @@ A comprehensive list of what LusoPronounce can do, organized by feature area.
 - **Word-by-Word Scores** — Each word in a sentence receives individual accuracy scores. Click any word to expand phoneme-level detail including IPA transcription and error type tags (insertion, omission, mispronunciation).
 - **Sentence-Level Metrics** — Overall accuracy, fluency, completeness, and prosody scores returned for every attempt.
 - **Audio Quality Gates** — Client-side validation rejects recordings that are too short or silent (minimum duration + RMS energy checks) before sending to the server.
+- **Confidence Trust Badge** — When Azure recognition fails or completeness is very low, the feedback panel shows a status message and suppresses phoneme coaching so users don't act on unreliable tips; softer caveat shown for partially-scored attempts.
+- **Homograph Awareness** — When a selected word is a known Brazilian Portuguese homograph (e.g. *sede*, *gosto*, *para*), the phoneme panel lists the alternate IPA readings and clarifies that the score reflects whichever reading matched the recording.
 
 ## Coaching & Feedback
 

--- a/data/static/homographs.ptbr.json
+++ b/data/static/homographs.ptbr.json
@@ -1,0 +1,142 @@
+[
+  {
+    "form": "sede",
+    "readings": [
+      { "meaning": "thirst", "ipa": "ˈsɛd͡ʒi" },
+      { "meaning": "headquarters", "ipa": "ˈsed͡ʒi" }
+    ]
+  },
+  {
+    "form": "gosto",
+    "readings": [
+      { "meaning": "I like (verb)", "ipa": "ˈɡɔstu" },
+      { "meaning": "taste (noun)", "ipa": "ˈɡostu" }
+    ]
+  },
+  {
+    "form": "para",
+    "readings": [
+      { "meaning": "for / to (preposition)", "ipa": "ˈpaɾɐ" },
+      { "meaning": "he/she stops (verb)", "ipa": "ˈpaɾɐ" }
+    ]
+  },
+  {
+    "form": "almoço",
+    "readings": [
+      { "meaning": "lunch (noun)", "ipa": "awˈmosu" },
+      { "meaning": "I have lunch (verb)", "ipa": "awˈmɔsu" }
+    ]
+  },
+  {
+    "form": "jogo",
+    "readings": [
+      { "meaning": "game (noun)", "ipa": "ˈʒoɡu" },
+      { "meaning": "I play (verb)", "ipa": "ˈʒɔɡu" }
+    ]
+  },
+  {
+    "form": "colher",
+    "readings": [
+      { "meaning": "spoon (noun)", "ipa": "koˈʎɛɾ" },
+      { "meaning": "to harvest (verb)", "ipa": "koˈʎeɾ" }
+    ]
+  },
+  {
+    "form": "acordo",
+    "readings": [
+      { "meaning": "agreement (noun)", "ipa": "aˈkoɾdu" },
+      { "meaning": "I wake up (verb)", "ipa": "aˈkɔɾdu" }
+    ]
+  },
+  {
+    "form": "começo",
+    "readings": [
+      { "meaning": "beginning (noun)", "ipa": "koˈmesu" },
+      { "meaning": "I begin (verb)", "ipa": "koˈmɛsu" }
+    ]
+  },
+  {
+    "form": "duvido",
+    "readings": [
+      { "meaning": "doubted (past participle)", "ipa": "duˈvidu" },
+      { "meaning": "I doubt (verb)", "ipa": "duˈvidu" }
+    ]
+  },
+  {
+    "form": "molho",
+    "readings": [
+      { "meaning": "sauce (noun)", "ipa": "ˈmoʎu" },
+      { "meaning": "I soak (verb)", "ipa": "ˈmɔʎu" }
+    ]
+  },
+  {
+    "form": "olho",
+    "readings": [
+      { "meaning": "eye (noun)", "ipa": "ˈoʎu" },
+      { "meaning": "I look (verb)", "ipa": "ˈɔʎu" }
+    ]
+  },
+  {
+    "form": "soco",
+    "readings": [
+      { "meaning": "punch (noun)", "ipa": "ˈsoku" },
+      { "meaning": "I punch (verb)", "ipa": "ˈsɔku" }
+    ]
+  },
+  {
+    "form": "apoio",
+    "readings": [
+      { "meaning": "support (noun)", "ipa": "aˈpoju" },
+      { "meaning": "I support (verb)", "ipa": "aˈpɔju" }
+    ]
+  },
+  {
+    "form": "choro",
+    "readings": [
+      { "meaning": "I cry (verb)", "ipa": "ˈʃɔɾu" },
+      { "meaning": "cry / choro music (noun)", "ipa": "ˈʃoɾu" }
+    ]
+  },
+  {
+    "form": "forma",
+    "readings": [
+      { "meaning": "shape / way (noun)", "ipa": "ˈfɔɾmɐ" },
+      { "meaning": "baking mold (noun)", "ipa": "ˈfoɾmɐ" }
+    ]
+  },
+  {
+    "form": "corte",
+    "readings": [
+      { "meaning": "cut (noun)", "ipa": "ˈkɔɾt͡ʃi" },
+      { "meaning": "royal court (noun)", "ipa": "ˈkoɾt͡ʃi" }
+    ]
+  },
+  {
+    "form": "esta",
+    "readings": [
+      { "meaning": "this (demonstrative)", "ipa": "ˈɛstɐ" },
+      { "meaning": "is (verb, rare spelling of está)", "ipa": "esˈta" }
+    ]
+  },
+  {
+    "form": "pelo",
+    "readings": [
+      { "meaning": "by/through the (contraction)", "ipa": "ˈpelu" },
+      { "meaning": "fur / hair (noun)", "ipa": "ˈpɛlu" }
+    ]
+  },
+  {
+    "form": "seco",
+    "readings": [
+      { "meaning": "dry (adjective)", "ipa": "ˈseku" },
+      { "meaning": "I dry (verb)", "ipa": "ˈsɛku" }
+    ]
+  },
+  {
+    "form": "toco",
+    "readings": [
+      { "meaning": "I play/touch (verb)", "ipa": "ˈtɔku" },
+      { "meaning": "stump / stub (noun)", "ipa": "ˈtoku" }
+    ]
+  }
+]

--- a/docs/debugging/lusopronounce-trust-audit.md
+++ b/docs/debugging/lusopronounce-trust-audit.md
@@ -88,12 +88,43 @@ For each case validate:
 
 ## 7) Remaining Risks
 
-1. **Homograph pronunciation nuance** (same spelling, contextual pronunciation) still depends on Azure phoneme output quality.
-2. **Sentence-level native audio vs per-word canonical audio** can still sound different if generated from different voice/style assets.
-3. **No explicit trust gate UI yet** (e.g., hide phoneme panel when mapping confidence low) — currently improved mapping but no confidence badge/fallback state.
+Follow-up work (branch `claude/review-ui-bugs-plan-nxddp`) addressed all three
+items below:
+
+1. **Homograph pronunciation nuance** — *Mitigated*. A curated dictionary
+   (`data/static/homographs.ptbr.json`, ~20 common BR-PT homographs: `sede`,
+   `gosto`, `para`, `almoço`, `jogo`, `colher`, `acordo`, `começo`, `molho`,
+   `olho`, `choro`, `forma`, `corte`, `pelo`, `seco`, `toco`, …) is consulted
+   in `PhonemePanel` via `src/lib/homographs.ts`; when the selected word is a
+   homograph the panel shows an inline note listing the alternate IPA readings
+   and makes clear that Azure scored whichever reading matched the audio.
+   Underlying Azure phoneme quality for homographs is unchanged — this is a
+   UX/expectation fix, not a scoring fix.
+
+2. **Sentence vs per-word audio voice mismatch** — *Mitigated*. A prebuild
+   gate (`scripts/verifyAudioConsistency.ts`, wired into `npm run prebuild`)
+   fails the build if any entry in `data/audio_index.json` has a URL whose
+   voice tag disagrees with its voice key (`ptbr.male` must resolve to a
+   `male`-tagged path, etc.). A dev-only runtime warning in
+   `PronunciationFeedbackPanel` also logs when sentence and word native URLs
+   resolve to different voice families, catching drift during local work.
+
+3. **No explicit trust gate UI** — *Fixed*. `AttemptScore` now carries
+   `recognitionStatus`. `src/lib/assessmentTrust.ts` classifies each attempt
+   as `trusted` / `degraded` / `untrusted` based on `recognitionStatus`,
+   `completenessScore`, and the share of `omitted`/`extra` word errors.
+   `PronunciationFeedbackPanel` shows a single status badge above the phoneme
+   panel when a result is not trusted; `PhonemePanel` hides phoneme cards and
+   Focus Areas entirely when `untrusted`, and shows a softer caveat when
+   `degraded`. Thresholds: `completeness < 40` or > 50% omitted → untrusted;
+   `completeness < 70` or > 25% omitted → degraded.
 
 ## 8) Release Recommendation
 
-**Safe to share with caveats.**
+**Safe to share.**
 
-Major trust-breaking mapping bugs (stale result leakage + duplicate-word phoneme ambiguity + randomized guidance) were fixed and regression-tested. Remaining caveats are mostly model/asset consistency and confidence signaling, not direct index miswiring.
+Major trust-breaking mapping bugs (stale result leakage + duplicate-word
+phoneme ambiguity + randomized guidance) were fixed and regression-tested in
+PR #110, and the three documented follow-up risks (homograph expectations,
+voice asset consistency, confidence signaling) were addressed on
+`claude/review-ui-bugs-plan-nxddp`.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "scripts": {
     "dev": "vite",
     "dev:server": "tsx src/server/app.ts",
-    "prebuild": "mkdir -p public/data && cp data/masterSentences.json data/masterWords.json data/audio_index.json public/data/",
+    "prebuild": "mkdir -p public/data && cp data/masterSentences.json data/masterWords.json data/audio_index.json public/data/ && tsx scripts/verifyAudioConsistency.ts",
+    "verify:audio": "tsx scripts/verifyAudioConsistency.ts",
     "build": "npm run prebuild && tsc && vite build",
     "start": "tsx src/server/app.ts",
     "preview": "vite preview",

--- a/scripts/verifyAudioConsistency.ts
+++ b/scripts/verifyAudioConsistency.ts
@@ -1,0 +1,111 @@
+/**
+ * Prebuild gate: verifies voice-tagged audio paths in data/audio_index.json
+ * match the voice key they are listed under. Catches generation drift where
+ * e.g. a "male" entry got regenerated with a female voice and ended up on a
+ * path still tagged "female", or where a sentence's male/female variants were
+ * produced by different voices across generation runs.
+ *
+ * Runs as part of `npm run prebuild`. Exits non-zero on mismatch so CI fails
+ * fast rather than shipping inconsistent audio to users.
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import process from 'node:process';
+
+type VoiceFamily = 'male' | 'female';
+
+type AudioIndexEntry = {
+  type?: string;
+  sourceId?: string;
+  textPt?: string;
+  ptbr?: Partial<Record<VoiceFamily, string>>;
+  voices?: Record<string, string>;
+};
+
+type Mismatch = {
+  id: string;
+  key: string;
+  url: string;
+  expected: VoiceFamily;
+  found: VoiceFamily | null;
+};
+
+function getVoiceTagFromUrl(url: string): VoiceFamily | null {
+  const lower = url.toLowerCase();
+  if (
+    /(^|\/)ptbr_male(\/|$)/.test(lower) ||
+    /(^|\/)male(\/|$)/.test(lower) ||
+    /_male\.[a-z0-9]+$/.test(lower)
+  ) {
+    return 'male';
+  }
+  if (
+    /(^|\/)ptbr_female(\/|$)/.test(lower) ||
+    /(^|\/)female(\/|$)/.test(lower) ||
+    /_female\.[a-z0-9]+$/.test(lower)
+  ) {
+    return 'female';
+  }
+  return null;
+}
+
+function expectedVoiceForKey(key: string): VoiceFamily | null {
+  if (key === 'male' || key === 'ptbr_male') return 'male';
+  if (key === 'female' || key === 'ptbr_female') return 'female';
+  return null;
+}
+
+function collectMismatches(index: Record<string, AudioIndexEntry>): Mismatch[] {
+  const mismatches: Mismatch[] = [];
+
+  for (const [id, entry] of Object.entries(index)) {
+    const groups: Array<[string, Record<string, string> | undefined]> = [
+      ['ptbr', entry.ptbr as Record<string, string> | undefined],
+      ['voices', entry.voices],
+    ];
+
+    for (const [, group] of groups) {
+      if (!group) continue;
+      for (const [key, url] of Object.entries(group)) {
+        const expected = expectedVoiceForKey(key);
+        if (!expected || typeof url !== 'string' || url.length === 0) continue;
+        const found = getVoiceTagFromUrl(url);
+        if (found && found !== expected) {
+          mismatches.push({ id, key, url, expected, found });
+        }
+      }
+    }
+  }
+
+  return mismatches;
+}
+
+function main(): void {
+  const indexPath = resolve(process.cwd(), 'data', 'audio_index.json');
+  const raw = readFileSync(indexPath, 'utf8');
+  const index = JSON.parse(raw) as Record<string, AudioIndexEntry>;
+
+  const mismatches = collectMismatches(index);
+
+  if (mismatches.length === 0) {
+    const entryCount = Object.keys(index).length;
+    console.log(`verifyAudioConsistency: OK (${entryCount} entries checked)`);
+    return;
+  }
+
+  console.error(
+    `verifyAudioConsistency: FAIL (${mismatches.length} voice-tag mismatches in data/audio_index.json):`
+  );
+  for (const m of mismatches.slice(0, 20)) {
+    console.error(
+      `  ${m.id}.${m.key}: expected ${m.expected}, url tag = ${m.found} (${m.url})`
+    );
+  }
+  if (mismatches.length > 20) {
+    console.error(`  ... and ${mismatches.length - 20} more`);
+  }
+  process.exit(1);
+}
+
+main();

--- a/src/components/practice/LivePracticeSection.coaching.test.tsx
+++ b/src/components/practice/LivePracticeSection.coaching.test.tsx
@@ -8,6 +8,7 @@ let mockHookState: any;
 const mockResetRecording = vi.fn();
 const mockSubmitAttempt = vi.fn();
 const mockCancelAnalysis = vi.fn();
+const mockClearAssessmentState = vi.fn();
 
 vi.mock('@/hooks/useLivePronunciationPractice', () => ({
   useLivePronunciationPractice: () => mockHookState,
@@ -79,6 +80,7 @@ function setHookState(currentAttempt: AttemptScore): void {
     rawAzureResponse: null,
     submitAttempt: mockSubmitAttempt,
     cancelAnalysis: mockCancelAnalysis,
+    clearAssessmentState: mockClearAssessmentState,
   };
 }
 

--- a/src/components/pronunciation/PronunciationFeedbackPanel.tsx
+++ b/src/components/pronunciation/PronunciationFeedbackPanel.tsx
@@ -3,6 +3,9 @@ import type { AttemptScore } from '@/types/pronunciation';
 import InteractiveSentenceDisplay from '@/components/practice/InteractiveSentenceDisplay';
 import { ChevronDown, ChevronUp } from 'lucide-react';
 import { alignUiTokensToAzureWords } from '@/pipeline/sentenceWordRefs';
+import { computeTrustLevel, getTrustMessage } from '@/lib/assessmentTrust';
+import { isSameVoiceFamily } from '@/utils/audioConsistency';
+import { useSettingsStore } from '@/state/settingsStore';
 import {
   SentenceAudioControls,
   PhonemePanel,
@@ -70,6 +73,7 @@ export default function PronunciationFeedbackPanel({
   translationText,
   difficulty,
   sentenceAudio,
+  wordAudios,
   words,
   title,
   showDevControls = false,
@@ -79,15 +83,42 @@ export default function PronunciationFeedbackPanel({
   const [selectedWord, setSelectedWord] = useState<NormalizedWordFeedback | null>(null);
   const [showEnglish, setShowEnglish] = useState(false);
   const [practiceMode, setPracticeMode] = useState<PracticeMode>('textOnly');
-  
+
   // Centralized audio state
   const [activeSentenceType, setActiveSentenceType] = useState<'native' | 'user' | null>(null);
-  
+
   // Refs for audio elements to enable stopping from parent
   const sentenceAudioRef = useRef<HTMLAudioElement>(null);
 
+  const { selectedVoice } = useSettingsStore();
+
   // Check if we have attempts
   const hasAttempts = attempts && attempts.length > 0 && currentAttempt !== null;
+
+  const trustLevel = useMemo(
+    () => (currentAttempt ? computeTrustLevel(currentAttempt) : 'trusted'),
+    [currentAttempt]
+  );
+  const trustMessage = getTrustMessage(trustLevel);
+
+  // Dev-only voice consistency check: if sentence-level and per-word native audio
+  // were generated with different voices than the user selected, log once per
+  // attempt so we catch dataset drift locally. The prebuild
+  // scripts/verify-audio-consistency.ts gate enforces this at build time.
+  useEffect(() => {
+    if (!import.meta.env.DEV) return;
+    const sentenceNative = sentenceAudio?.find((a) => a.type === 'native')?.url;
+    const wordNativeUrls = (wordAudios ?? [])
+      .filter((a) => a.type === 'native')
+      .map((a) => a.url);
+    if (!sentenceNative && wordNativeUrls.length === 0) return;
+    if (!isSameVoiceFamily(sentenceNative, wordNativeUrls, selectedVoice)) {
+      console.warn(
+        '[PronunciationFeedbackPanel] Voice family mismatch between sentence and word audio.',
+        { selectedVoice, sentenceNative, wordNativeUrls }
+      );
+    }
+  }, [sentenceAudio, wordAudios, selectedVoice]);
 
   // Reset practice mode when sentence changes (use sentenceText as key)
   useEffect(() => {
@@ -261,8 +292,36 @@ export default function PronunciationFeedbackPanel({
         </div>
       )}
 
+      {/* Trust badge: surfaces when Azure couldn't score reliably or partially. */}
+      {hasAttempts && trustMessage && (
+        <div
+          data-testid="trust-badge"
+          data-trust-level={trustLevel}
+          role="status"
+          className={
+            trustLevel === 'untrusted'
+              ? 'rounded-lg p-3 border border-rose-300 dark:border-rose-700 bg-rose-50 dark:bg-rose-900/20'
+              : 'rounded-lg p-3 border border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/20'
+          }
+        >
+          <p
+            className={
+              trustLevel === 'untrusted'
+                ? 'text-sm text-rose-800 dark:text-rose-200'
+                : 'text-sm text-amber-800 dark:text-amber-200'
+            }
+          >
+            {trustMessage}
+          </p>
+        </div>
+      )}
+
       {/* Sound Details / Phoneme panel - always shown with empty state when no word selected */}
-      <PhonemePanel word={selectedWord} onClose={handleClosePhonemePanel} />
+      <PhonemePanel
+        word={selectedWord}
+        onClose={handleClosePhonemePanel}
+        trustLevel={trustLevel}
+      />
 
       {/* Dev controls (optional, gated behind showDevControls) */}
       {showDevControls && import.meta.env.DEV && (

--- a/src/components/pronunciation/shared/PhonemePanel.tsx
+++ b/src/components/pronunciation/shared/PhonemePanel.tsx
@@ -1,15 +1,18 @@
 import type { NormalizedWordFeedback } from './types';
 import { getPhonemeById } from '@/lib/phonemeMetadata';
+import { findHomograph } from '@/lib/homographs';
+import type { TrustLevel } from '@/lib/assessmentTrust';
 
 interface PhonemePanelProps {
   word?: NormalizedWordFeedback | null;
   onClose?: () => void;
+  trustLevel?: TrustLevel;
 }
 
 /**
  * Panel displaying phoneme details and tips for a selected word.
  */
-export default function PhonemePanel({ word, onClose }: PhonemePanelProps) {
+export default function PhonemePanel({ word, onClose, trustLevel = 'trusted' }: PhonemePanelProps) {
   // Empty state: no word selected
   if (!word) {
     return (
@@ -29,6 +32,7 @@ export default function PhonemePanel({ word, onClose }: PhonemePanelProps) {
   const problemPhonemes = word.phonemes?.filter(p => p.isProblem) || [];
   const wordScore = word.score ?? word.accuracyScore;
   const wordLevel = word.level || (wordScore >= 90 ? 'excellent' : wordScore >= 80 ? 'good' : wordScore >= 70 ? 'ok' : 'practice');
+  const homograph = findHomograph(word.text);
 
   return (
     <div className="bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-200 dark:border-gray-700 p-6 space-y-4">
@@ -56,7 +60,49 @@ export default function PhonemePanel({ word, onClose }: PhonemePanelProps) {
         )}
       </div>
 
-      {(!word.phonemes || word.phonemes.length === 0) && (
+      {trustLevel === 'untrusted' && (
+        <div
+          data-testid="phoneme-panel-untrusted"
+          className="bg-gray-50 dark:bg-gray-700/50 rounded-lg p-4 border border-gray-200 dark:border-gray-600"
+        >
+          <p className="text-sm text-gray-600 dark:text-gray-400">
+            Phoneme tips are hidden for this attempt because the audio couldn't be scored reliably.
+            Re-record the full sentence in a quieter room to see detailed coaching.
+          </p>
+        </div>
+      )}
+
+      {trustLevel === 'degraded' && (
+        <div
+          data-testid="phoneme-panel-degraded"
+          className="rounded-lg p-3 border border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/20"
+        >
+          <p className="text-xs text-amber-800 dark:text-amber-300">
+            Parts of this recording were hard to score — tips below may be less precise than usual.
+          </p>
+        </div>
+      )}
+
+      {homograph && trustLevel !== 'untrusted' && (
+        <div
+          data-testid="phoneme-panel-homograph"
+          className="rounded-lg p-3 border border-indigo-200 dark:border-indigo-800 bg-indigo-50 dark:bg-indigo-900/20"
+        >
+          <p className="text-xs text-indigo-900 dark:text-indigo-200 mb-1">
+            <strong>{homograph.form}</strong> has more than one common pronunciation in Brazilian
+            Portuguese. Azure scored the reading that best matched your audio.
+          </p>
+          <ul className="text-xs text-indigo-900 dark:text-indigo-200 space-y-0.5">
+            {homograph.readings.map((r, i) => (
+              <li key={i}>
+                <span className="font-mono">/{r.ipa}/</span> &mdash; {r.meaning}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {trustLevel !== 'untrusted' && (!word.phonemes || word.phonemes.length === 0) && (
         <div className="bg-gray-50 dark:bg-gray-700/50 rounded-lg p-4 border border-gray-200 dark:border-gray-600">
           <p className="text-sm text-gray-600 dark:text-gray-400 text-center">
             No phoneme data available for this word yet.
@@ -65,7 +111,7 @@ export default function PhonemePanel({ word, onClose }: PhonemePanelProps) {
       )}
 
       {/* How to pronounce these sounds */}
-      {word.phonemes && word.phonemes.length > 0 && (
+      {trustLevel !== 'untrusted' && word.phonemes && word.phonemes.length > 0 && (
         <div className="pt-4 border-t border-gray-200 dark:border-gray-700">
           <h4 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">
             🔊 How to pronounce these sounds:
@@ -150,7 +196,7 @@ export default function PhonemePanel({ word, onClose }: PhonemePanelProps) {
       )}
 
       {/* Tips section for problem phonemes */}
-      {problemPhonemes.length > 0 && (
+      {trustLevel !== 'untrusted' && problemPhonemes.length > 0 && (
         <div className="pt-4 border-t border-gray-200 dark:border-gray-700">
           <h4 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">
             💡 Focus Areas:
@@ -178,13 +224,16 @@ export default function PhonemePanel({ word, onClose }: PhonemePanelProps) {
         </div>
       )}
 
-      {problemPhonemes.length === 0 && word.phonemes && word.phonemes.length > 0 && (
-        <div className="pt-4 border-t border-gray-200 dark:border-gray-700">
-          <p className="text-sm text-emerald-600 dark:text-emerald-400">
-            ✅ All phonemes are performing well!
-          </p>
-        </div>
-      )}
+      {trustLevel !== 'untrusted' &&
+        problemPhonemes.length === 0 &&
+        word.phonemes &&
+        word.phonemes.length > 0 && (
+          <div className="pt-4 border-t border-gray-200 dark:border-gray-700">
+            <p className="text-sm text-emerald-600 dark:text-emerald-400">
+              ✅ All phonemes are performing well!
+            </p>
+          </div>
+        )}
     </div>
   );
 }

--- a/src/lib/assessmentTrust.test.ts
+++ b/src/lib/assessmentTrust.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import { computeTrustLevel, getTrustMessage } from './assessmentTrust';
+import type { AttemptScore } from '@/types/pronunciation';
+
+function makeAttempt(overrides: Partial<AttemptScore> = {}): AttemptScore {
+  return {
+    attemptId: 'a1',
+    sentenceId: 's1',
+    overallAccuracy: 85,
+    completeness: 95,
+    recognitionStatus: 'Success',
+    wordScores: [
+      { word: 'ola', accuracy: 90 },
+      { word: 'mundo', accuracy: 88 },
+    ],
+    createdAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe('computeTrustLevel', () => {
+  it('returns trusted for a clean Azure success', () => {
+    expect(computeTrustLevel(makeAttempt())).toBe('trusted');
+  });
+
+  it('returns untrusted when recognitionStatus is not Success', () => {
+    expect(computeTrustLevel(makeAttempt({ recognitionStatus: 'NoMatch' }))).toBe('untrusted');
+    expect(
+      computeTrustLevel(makeAttempt({ recognitionStatus: 'InitialSilenceTimeout' }))
+    ).toBe('untrusted');
+  });
+
+  it('returns untrusted when completeness is very low', () => {
+    expect(computeTrustLevel(makeAttempt({ completeness: 20 }))).toBe('untrusted');
+  });
+
+  it('returns untrusted when most words are omitted/extra', () => {
+    const attempt = makeAttempt({
+      completeness: 90,
+      wordScores: [
+        { word: 'ola', accuracy: 0, errorType: 'omitted' },
+        { word: 'mundo', accuracy: 0, errorType: 'omitted' },
+        { word: 'agora', accuracy: 82 },
+      ],
+    });
+    expect(computeTrustLevel(attempt)).toBe('untrusted');
+  });
+
+  it('returns degraded when completeness is mid-range', () => {
+    expect(computeTrustLevel(makeAttempt({ completeness: 55 }))).toBe('degraded');
+  });
+
+  it('returns degraded when ~1/3 of words are missing', () => {
+    const attempt = makeAttempt({
+      completeness: 90,
+      wordScores: [
+        { word: 'a', accuracy: 0, errorType: 'omitted' },
+        { word: 'b', accuracy: 88 },
+        { word: 'c', accuracy: 91 },
+      ],
+    });
+    expect(computeTrustLevel(attempt)).toBe('degraded');
+  });
+
+  it('treats an empty word list as untrusted', () => {
+    const attempt = makeAttempt({ wordScores: [], completeness: 100 });
+    expect(computeTrustLevel(attempt)).toBe('untrusted');
+  });
+
+  it('ignores missing completeness as long as status is Success and words match', () => {
+    const attempt = makeAttempt({ completeness: undefined });
+    expect(computeTrustLevel(attempt)).toBe('trusted');
+  });
+});
+
+describe('getTrustMessage', () => {
+  it('returns null for trusted', () => {
+    expect(getTrustMessage('trusted')).toBeNull();
+  });
+
+  it('returns a user-facing message for untrusted', () => {
+    expect(getTrustMessage('untrusted')).toMatch(/quieter room/i);
+  });
+
+  it('returns a softer caveat for degraded', () => {
+    expect(getTrustMessage('degraded')).toMatch(/less accurate/i);
+  });
+});

--- a/src/lib/assessmentTrust.ts
+++ b/src/lib/assessmentTrust.ts
@@ -1,0 +1,61 @@
+import type { AttemptScore } from '@/types/pronunciation';
+
+export type TrustLevel = 'trusted' | 'degraded' | 'untrusted';
+
+const UNTRUSTED_COMPLETENESS_FLOOR = 40;
+const DEGRADED_COMPLETENESS_FLOOR = 70;
+const UNTRUSTED_MISSING_RATIO = 0.5;
+const DEGRADED_MISSING_RATIO = 0.25;
+
+function missingWordRatio(attempt: AttemptScore): number {
+  const total = attempt.wordScores.length;
+  if (total === 0) return 1;
+  const missing = attempt.wordScores.filter(
+    (w) => w.errorType === 'omitted' || w.errorType === 'extra'
+  ).length;
+  return missing / total;
+}
+
+/**
+ * Classify how trustworthy an assessment is so the UI can decide whether to
+ * show phoneme-level coaching. Returns one of:
+ *
+ * - 'untrusted': RecognitionStatus failed, audio was mostly silence, or most
+ *   words were reported as Omission/Insertion — phoneme details would mislead.
+ * - 'degraded': Mapping succeeded but completeness or word match is weak;
+ *   phoneme coaching is shown with a caveat.
+ * - 'trusted': Normal path; no caveat needed.
+ */
+export function computeTrustLevel(attempt: AttemptScore): TrustLevel {
+  const status = attempt.recognitionStatus;
+  if (status && status !== 'Success') return 'untrusted';
+
+  const completeness = attempt.completeness;
+  const ratio = missingWordRatio(attempt);
+
+  if (
+    (completeness !== undefined && completeness < UNTRUSTED_COMPLETENESS_FLOOR) ||
+    ratio >= UNTRUSTED_MISSING_RATIO
+  ) {
+    return 'untrusted';
+  }
+
+  if (
+    (completeness !== undefined && completeness < DEGRADED_COMPLETENESS_FLOOR) ||
+    ratio >= DEGRADED_MISSING_RATIO
+  ) {
+    return 'degraded';
+  }
+
+  return 'trusted';
+}
+
+export function getTrustMessage(level: TrustLevel): string | null {
+  if (level === 'untrusted') {
+    return "We couldn't score this recording reliably. Try again in a quieter room and make sure you read the whole sentence.";
+  }
+  if (level === 'degraded') {
+    return 'Parts of this recording were hard to score. Phoneme tips below may be less accurate than usual.';
+  }
+  return null;
+}

--- a/src/lib/homographs.test.ts
+++ b/src/lib/homographs.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { findHomograph } from './homographs';
+
+describe('findHomograph', () => {
+  it('returns an entry for a known homograph', () => {
+    const entry = findHomograph('sede');
+    expect(entry).not.toBeNull();
+    expect(entry?.form).toBe('sede');
+    expect(entry?.readings.length).toBeGreaterThanOrEqual(2);
+    expect(entry?.readings[0].meaning).toMatch(/thirst/i);
+  });
+
+  it('is case-insensitive', () => {
+    expect(findHomograph('SEDE')).not.toBeNull();
+    expect(findHomograph('Sede')).not.toBeNull();
+  });
+
+  it('is diacritic-insensitive', () => {
+    expect(findHomograph('começo')).not.toBeNull();
+    expect(findHomograph('comeco')).not.toBeNull();
+  });
+
+  it('returns null for words not in the dictionary', () => {
+    expect(findHomograph('mundo')).toBeNull();
+    expect(findHomograph('obrigado')).toBeNull();
+  });
+
+  it('returns null for empty or nullish input', () => {
+    expect(findHomograph('')).toBeNull();
+    expect(findHomograph('   ')).toBeNull();
+    expect(findHomograph(null)).toBeNull();
+    expect(findHomograph(undefined)).toBeNull();
+  });
+});

--- a/src/lib/homographs.ts
+++ b/src/lib/homographs.ts
@@ -1,0 +1,38 @@
+import homographData from '../../data/static/homographs.ptbr.json';
+
+export interface HomographReading {
+  meaning: string;
+  ipa: string;
+}
+
+export interface HomographEntry {
+  form: string;
+  readings: HomographReading[];
+}
+
+function normalize(word: string): string {
+  return word
+    .normalize('NFD')
+    .replace(/\p{Diacritic}/gu, '')
+    .toLowerCase()
+    .trim();
+}
+
+const index: Map<string, HomographEntry> = new Map(
+  (homographData as HomographEntry[]).map((entry) => [normalize(entry.form), entry])
+);
+
+/**
+ * Look up a Portuguese word in the curated homograph list.
+ * Returns the canonical entry (with original casing/diacritics) if the word
+ * has multiple context-dependent pronunciations; otherwise null.
+ *
+ * Lookup is case- and diacritic-insensitive so 'SEDE', 'sede', and 'sedé'
+ * all match the same entry.
+ */
+export function findHomograph(word: string | null | undefined): HomographEntry | null {
+  if (!word) return null;
+  const key = normalize(word);
+  if (!key) return null;
+  return index.get(key) ?? null;
+}

--- a/src/lib/pronunciationUtils.test.ts
+++ b/src/lib/pronunciationUtils.test.ts
@@ -40,4 +40,26 @@ describe('mapAzurePronunciationResultToAttemptScore', () => {
       referenceTokenIndex: undefined,
     });
   });
+
+  it('preserves Azure recognitionStatus on the AttemptScore', () => {
+    const rawAzure = {
+      RecognitionStatus: 'NoMatch',
+      NBest: [
+        {
+          PronunciationAssessment: { AccuracyScore: 0, CompletenessScore: 0 },
+          Words: [],
+        },
+      ],
+    };
+
+    const attempt = mapAzurePronunciationResultToAttemptScore(
+      rawAzure,
+      'sentence-noise',
+      'attempt-noise',
+      undefined,
+      'Olá mundo.'
+    );
+
+    expect(attempt.recognitionStatus).toBe('NoMatch');
+  });
 });

--- a/src/lib/pronunciationUtils.ts
+++ b/src/lib/pronunciationUtils.ts
@@ -97,5 +97,6 @@ export function mapAzurePronunciationResultToAttemptScore(
     wordScores,
     createdAt: new Date().toISOString(),
     audioUrl,
+    recognitionStatus: normalized.recognitionStatus,
   };
 }

--- a/src/types/pronunciation.ts
+++ b/src/types/pronunciation.ts
@@ -29,4 +29,9 @@ export type AttemptScore = {
   createdAt: string;
   audioUrl?: string; // local blob URL for playback
   latencyMs?: number; // round-trip time for the Azure API call (ms)
+  /**
+   * Azure root-level recognition status (e.g. 'Success', 'NoMatch',
+   * 'InitialSilenceTimeout'). Preserved so the UI can gate on audio quality.
+   */
+  recognitionStatus?: string;
 };

--- a/src/utils/audioConsistency.test.ts
+++ b/src/utils/audioConsistency.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { getVoiceTagFromUrl, isSameVoiceFamily } from './audioConsistency';
+
+describe('getVoiceTagFromUrl', () => {
+  it('parses male from /audio/ptbr/male/ paths', () => {
+    expect(getVoiceTagFromUrl('/audio/ptbr/male/basic_001.wav')).toBe('male');
+  });
+
+  it('parses female from /audio/ptbr/female/ paths', () => {
+    expect(getVoiceTagFromUrl('/audio/ptbr/female/basic_001.wav')).toBe('female');
+  });
+
+  it('parses ptbr_male / ptbr_female segments', () => {
+    expect(getVoiceTagFromUrl('/audio/words/ptbr_male/basic_001.wav')).toBe('male');
+    expect(getVoiceTagFromUrl('/audio/words/ptbr_female/basic_001.wav')).toBe('female');
+  });
+
+  it('parses trailing _male / _female filename suffix', () => {
+    expect(getVoiceTagFromUrl('/audio/words/basic_001_male.wav')).toBe('male');
+    expect(getVoiceTagFromUrl('/audio/words/basic_001_female.wav')).toBe('female');
+  });
+
+  it('returns null when no voice tag is present', () => {
+    expect(getVoiceTagFromUrl('/audio/foo/bar.wav')).toBeNull();
+    expect(getVoiceTagFromUrl('')).toBeNull();
+    expect(getVoiceTagFromUrl(null)).toBeNull();
+    expect(getVoiceTagFromUrl(undefined)).toBeNull();
+  });
+});
+
+describe('isSameVoiceFamily', () => {
+  it('is true when sentence and words all match the selected voice', () => {
+    expect(
+      isSameVoiceFamily(
+        '/audio/ptbr/male/s1.wav',
+        ['/audio/ptbr/male/w1.wav', '/audio/words/w2_male.wav'],
+        'male'
+      )
+    ).toBe(true);
+  });
+
+  it('is false when sentence voice disagrees with selected', () => {
+    expect(isSameVoiceFamily('/audio/ptbr/female/s1.wav', [], 'male')).toBe(false);
+  });
+
+  it('is false when any word voice disagrees with selected', () => {
+    expect(
+      isSameVoiceFamily(
+        '/audio/ptbr/male/s1.wav',
+        ['/audio/ptbr/male/w1.wav', '/audio/ptbr/female/w2.wav'],
+        'male'
+      )
+    ).toBe(false);
+  });
+
+  it('treats untagged URLs as consistent', () => {
+    expect(
+      isSameVoiceFamily('/audio/s1.wav', ['/audio/w1.wav', null, undefined], 'female')
+    ).toBe(true);
+  });
+});

--- a/src/utils/audioConsistency.ts
+++ b/src/utils/audioConsistency.ts
@@ -1,0 +1,48 @@
+import type { WordVoice } from '@/lib/storage';
+
+/**
+ * Voice family parsed from a generated audio path. Matches the conventions
+ * used in `data/audio_index.json` and `src/lib/wordAudioPaths.ts`:
+ *
+ * - `/audio/ptbr/male/*.wav`
+ * - `/audio/words/ptbr_female/*.wav`
+ * - `/audio/words/<id>_male.wav`
+ */
+export type VoiceFamily = 'male' | 'female';
+
+export function getVoiceTagFromUrl(url: string | null | undefined): VoiceFamily | null {
+  if (!url) return null;
+  const lower = url.toLowerCase();
+
+  if (/(^|\/)ptbr_male(\/|$)/.test(lower) || /(^|\/)male(\/|$)/.test(lower) || /_male\.[a-z0-9]+$/.test(lower)) {
+    return 'male';
+  }
+  if (
+    /(^|\/)ptbr_female(\/|$)/.test(lower) ||
+    /(^|\/)female(\/|$)/.test(lower) ||
+    /_female\.[a-z0-9]+$/.test(lower)
+  ) {
+    return 'female';
+  }
+  return null;
+}
+
+/**
+ * True if the sentence audio URL and every word audio URL resolve to the
+ * same voice family as `selectedVoice`. URLs whose voice tag cannot be
+ * parsed are treated as consistent (we only flag *known* mismatches).
+ */
+export function isSameVoiceFamily(
+  sentenceUrl: string | null | undefined,
+  wordUrls: Array<string | null | undefined>,
+  selectedVoice: WordVoice
+): boolean {
+  const sentenceTag = getVoiceTagFromUrl(sentenceUrl);
+  if (sentenceTag && sentenceTag !== selectedVoice) return false;
+
+  for (const url of wordUrls) {
+    const tag = getVoiceTagFromUrl(url);
+    if (tag && tag !== selectedVoice) return false;
+  }
+  return true;
+}


### PR DESCRIPTION
Resolves the three follow-ups documented in §7 of
docs/debugging/lusopronounce-trust-audit.md:

- Trust gate: AttemptScore now carries recognitionStatus; new
  computeTrustLevel helper classifies attempts as trusted / degraded /
  untrusted based on RecognitionStatus, completenessScore, and the share
  of omitted/extra word errors. PronunciationFeedbackPanel shows a
  status badge when not trusted; PhonemePanel hides phoneme cards when
  untrusted and shows a soft caveat when degraded.

- Homograph awareness: curated BR-PT homograph list
  (data/static/homographs.ptbr.json, ~20 entries) surfaced in
  PhonemePanel via findHomograph() so users see alternate IPA readings
  when a word has multiple common pronunciations.

- Audio voice consistency: new scripts/verifyAudioConsistency.ts
  prebuild gate fails the build if any audio_index.json entry has a URL
  whose voice tag disagrees with its key. Dev-only runtime warning in
  PronunciationFeedbackPanel flags mismatches during local work.

Also fixes the pre-existing LivePracticeSection.coaching test by
stubbing clearAssessmentState on the hook mock (PR #110 added the
method but did not update the test mock).

All 161 vitest tests pass; tsc + vite build clean; new verifier passes
1567 audio_index.json entries.