### PR TITLE
feat(analytics): build Progress Analytics dashboard

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -56,7 +56,13 @@ A comprehensive list of what LusoPronounce can do, organized by feature area.
 
 ## Progress & Review
 
-- **Progress Page** — Lightweight page with three hero metrics (today's practice time, current streak, items due for review), a weekly trend chart, and top weak phonemes with action links.
+- **Progress Analytics Dashboard** — A sectioned Progress page (Overview, Progress, Strengths, Focus Areas, Recommendations, Learning Resources) answering "Am I improving?" and "What should I practice next?" with a sticky in-page nav.
+- **Score Trends** — Multi-metric trend chart (pronunciation, accuracy, fluency, completeness) with selectable 7-day / 30-day / 90-day / all-time windows.
+- **Improvement Tracking** — "Most Improved" and "Needs More Practice" lists for words, phrases, and phonemes, comparing earlier attempts to recent ones (e.g. `pão 72 → 91`), with a noise guard that requires several attempts.
+- **Weakness Detection** — Hardest sounds, frequently mispronounced words, and most-retried phrases surfaced from stored assessment data.
+- **Personalized Insights** — Deterministic, data-grounded insights (e.g. nasal vowels below your average, better on short than long phrases, scores improving with repetition).
+- **Practice Recommendations** — Recommended sounds, words, and phrases grounded in real content and your own weaknesses, each linking to the relevant practice surface.
+- **Learning Resources** — Click any difficult sound or word to open pronunciation tutorials; resource links are generated dynamically (YouTube search + Forvo) with no manual video curation or API key required.
 - **Review Page** — Tabbed interface with a Review Queue (SRS-driven items) and Recent Attempts timeline. Queue shows progress bar and item-by-item navigation with difficulty rating. Attempts list shows scores with "Practice again" links.
 - **Review Queue Algorithm** — Score-weighted review queue (`buildReviewQueue`) ranks items by `(1 - bestScore/100) * recencyWeight`, filtering items below a configurable threshold (default 80).
 - **Completion Moments** — Animated confirmation when the review queue is cleared, linking back to practice.

--- a/docs/architecture/analytics-pipeline.md
+++ b/docs/architecture/analytics-pipeline.md
@@ -1,0 +1,117 @@
+# Progress Analytics Pipeline
+
+LusoPronunciation uses Azure Speech Pronunciation Assessment to evaluate pronunciation
+accuracy, fluency, completeness, and phoneme-level performance. Historical assessment
+data is analyzed to identify weaknesses, track improvement, and generate personalized
+practice recommendations and learning resources. This document describes how that
+pipeline works end to end.
+
+## Speech assessment pipeline
+
+1. **Microphone recording** — The client records audio via `MediaRecorder`
+   (`useMicrophoneRecorder`, driven by `useLivePronunciationPractice`). Audio-quality
+   gates (`src/lib/audioQuality.ts`) reject clips that are too short or silent.
+2. **Audio processing** — The server converts WebM/Opus to 16 kHz / 16-bit mono WAV
+   (`src/server/lib/audioConversion.ts`, ffmpeg-static).
+3. **Azure Pronunciation Assessment** — The WAV is sent to Azure with
+   `Granularity: Word` and `Dimension: Comprehensive`
+   (`src/server/routes/pronunciationAssessment.ts`). Azure returns phrase-, word-, and
+   phoneme-level scores.
+4. **Scoring & normalization** — Responses are normalized
+   (`src/lib/azurePronunciationNormalizer.ts`) and mapped to internal scores
+   (`src/lib/pronunciationUtils.ts`).
+5. **Persistence** — Each attempt is stored with phrase scores (overall / accuracy /
+   fluency / completeness / optional prosody), `wordScores[]` (with `errorType`), and
+   `phonemeScores[{phonemeId, overallScore}]`, plus `createdAt`, `retriesInThisSession`,
+   and content references. Storage is dual-write: `localStorage` (offline source of
+   truth) via `practiceLogStore`, and MongoDB (`PronunciationAttemptModel`).
+6. **Analytics generation** — All analytics are computed **client-side** from the
+   practice log by the pure functions in `src/lib/practiceAnalytics.ts`. No additional
+   backend aggregation is required because the full per-attempt history (including
+   phoneme scores) is already available to the client.
+7. **Recommendation & resource generation** — Weaknesses are mapped to existing content
+   and to learning resources (see below).
+
+## Analytics features
+
+All computation lives in `src/lib/practiceAnalytics.ts` (pure, unit-tested) and is
+rendered by the section components under `src/components/analytics/`. The Progress page
+(`src/pages/ProgressPage.tsx`) owns the data computations and passes results to
+presentational sections.
+
+### Score tracking
+
+- `filterByWindow(items, window, now?)` filters any timestamped list to a 7d / 30d / 90d
+  window (inclusive cutoff) or passes everything through for `all`.
+- `buildMultiMetricTrend(...)` buckets attempts over the window (daily for short windows,
+  weekly/monthly for longer ones) and collects raw scores per metric. The chart
+  (`MultiMetricTrendChart`) averages each bucket and plots only buckets that contain data,
+  so no-practice gaps collapse rather than dipping the line to zero.
+
+### Improvement tracking
+
+- `computeImprovement(...)` groups attempts by word, sentence, and phoneme, sorts each
+  group chronologically, and compares the **earlier half** of attempts to the **recent
+  half** (`delta = recentAvg - earlyAvg`).
+- **Noise guard:** an item must have at least `minAttempts` attempts (default 4) — and
+  optionally span `minSpanDays` days — to appear in either list. This prevents one or two
+  lucky attempts from dominating "Most Improved".
+- "Most Improved" = positive delta above a small threshold, sorted descending. "Needs More
+  Practice" = low recent average or a non-positive delta.
+
+### Weakness detection
+
+- `computePhonemeStats(...)` aggregates per-phoneme scores and labels each weak / ok /
+  strong. The dashboard surfaces the weakest sounds, the most frequently mispronounced
+  words (from sentence `wordScores` with `errorType: mispronounced` or low scores), and the
+  most-retried phrases (`retriesInThisSession` plus repeated attempts).
+
+### Personalized recommendations
+
+- `generateInsights(...)` runs a **fixed, ordered set of rules**, each guarded by a
+  minimum-sample check, so output is fully deterministic for a given input (no randomness;
+  `now` is injectable). Rules cover phoneme-category vs. personal average, short vs. long
+  phrases, improvement-with-repetition, the easy-vs-hard difficulty gradient, and
+  window momentum. Deterministic analytics are preferred over LLM-generated text.
+- `buildRecommendations(...)` ranks weak phonemes, weak words, and low-scoring phrases,
+  and maps them to **real content** (`loadAllWords` / `loadAllSentences`), so every
+  recommendation points to an item that exists and links to the right practice surface.
+
+### Learning resource integration
+
+- `src/lib/learningResources.ts` resolves a phoneme or word to pronunciation tutorials.
+  It always generates a deterministic YouTube **search** URL (and a Forvo link for words),
+  so every difficult sound/word has a working "learn more" link with **no manual video
+  curation and no API key**. A small optional `CURATED_*` override map pins durable
+  reference pages (e.g. Wikipedia's Portuguese phonology) for the hardest sounds; because
+  it links to reference pages rather than specific videos, it does not rot.
+
+#### Why this approach
+
+We evaluated three options for tutorial videos:
+
+- **A — Dynamic search URLs (chosen):** zero maintenance, no API key, always relevant,
+  fully deterministic and testable. Trade-off: links to a results page, not a single
+  vetted video.
+- **B — Curated database:** highest quality control, but requires ongoing manual curation
+  and links rot over time. Retained only as the tiny optional override map.
+- **C — AI-generated recommendations:** non-deterministic, adds latency/cost and an
+  external dependency; conflicts with the "prefer deterministic analytics" goal.
+
+## Resume / portfolio summary
+
+> LusoPronunciation uses Azure Speech Pronunciation Assessment to evaluate pronunciation
+> accuracy, fluency, completeness, and phoneme-level performance. Historical assessment
+> data is analyzed to identify weaknesses, track improvement over time, and generate
+> personalized, deterministic practice recommendations and learning resources —
+> demonstrating an end-to-end speech-AI analytics and human-in-the-loop feedback system.
+
+## Testing
+
+Pure analytics and resource functions are unit-tested (Vitest):
+
+- `src/lib/practiceAnalytics.test.ts` — window filtering boundaries, trend bucketing and
+  optional-metric handling, improvement thresholds / early-recent split / topN caps,
+  insight determinism, and recommendation grounding.
+- `src/lib/learningResources.test.ts` — curated-then-generated ordering, fallback for
+  unknown phonemes, and URL escaping.

--- a/src/components/analytics/AnalyticsTabs.tsx
+++ b/src/components/analytics/AnalyticsTabs.tsx
@@ -1,0 +1,39 @@
+interface AnalyticsTabsProps {
+  /** Section ids that are actually rendered, in display order. */
+  sections: string[];
+}
+
+const SECTION_LABELS: Record<string, string> = {
+  overview: 'Overview',
+  progress: 'Progress',
+  strengths: 'Strengths',
+  focus: 'Focus Areas',
+  recommendations: 'Recommendations',
+  resources: 'Resources',
+};
+
+/**
+ * Sticky, horizontally scrollable in-page navigation that jumps to dashboard sections.
+ * Uses anchor links + CSS smooth scrolling (scroll-mt on each section), so it works on
+ * mobile and desktop with no router changes.
+ */
+export default function AnalyticsTabs({ sections }: AnalyticsTabsProps) {
+  return (
+    <nav
+      className="sticky top-0 z-10 -mx-4 px-4 sm:mx-0 sm:px-0 bg-white/90 dark:bg-gray-900/90 backdrop-blur border-b border-gray-200 dark:border-gray-800"
+      aria-label="Analytics sections"
+    >
+      <div className="flex gap-1 overflow-x-auto py-2 scrollbar-none">
+        {sections.map((id) => (
+          <a
+            key={id}
+            href={`#${id}`}
+            className="shrink-0 px-3 py-1.5 text-sm font-medium rounded-md text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-900 dark:hover:text-gray-100 transition-colors"
+          >
+            {SECTION_LABELS[id] ?? id}
+          </a>
+        ))}
+      </div>
+    </nav>
+  );
+}

--- a/src/components/analytics/FocusAreasSection.tsx
+++ b/src/components/analytics/FocusAreasSection.tsx
@@ -1,0 +1,165 @@
+import { Link } from 'react-router-dom';
+import { AlertTriangle } from 'lucide-react';
+import type { ImprovementItem, PhonemeStats } from '@/lib/types';
+import { getPhonemeById } from '@/lib/phonemeMetadata';
+import ImprovementRow from './ImprovementRow';
+import { resolveItemLabel } from './itemLabels';
+
+export interface MispronouncedWord {
+  token: string;
+  count: number;
+}
+
+export interface RetriedPhrase {
+  id: string;
+  label: string;
+  retries: number;
+}
+
+interface FocusAreasSectionProps {
+  weakPhonemes: PhonemeStats[];
+  needsPractice: ImprovementItem[];
+  mispronouncedWords: MispronouncedWord[];
+  retriedPhrases: RetriedPhrase[];
+  wordLabels: Map<string, string>;
+  sentenceLabels: Map<string, string>;
+}
+
+/**
+ * Focus Areas: weakest sounds, items that need more practice, frequently mispronounced
+ * words, and phrases that were repeatedly retried.
+ */
+export default function FocusAreasSection({
+  weakPhonemes,
+  needsPractice,
+  mispronouncedWords,
+  retriedPhrases,
+  wordLabels,
+  sentenceLabels,
+}: FocusAreasSectionProps) {
+  const hasData =
+    weakPhonemes.length > 0 ||
+    needsPractice.length > 0 ||
+    mispronouncedWords.length > 0 ||
+    retriedPhrases.length > 0;
+
+  return (
+    <section id="focus" className="card scroll-mt-20">
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center gap-2">
+          <AlertTriangle size={18} className="text-amber-500 dark:text-amber-400" />
+          <h2 className="text-xl font-bold text-gray-900 dark:text-gray-100">Focus Areas</h2>
+        </div>
+        <Link
+          to="/review"
+          className="text-sm text-primary-600 dark:text-primary-400 hover:underline"
+        >
+          Review weak items
+        </Link>
+      </div>
+
+      {!hasData ? (
+        <p className="text-sm text-gray-500 dark:text-gray-400 py-4">
+          No problem areas detected yet. Practice more to surface the sounds, words, and
+          phrases worth extra attention.
+        </p>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          {weakPhonemes.length > 0 && (
+            <div>
+              <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2">
+                Hardest Sounds
+              </h3>
+              <div className="space-y-2">
+                {weakPhonemes.map((p) => {
+                  const meta = getPhonemeById(p.phonemeId);
+                  return (
+                    <div
+                      key={p.phonemeId}
+                      className="flex items-center justify-between p-3 bg-gray-50 dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700"
+                    >
+                      <div>
+                        <span className="font-mono text-sm font-medium text-gray-900 dark:text-gray-100">
+                          {meta?.ipa ?? p.phonemeId}
+                        </span>
+                        <span className="text-xs text-gray-500 dark:text-gray-400 ml-2">
+                          {p.attempts} reps
+                        </span>
+                      </div>
+                      <span className="text-sm font-semibold text-red-600 dark:text-red-400">
+                        {Math.round(p.avgOverallScore ?? 0)}
+                      </span>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+
+          {needsPractice.length > 0 && (
+            <div>
+              <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2">
+                Needs More Practice
+              </h3>
+              <div className="space-y-2">
+                {needsPractice.map((item) => (
+                  <ImprovementRow
+                    key={`${item.kind}-${item.id}`}
+                    item={item}
+                    label={resolveItemLabel(item, wordLabels, sentenceLabels)}
+                    showAsRegression={item.delta <= 0}
+                  />
+                ))}
+              </div>
+            </div>
+          )}
+
+          {mispronouncedWords.length > 0 && (
+            <div>
+              <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2">
+                Frequently Mispronounced Words
+              </h3>
+              <div className="flex flex-wrap gap-2">
+                {mispronouncedWords.map((w) => (
+                  <span
+                    key={w.token}
+                    className="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-300 border border-red-200 dark:border-red-800"
+                  >
+                    {w.token}
+                    <span className="text-red-400 dark:text-red-500">×{w.count}</span>
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {retriedPhrases.length > 0 && (
+            <div>
+              <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2">
+                Most Retried Phrases
+              </h3>
+              <div className="space-y-2">
+                {retriedPhrases.map((phrase) => (
+                  <div
+                    key={phrase.id}
+                    className="flex items-center justify-between gap-3 p-3 bg-gray-50 dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700"
+                  >
+                    <span
+                      className="truncate text-sm text-gray-900 dark:text-gray-100"
+                      title={phrase.label}
+                    >
+                      {phrase.label}
+                    </span>
+                    <span className="shrink-0 text-xs font-medium text-amber-600 dark:text-amber-400">
+                      {phrase.retries} retries
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/analytics/ImprovementRow.tsx
+++ b/src/components/analytics/ImprovementRow.tsx
@@ -1,0 +1,54 @@
+import type { ImprovementItem } from '@/lib/types';
+import { KIND_LABEL } from './itemLabels';
+
+interface ImprovementRowProps {
+  item: ImprovementItem;
+  label: string;
+  /** When true, show the delta in red (regression) instead of green. */
+  showAsRegression?: boolean;
+}
+
+/**
+ * A single row in a Most-Improved / Needs-Practice list: kind chip, label,
+ * early→recent score transition, and signed delta.
+ */
+export default function ImprovementRow({ item, label, showAsRegression }: ImprovementRowProps) {
+  const early = Math.round(item.earlyAvg);
+  const recent = Math.round(item.recentAvg);
+  const delta = Math.round(item.delta);
+  const improved = delta > 0;
+  const deltaColor =
+    showAsRegression || delta < 0
+      ? 'text-red-600 dark:text-red-400'
+      : 'text-green-600 dark:text-green-400';
+
+  return (
+    <div className="flex items-center justify-between gap-3 p-3 bg-gray-50 dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700">
+      <div className="min-w-0">
+        <div className="flex items-center gap-2">
+          <span className="text-[10px] uppercase tracking-wide font-semibold text-gray-400 dark:text-gray-500">
+            {KIND_LABEL[item.kind]}
+          </span>
+          <span
+            className={`truncate text-sm font-medium text-gray-900 dark:text-gray-100 ${item.kind === 'phoneme' ? 'font-mono' : ''}`}
+            title={label}
+          >
+            {label}
+          </span>
+        </div>
+        <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+          {item.attempts} attempts
+        </p>
+      </div>
+      <div className="flex items-center gap-2 shrink-0 text-sm">
+        <span className="text-gray-500 dark:text-gray-400">{early}</span>
+        <span className="text-gray-400 dark:text-gray-500">→</span>
+        <span className="font-semibold text-gray-900 dark:text-gray-100">{recent}</span>
+        <span className={`font-semibold tabular-nums ${deltaColor}`}>
+          {improved ? '+' : ''}
+          {delta}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/analytics/LearningResourcesSection.tsx
+++ b/src/components/analytics/LearningResourcesSection.tsx
@@ -1,0 +1,114 @@
+import { GraduationCap, ExternalLink, Play } from 'lucide-react';
+import { getPhonemeById } from '@/lib/phonemeMetadata';
+import { getPhonemeResources, getWordResources } from '@/lib/learningResources';
+import type { LearningResource } from '@/lib/types';
+
+interface LearningResourcesSectionProps {
+  /** Canonical/Azure phoneme ids the learner struggles with (already prioritized). */
+  weakPhonemeIds: string[];
+  /** Words the learner should review (already prioritized). */
+  focusWords: { textPt: string }[];
+}
+
+function ResourceLinks({ resources }: { resources: LearningResource[] }) {
+  return (
+    <ul className="mt-2 space-y-1">
+      {resources.map((res) => (
+        <li key={res.url}>
+          <a
+            href={res.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1.5 text-sm text-primary-600 dark:text-primary-400 hover:underline"
+          >
+            {res.source === 'youtube-search' ? (
+              <Play size={13} className="shrink-0" />
+            ) : (
+              <ExternalLink size={13} className="shrink-0" />
+            )}
+            {res.label}
+          </a>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+/**
+ * Learning Resources: clickable pronunciation tutorials for the learner's hardest
+ * sounds and words. Resource links are generated deterministically (see
+ * src/lib/learningResources.ts) — no manual curation or API key required.
+ */
+export default function LearningResourcesSection({
+  weakPhonemeIds,
+  focusWords,
+}: LearningResourcesSectionProps) {
+  const hasData = weakPhonemeIds.length > 0 || focusWords.length > 0;
+
+  return (
+    <section id="resources" className="card scroll-mt-20">
+      <div className="flex items-center gap-2 mb-4">
+        <GraduationCap size={18} className="text-primary-500 dark:text-primary-400" />
+        <h2 className="text-xl font-bold text-gray-900 dark:text-gray-100">
+          Learning Resources
+        </h2>
+      </div>
+
+      {!hasData ? (
+        <p className="text-sm text-gray-500 dark:text-gray-400 py-4">
+          As you practice, tutorials for the sounds and words you find hardest will
+          appear here.
+        </p>
+      ) : (
+        <div className="space-y-4">
+          {weakPhonemeIds.map((phonemeId) => {
+            const meta = getPhonemeById(phonemeId);
+            return (
+              <div
+                key={phonemeId}
+                className="p-3 bg-gray-50 dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700"
+              >
+                <div className="flex items-baseline gap-2">
+                  <span className="text-[10px] uppercase tracking-wide font-semibold text-gray-400 dark:text-gray-500">
+                    Problem Sound
+                  </span>
+                  <span className="font-mono text-base font-semibold text-gray-900 dark:text-gray-100">
+                    {meta?.ipa ?? phonemeId}
+                  </span>
+                  {meta?.category && (
+                    <span className="text-xs text-gray-500 dark:text-gray-400">
+                      {meta.category}
+                    </span>
+                  )}
+                </div>
+                {meta?.teachingTips?.[0] && (
+                  <p className="text-xs text-gray-600 dark:text-gray-400 mt-1">
+                    {meta.teachingTips[0]}
+                  </p>
+                )}
+                <ResourceLinks resources={getPhonemeResources(phonemeId)} />
+              </div>
+            );
+          })}
+
+          {focusWords.map((word) => (
+            <div
+              key={word.textPt}
+              className="p-3 bg-gray-50 dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700"
+            >
+              <div className="flex items-baseline gap-2">
+                <span className="text-[10px] uppercase tracking-wide font-semibold text-gray-400 dark:text-gray-500">
+                  Word
+                </span>
+                <span className="text-base font-semibold text-gray-900 dark:text-gray-100">
+                  {word.textPt}
+                </span>
+              </div>
+              <ResourceLinks resources={getWordResources(word)} />
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/analytics/MultiMetricTrendChart.tsx
+++ b/src/components/analytics/MultiMetricTrendChart.tsx
@@ -1,0 +1,163 @@
+import type { TrendMetric, TrendPoint } from '@/lib/types';
+
+interface MultiMetricTrendChartProps {
+  data: TrendPoint[];
+  activeMetric: TrendMetric;
+}
+
+/**
+ * Responsive SVG line chart for a single metric across a window of time buckets.
+ *
+ * Generalizes the rolling-7-day chart: it averages each bucket's raw scores for the
+ * active metric and plots only buckets that contain data (so no-practice gaps collapse
+ * rather than dipping the line to zero). Fixed 0-100 Y-axis. The parent owns the metric
+ * and window selectors; this component is purely presentational.
+ */
+export default function MultiMetricTrendChart({
+  data,
+  activeMetric,
+}: MultiMetricTrendChartProps) {
+  // Average each bucket for the active metric, keeping only buckets with data.
+  const series = data
+    .map((point) => {
+      const values = point.values[activeMetric];
+      return {
+        date: point.date,
+        label: point.label,
+        average: values.length > 0
+          ? values.reduce((sum, v) => sum + v, 0) / values.length
+          : null,
+        count: values.length,
+      };
+    })
+    .filter((p): p is { date: string; label: string; average: number; count: number } => p.average !== null);
+
+  if (series.length === 0) {
+    return (
+      <p className="text-sm text-gray-500 dark:text-gray-400 text-center py-8">
+        No {activeMetric} scores recorded in this period yet.
+      </p>
+    );
+  }
+
+  const chartHeight = 240;
+  const chartWidth = 460;
+  const padding = { top: 24, right: 24, bottom: 44, left: 44 };
+  const maxValue = 100;
+  const minValue = 0;
+
+  const normalizeY = (value: number) => {
+    const range = maxValue - minValue || 1;
+    return padding.top + chartHeight - ((value - minValue) / range) * chartHeight;
+  };
+
+  const points = series.map((s, index) => {
+    const x = padding.left + (index / (series.length - 1 || 1)) * chartWidth;
+    const y = normalizeY(s.average);
+    return { x, y, ...s };
+  });
+
+  const pathData = points
+    .map((point, index) => `${index === 0 ? 'M' : 'L'} ${point.x} ${point.y}`)
+    .join(' ');
+
+  const overallAvg = series.reduce((sum, s) => sum + s.average, 0) / series.length;
+
+  return (
+    <div className="group">
+      <div
+        className="relative"
+        style={{ height: `${chartHeight + padding.top + padding.bottom}px` }}
+      >
+        <svg
+          viewBox={`0 0 ${chartWidth + padding.left + padding.right} ${chartHeight + padding.top + padding.bottom}`}
+          className="absolute inset-0 w-full h-full"
+          preserveAspectRatio="xMidYMid meet"
+          role="img"
+          aria-label={`${activeMetric} score trend`}
+        >
+          {/* Grid lines */}
+          {[0, 25, 50, 75, 100].map((value) => {
+            const y = normalizeY(value);
+            return (
+              <g key={`grid-${value}`}>
+                <line
+                  x1={padding.left}
+                  y1={y}
+                  x2={padding.left + chartWidth}
+                  y2={y}
+                  stroke="currentColor"
+                  strokeWidth="0.5"
+                  className="text-gray-200 dark:text-gray-700"
+                  strokeDasharray="2,2"
+                />
+                <text
+                  x={padding.left - 10}
+                  y={y + 4}
+                  textAnchor="end"
+                  className="text-xs fill-gray-500 dark:fill-gray-400 font-medium"
+                >
+                  {value}
+                </text>
+              </g>
+            );
+          })}
+
+          {/* Line */}
+          <path
+            d={pathData}
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className="text-primary-500 dark:text-primary-400"
+          />
+
+          {/* Points with tooltips */}
+          {points.map((point, index) => (
+            <g key={`point-${index}`}>
+              <circle
+                cx={point.x}
+                cy={point.y}
+                r="4"
+                fill="currentColor"
+                className="text-primary-500 dark:text-primary-400"
+              />
+              <circle cx={point.x} cy={point.y} r="9" fill="transparent" />
+              <title>
+                {point.label}: {point.average.toFixed(1)} ({point.count} attempt
+                {point.count === 1 ? '' : 's'})
+              </title>
+            </g>
+          ))}
+
+          {/* X-axis labels (avoid crowding) */}
+          {points.map((point, index) => {
+            const step = Math.ceil(points.length / 7);
+            if (index % step === 0 || index === points.length - 1) {
+              return (
+                <text
+                  key={`label-${index}`}
+                  x={point.x}
+                  y={chartHeight + padding.top + padding.bottom - 12}
+                  textAnchor="middle"
+                  className="text-xs fill-gray-600 dark:fill-gray-400 font-medium"
+                >
+                  {point.label}
+                </text>
+              );
+            }
+            return null;
+          })}
+        </svg>
+      </div>
+      <p className="mt-2 text-center text-xs font-medium text-gray-600 dark:text-gray-400">
+        Average:{' '}
+        <span className="font-bold text-gray-900 dark:text-gray-100">
+          {overallAvg.toFixed(1)}
+        </span>
+      </p>
+    </div>
+  );
+}

--- a/src/components/analytics/OverviewSection.tsx
+++ b/src/components/analytics/OverviewSection.tsx
@@ -1,0 +1,116 @@
+import { Clock, Flame, ClipboardList, Target, TrendingUp, TrendingDown, Minus, Lightbulb } from 'lucide-react';
+import type { AnalyticsInsight, UserGlobalStats } from '@/lib/types';
+import MetricTile from '@/components/common/MetricTile';
+
+interface OverviewSectionProps {
+  userStats: UserGlobalStats | null;
+  totalAttempts: number;
+  todayMinutes: number;
+  dueCount: number;
+  insights: AnalyticsInsight[];
+}
+
+const SEVERITY_ICON = {
+  positive: TrendingUp,
+  attention: TrendingDown,
+  neutral: Minus,
+} as const;
+
+const SEVERITY_STYLES = {
+  positive:
+    'border-green-200 dark:border-green-800 bg-green-50 dark:bg-green-900/20 text-green-800 dark:text-green-300',
+  attention:
+    'border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-900/20 text-amber-800 dark:text-amber-300',
+  neutral:
+    'border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-gray-700 dark:text-gray-300',
+} as const;
+
+/**
+ * Top-of-dashboard overview: headline metrics + deterministic personalized insights.
+ */
+export default function OverviewSection({
+  userStats,
+  totalAttempts,
+  todayMinutes,
+  dueCount,
+  insights,
+}: OverviewSectionProps) {
+  const currentAvg = userStats?.rolling7DayAvgOverallScore ?? userStats?.rolling30DayAvgOverallScore;
+  const trend = computeTrend(userStats);
+
+  return (
+    <section id="overview" className="space-y-4 scroll-mt-20">
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
+        <MetricTile
+          label="Current Score"
+          value={currentAvg !== undefined ? Math.round(currentAvg) : '—'}
+          icon={Target}
+          description="Recent average pronunciation score"
+          trend={trend}
+        />
+        <MetricTile
+          label="Total Attempts"
+          value={totalAttempts}
+          icon={ClipboardList}
+          description="Pronunciation attempts recorded"
+        />
+        <MetricTile
+          label="Current Streak"
+          value={userStats?.currentDailyStreak ?? 0}
+          icon={Flame}
+          description="Days practiced in a row"
+        />
+        <MetricTile
+          label="Today's Practice"
+          value={`${todayMinutes} min`}
+          icon={Clock}
+          description="Practice time today"
+          action={dueCount > 0 ? { label: `${dueCount} due`, to: '/review' } : undefined}
+        />
+      </div>
+
+      {insights.length > 0 && (
+        <div className="card">
+          <div className="flex items-center gap-2 mb-3">
+            <Lightbulb size={18} className="text-primary-500 dark:text-primary-400" />
+            <h2 className="text-lg font-bold text-gray-900 dark:text-gray-100">
+              Insights
+            </h2>
+          </div>
+          <div className="space-y-2">
+            {insights.map((insight) => {
+              const Icon = SEVERITY_ICON[insight.severity];
+              return (
+                <div
+                  key={insight.id}
+                  className={`flex items-start gap-3 p-3 rounded-lg border ${SEVERITY_STYLES[insight.severity]}`}
+                >
+                  <Icon size={18} className="mt-0.5 shrink-0" />
+                  <div>
+                    <p className="text-sm font-semibold">{insight.title}</p>
+                    <p className="text-xs opacity-90 mt-0.5">{insight.detail}</p>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function computeTrend(
+  userStats: UserGlobalStats | null,
+): { direction: 'up' | 'down' | 'flat'; delta?: string } | undefined {
+  if (!userStats) return undefined;
+  const recent = userStats.rolling7DayAvgOverallScore;
+  const baseline = userStats.rolling30DayAvgOverallScore;
+  if (recent === undefined || baseline === undefined) return undefined;
+  const delta = recent - baseline;
+  if (Math.abs(delta) < 1) return { direction: 'flat' };
+  return {
+    direction: delta > 0 ? 'up' : 'down',
+    delta: `${delta > 0 ? '+' : ''}${delta.toFixed(1)} vs 30-day`,
+  };
+}

--- a/src/components/analytics/ProgressTrendSection.tsx
+++ b/src/components/analytics/ProgressTrendSection.tsx
@@ -1,0 +1,98 @@
+import { useMemo, useState } from 'react';
+import type { AnalyticsWindow, TrendMetric, TrendPoint } from '@/lib/types';
+import { TREND_METRICS } from '@/lib/practiceAnalytics';
+import MultiMetricTrendChart from './MultiMetricTrendChart';
+
+interface ProgressTrendSectionProps {
+  data: TrendPoint[];
+  window: AnalyticsWindow;
+  onWindowChange: (window: AnalyticsWindow) => void;
+}
+
+const WINDOW_OPTIONS: { value: AnalyticsWindow; label: string }[] = [
+  { value: '7d', label: '7 days' },
+  { value: '30d', label: '30 days' },
+  { value: '90d', label: '90 days' },
+  { value: 'all', label: 'All time' },
+];
+
+const METRIC_LABELS: Record<TrendMetric, string> = {
+  overall: 'Pronunciation',
+  accuracy: 'Accuracy',
+  fluency: 'Fluency',
+  completeness: 'Completeness',
+  prosody: 'Prosody',
+};
+
+/**
+ * Progress section: window selector (7/30/90/all) + metric toggle driving a
+ * multi-metric trend chart of pronunciation/accuracy/fluency/completeness scores.
+ */
+export default function ProgressTrendSection({
+  data,
+  window,
+  onWindowChange,
+}: ProgressTrendSectionProps) {
+  // Only offer metric toggles for metrics that actually have data in this window.
+  const availableMetrics = useMemo(
+    () =>
+      TREND_METRICS.filter((metric) =>
+        data.some((point) => point.values[metric].length > 0),
+      ),
+    [data],
+  );
+
+  const [activeMetric, setActiveMetric] = useState<TrendMetric>('overall');
+  const effectiveMetric = availableMetrics.includes(activeMetric)
+    ? activeMetric
+    : availableMetrics[0] ?? 'overall';
+
+  return (
+    <section id="progress" className="card scroll-mt-20">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-4">
+        <h2 className="text-xl font-bold text-gray-900 dark:text-gray-100">
+          Score History
+        </h2>
+        <div className="flex flex-wrap gap-1" role="group" aria-label="Time window">
+          {WINDOW_OPTIONS.map((opt) => (
+            <button
+              key={opt.value}
+              type="button"
+              onClick={() => onWindowChange(opt.value)}
+              className={`px-3 py-1 text-xs font-medium rounded-md transition-colors ${
+                window === opt.value
+                  ? 'bg-primary-600 text-white'
+                  : 'bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700'
+              }`}
+              aria-pressed={window === opt.value}
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {availableMetrics.length > 1 && (
+        <div className="flex flex-wrap gap-1 mb-4" role="group" aria-label="Metric">
+          {availableMetrics.map((metric) => (
+            <button
+              key={metric}
+              type="button"
+              onClick={() => setActiveMetric(metric)}
+              className={`px-3 py-1 text-xs font-medium rounded-full border transition-colors ${
+                effectiveMetric === metric
+                  ? 'border-primary-500 bg-primary-50 dark:bg-primary-900/30 text-primary-700 dark:text-primary-300'
+                  : 'border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-400 hover:border-gray-300 dark:hover:border-gray-600'
+              }`}
+              aria-pressed={effectiveMetric === metric}
+            >
+              {METRIC_LABELS[metric]}
+            </button>
+          ))}
+        </div>
+      )}
+
+      <MultiMetricTrendChart data={data} activeMetric={effectiveMetric} />
+    </section>
+  );
+}

--- a/src/components/analytics/RecommendationsSection.tsx
+++ b/src/components/analytics/RecommendationsSection.tsx
@@ -1,0 +1,70 @@
+import { Link } from 'react-router-dom';
+import { Sparkles } from 'lucide-react';
+import type { PracticeRecommendation } from '@/lib/types';
+
+interface RecommendationsSectionProps {
+  recommendations: PracticeRecommendation[];
+}
+
+const GROUPS: { kind: PracticeRecommendation['kind']; title: string }[] = [
+  { kind: 'phoneme', title: 'Recommended Sounds' },
+  { kind: 'word', title: 'Recommended Words' },
+  { kind: 'sentence', title: 'Recommended Phrases' },
+];
+
+/**
+ * Practice Recommendations: data-grounded "what to practice next" across sounds,
+ * words, and phrases. Each item links to the relevant practice surface.
+ */
+export default function RecommendationsSection({
+  recommendations,
+}: RecommendationsSectionProps) {
+  return (
+    <section id="recommendations" className="card scroll-mt-20">
+      <div className="flex items-center gap-2 mb-4">
+        <Sparkles size={18} className="text-primary-500 dark:text-primary-400" />
+        <h2 className="text-xl font-bold text-gray-900 dark:text-gray-100">
+          Practice Recommendations
+        </h2>
+      </div>
+
+      {recommendations.length === 0 ? (
+        <p className="text-sm text-gray-500 dark:text-gray-400 py-4">
+          Practice a little more and we'll recommend exactly what to work on next.
+        </p>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+          {GROUPS.map(({ kind, title }) => {
+            const items = recommendations.filter((r) => r.kind === kind);
+            if (items.length === 0) return null;
+            return (
+              <div key={kind}>
+                <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2">
+                  {title}
+                </h3>
+                <div className="space-y-2">
+                  {items.map((rec) => (
+                    <Link
+                      key={`${rec.kind}-${rec.id}`}
+                      to={rec.to}
+                      className="block p-3 bg-gray-50 dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 hover:border-primary-300 dark:hover:border-primary-600 transition-colors"
+                    >
+                      <span
+                        className={`text-sm font-medium text-gray-900 dark:text-gray-100 ${kind === 'phoneme' ? 'font-mono' : ''}`}
+                      >
+                        {rec.label}
+                      </span>
+                      <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                        {rec.reason}
+                      </p>
+                    </Link>
+                  ))}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/analytics/StrengthsSection.tsx
+++ b/src/components/analytics/StrengthsSection.tsx
@@ -1,0 +1,101 @@
+import { Award, TrendingUp } from 'lucide-react';
+import type { ImprovementItem, PhonemeStats } from '@/lib/types';
+import { getPhonemeById } from '@/lib/phonemeMetadata';
+import ImprovementRow from './ImprovementRow';
+import { resolveItemLabel } from './itemLabels';
+
+interface StrengthsSectionProps {
+  mostImproved: ImprovementItem[];
+  strongPhonemes: PhonemeStats[];
+  wordLabels: Map<string, string>;
+  sentenceLabels: Map<string, string>;
+}
+
+/**
+ * Strengths: items the learner improved most over the window, plus their strongest sounds.
+ */
+export default function StrengthsSection({
+  mostImproved,
+  strongPhonemes,
+  wordLabels,
+  sentenceLabels,
+}: StrengthsSectionProps) {
+  const hasData = mostImproved.length > 0 || strongPhonemes.length > 0;
+
+  return (
+    <section id="strengths" className="card scroll-mt-20">
+      <div className="flex items-center gap-2 mb-4">
+        <Award size={18} className="text-green-500 dark:text-green-400" />
+        <h2 className="text-xl font-bold text-gray-900 dark:text-gray-100">Strengths</h2>
+      </div>
+
+      {!hasData ? (
+        <p className="text-sm text-gray-500 dark:text-gray-400 py-4">
+          Keep practicing — once you have a few attempts per item, your biggest gains
+          and strongest sounds will appear here.
+        </p>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <div>
+            <div className="flex items-center gap-2 mb-2">
+              <TrendingUp size={15} className="text-green-500 dark:text-green-400" />
+              <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300">
+                Most Improved
+              </h3>
+            </div>
+            {mostImproved.length > 0 ? (
+              <div className="space-y-2">
+                {mostImproved.map((item) => (
+                  <ImprovementRow
+                    key={`${item.kind}-${item.id}`}
+                    item={item}
+                    label={resolveItemLabel(item, wordLabels, sentenceLabels)}
+                  />
+                ))}
+              </div>
+            ) : (
+              <p className="text-xs text-gray-500 dark:text-gray-400">
+                No measurable gains yet in this period.
+              </p>
+            )}
+          </div>
+
+          <div>
+            <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2">
+              Strongest Sounds
+            </h3>
+            {strongPhonemes.length > 0 ? (
+              <div className="space-y-2">
+                {strongPhonemes.map((p) => {
+                  const meta = getPhonemeById(p.phonemeId);
+                  return (
+                    <div
+                      key={p.phonemeId}
+                      className="flex items-center justify-between p-3 bg-gray-50 dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700"
+                    >
+                      <div>
+                        <span className="font-mono text-sm font-medium text-gray-900 dark:text-gray-100">
+                          {meta?.ipa ?? p.phonemeId}
+                        </span>
+                        <span className="text-xs text-gray-500 dark:text-gray-400 ml-2">
+                          {p.attempts} reps
+                        </span>
+                      </div>
+                      <span className="text-sm font-semibold text-green-600 dark:text-green-400">
+                        {Math.round(p.avgOverallScore ?? 0)}
+                      </span>
+                    </div>
+                  );
+                })}
+              </div>
+            ) : (
+              <p className="text-xs text-gray-500 dark:text-gray-400">
+                No standout sounds yet.
+              </p>
+            )}
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/analytics/itemLabels.ts
+++ b/src/components/analytics/itemLabels.ts
@@ -1,0 +1,28 @@
+import { getPhonemeById } from '@/lib/phonemeMetadata';
+import type { ImprovementItem } from '@/lib/types';
+
+/**
+ * Resolves an analytics item id to a human-readable label.
+ * - phonemes → IPA symbol (falling back to the id)
+ * - words / sentences → text from the provided lookup maps (falling back to the id)
+ */
+export function resolveItemLabel(
+  item: Pick<ImprovementItem, 'id' | 'kind'>,
+  wordLabels: Map<string, string>,
+  sentenceLabels: Map<string, string>,
+): string {
+  switch (item.kind) {
+    case 'phoneme':
+      return getPhonemeById(item.id)?.ipa ?? item.id;
+    case 'word':
+      return wordLabels.get(item.id) ?? item.id;
+    case 'sentence':
+      return sentenceLabels.get(item.id) ?? item.id;
+  }
+}
+
+export const KIND_LABEL: Record<ImprovementItem['kind'], string> = {
+  phoneme: 'Sound',
+  word: 'Word',
+  sentence: 'Phrase',
+};

--- a/src/lib/learningResources.test.ts
+++ b/src/lib/learningResources.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { getPhonemeResources, getWordResources } from './learningResources';
+
+describe('getPhonemeResources', () => {
+  it('returns curated resources first, then a generated YouTube search', () => {
+    const resources = getPhonemeResources('AN_NASAL');
+    expect(resources.length).toBeGreaterThanOrEqual(2);
+    expect(resources[0].source).toBe('curated');
+    const last = resources[resources.length - 1];
+    expect(last.source).toBe('youtube-search');
+    expect(last.url.startsWith('https://www.youtube.com/results?search_query=')).toBe(true);
+    expect(decodeURIComponent(last.url)).toContain('Brazilian Portuguese');
+  });
+
+  it('falls back to only a generated search for unknown phonemes', () => {
+    const resources = getPhonemeResources('NOT_A_PHONEME');
+    expect(resources).toHaveLength(1);
+    expect(resources[0].source).toBe('youtube-search');
+    expect(resources[0].url).toContain('NOT_A_PHONEME');
+  });
+
+  it('is deterministic', () => {
+    expect(getPhonemeResources('LH')).toEqual(getPhonemeResources('LH'));
+  });
+});
+
+describe('getWordResources', () => {
+  it('returns a YouTube search and a Forvo link with escaped text', () => {
+    const resources = getWordResources({ textPt: 'pão' });
+    expect(resources.map((r) => r.source)).toEqual(['youtube-search', 'forvo']);
+    expect(resources[0].url).toContain(encodeURIComponent('"pão"'));
+    expect(resources[1].url).toContain(encodeURIComponent('pão'));
+    expect(resources[1].url).toContain('forvo.com/word/');
+  });
+});

--- a/src/lib/learningResources.ts
+++ b/src/lib/learningResources.ts
@@ -1,0 +1,103 @@
+/**
+ * Learning Resources Resolver
+ *
+ * Maps difficult phonemes and words to pronunciation learning resources.
+ *
+ * Strategy (see docs/architecture/analytics-pipeline.md):
+ *   - Deterministic, zero-maintenance YouTube *search* URLs are always generated, so
+ *     every sound/word has a working "learn more" link without any manual curation and
+ *     without an API key.
+ *   - A small, optional `CURATED_*` override map can pin a few stable, high-authority
+ *     reference pages for the hardest sounds. It links to durable reference pages
+ *     (not specific videos), so it does not rot. Leave it empty to rely purely on search.
+ *
+ * All functions are pure and synchronous (no network calls).
+ */
+
+import { getPhonemeById } from './phonemeMetadata';
+import type { LearningResource } from './types';
+
+const YOUTUBE_SEARCH = 'https://www.youtube.com/results?search_query=';
+const FORVO_WORD = 'https://forvo.com/word/';
+
+/**
+ * Curated overrides keyed by canonical phoneme id. Intentionally tiny and limited to
+ * durable reference pages for the sounds English speakers struggle with most.
+ */
+const CURATED_PHONEME_RESOURCES: Record<string, LearningResource[]> = {
+  AN_NASAL: nasalVowelReference(),
+  EN_NASAL: nasalVowelReference(),
+  IN_NASAL: nasalVowelReference(),
+  ON_NASAL: nasalVowelReference(),
+  UN_NASAL: nasalVowelReference(),
+  LH: [
+    {
+      label: 'Portuguese phonology reference (lh / ʎ)',
+      url: 'https://en.wikipedia.org/wiki/Portuguese_phonology#Consonants',
+      source: 'curated',
+    },
+  ],
+  NH: [
+    {
+      label: 'Portuguese phonology reference (nh / ɲ)',
+      url: 'https://en.wikipedia.org/wiki/Portuguese_phonology#Consonants',
+      source: 'curated',
+    },
+  ],
+};
+
+function nasalVowelReference(): LearningResource[] {
+  return [
+    {
+      label: 'Portuguese nasal vowels reference',
+      url: 'https://en.wikipedia.org/wiki/Portuguese_phonology#Nasal_vowels',
+      source: 'curated',
+    },
+  ];
+}
+
+/**
+ * Returns pronunciation learning resources for a phoneme.
+ *
+ * Curated overrides (if any) come first, followed by an always-present generated
+ * YouTube search tuned to the phoneme's IPA symbol.
+ */
+export function getPhonemeResources(phonemeId: string): LearningResource[] {
+  const meta = getPhonemeById(phonemeId);
+  const canonical = meta?.id ?? phonemeId.trim().toUpperCase();
+  const symbol = meta?.ipa ? `/${meta.ipa}/` : canonical;
+
+  const resources: LearningResource[] = [];
+  const curated = CURATED_PHONEME_RESOURCES[canonical];
+  if (curated) resources.push(...curated);
+
+  const query = `Brazilian Portuguese ${symbol} sound pronunciation tutorial`;
+  resources.push({
+    label: `How to pronounce ${symbol} in Brazilian Portuguese`,
+    url: YOUTUBE_SEARCH + encodeURIComponent(query),
+    source: 'youtube-search',
+  });
+
+  return resources;
+}
+
+/**
+ * Returns pronunciation learning resources for a word: a YouTube search and a
+ * direct Forvo native-speaker recording link.
+ */
+export function getWordResources(word: { textPt: string }): LearningResource[] {
+  const text = word.textPt;
+  const query = `Brazilian Portuguese pronunciation "${text}"`;
+  return [
+    {
+      label: `How to say “${text}”`,
+      url: YOUTUBE_SEARCH + encodeURIComponent(query),
+      source: 'youtube-search',
+    },
+    {
+      label: `Hear “${text}” on Forvo`,
+      url: `${FORVO_WORD}${encodeURIComponent(text)}/#pt`,
+      source: 'forvo',
+    },
+  ];
+}

--- a/src/lib/practiceAnalytics.test.ts
+++ b/src/lib/practiceAnalytics.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, it } from 'vitest';
+import type {
+  SentencePracticeAttempt,
+  WordPracticeAttempt,
+  Word,
+  Sentence,
+} from './types';
+import {
+  filterByWindow,
+  buildMultiMetricTrend,
+  computeImprovement,
+  generateInsights,
+  buildRecommendations,
+} from './practiceAnalytics';
+
+const NOW = new Date('2026-06-17T12:00:00.000Z');
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function daysAgo(days: number, extraMs = 0): string {
+  return new Date(NOW.getTime() - days * DAY_MS + extraMs).toISOString();
+}
+
+function sentence(overrides: Partial<SentencePracticeAttempt> = {}): SentencePracticeAttempt {
+  return {
+    attemptId: `s-${Math.random()}`,
+    userId: 'u',
+    sessionId: 'sess-1',
+    sentenceId: 'sent-1',
+    difficulty: 3,
+    category: 'food',
+    createdAt: NOW.toISOString(),
+    overallScore: 80,
+    accuracyScore: 80,
+    fluencyScore: 80,
+    completenessScore: 80,
+    ...overrides,
+  };
+}
+
+function word(overrides: Partial<WordPracticeAttempt> = {}): WordPracticeAttempt {
+  return {
+    attemptId: `w-${Math.random()}`,
+    userId: 'u',
+    sessionId: 'sess-1',
+    wordId: 'word-1',
+    difficulty: 3,
+    category: 'food',
+    createdAt: NOW.toISOString(),
+    overallScore: 80,
+    accuracyScore: 80,
+    ...overrides,
+  };
+}
+
+function makeWord(id: string, textPt: string, phonemes: string[] = []): Word {
+  return {
+    id,
+    textPt,
+    translationEn: 'x',
+    partOfSpeech: 'noun',
+    difficulty: 3,
+    difficultForEnglish: false,
+    categoryId: 'food',
+    categoryLabelEn: 'Food',
+    categoryLabelPt: 'Comida',
+    phonemes,
+  };
+}
+
+function makeSentence(id: string, textPt: string, phonemes: string[] = []): Sentence {
+  return {
+    id,
+    textPt,
+    translationEn: 'x',
+    difficulty: 3,
+    categoryId: 'food',
+    categoryLabelEn: 'Food',
+    categoryLabelPt: 'Comida',
+    phonemes,
+  };
+}
+
+describe('filterByWindow', () => {
+  it('includes items exactly at the cutoff and excludes items just before', () => {
+    const items = [
+      { createdAt: daysAgo(7) }, // exactly at cutoff (inclusive)
+      { createdAt: daysAgo(7, -1) }, // 1ms before cutoff
+    ];
+    const result = filterByWindow(items, '7d', NOW);
+    expect(result).toHaveLength(1);
+    expect(result[0].createdAt).toBe(daysAgo(7));
+  });
+
+  it('passes everything through for the "all" window', () => {
+    const items = [{ createdAt: daysAgo(1000) }, { createdAt: daysAgo(1) }];
+    expect(filterByWindow(items, 'all', NOW)).toHaveLength(2);
+  });
+});
+
+describe('buildMultiMetricTrend', () => {
+  it('produces a fixed number of buckets per window', () => {
+    expect(buildMultiMetricTrend([], [], '7d', NOW)).toHaveLength(7);
+    expect(buildMultiMetricTrend([], [], '30d', NOW)).toHaveLength(30);
+    expect(buildMultiMetricTrend([], [], '90d', NOW)).toHaveLength(13);
+  });
+
+  it('returns no buckets for "all" when there is no data', () => {
+    expect(buildMultiMetricTrend([], [], 'all', NOW)).toEqual([]);
+  });
+
+  it('only includes metrics that are actually recorded', () => {
+    const s = sentence({ createdAt: NOW.toISOString(), overallScore: 80, fluencyScore: 70 });
+    const w = word({ createdAt: NOW.toISOString(), overallScore: 90, accuracyScore: 85 }); // no fluency
+    const trend = buildMultiMetricTrend([s], [w], '7d', NOW);
+
+    expect(trend.flatMap((p) => p.values.overall).sort()).toEqual([80, 90]);
+    // Only the sentence contributes a fluency score; the word has none.
+    expect(trend.flatMap((p) => p.values.fluency)).toEqual([70]);
+  });
+});
+
+describe('computeImprovement', () => {
+  it('excludes items below the minimum attempt threshold', () => {
+    const attempts = [
+      word({ wordId: 'w-short', overallScore: 50, createdAt: daysAgo(3) }),
+      word({ wordId: 'w-short', overallScore: 60, createdAt: daysAgo(2) }),
+      word({ wordId: 'w-short', overallScore: 90, createdAt: daysAgo(1) }),
+    ];
+    const { mostImproved, needsPractice } = computeImprovement([], attempts, 'all', { now: NOW });
+    const allIds = [...mostImproved, ...needsPractice].map((i) => i.id);
+    expect(allIds).not.toContain('w-short');
+  });
+
+  it('surfaces rising items in mostImproved and falling items in needsPractice', () => {
+    const improving = [50, 55, 60, 90].map((score, i) =>
+      word({ wordId: 'w-improve', overallScore: score, createdAt: daysAgo(4 - i) }),
+    );
+    const declining = [80, 70, 60, 50].map((score, i) =>
+      word({ wordId: 'w-decline', overallScore: score, createdAt: daysAgo(4 - i) }),
+    );
+    const { mostImproved, needsPractice } = computeImprovement(
+      [],
+      [...improving, ...declining],
+      'all',
+      { now: NOW },
+    );
+
+    const improved = mostImproved.find((i) => i.id === 'w-improve');
+    expect(improved).toBeDefined();
+    expect(improved!.delta).toBeCloseTo(22.5);
+    expect(mostImproved.map((i) => i.id)).not.toContain('w-decline');
+
+    expect(needsPractice.map((i) => i.id)).toContain('w-decline');
+  });
+
+  it('splits odd attempt counts with an overlapping middle element', () => {
+    const attempts = [10, 20, 30, 40, 50].map((score, i) =>
+      word({ wordId: 'w-odd', overallScore: score, createdAt: daysAgo(5 - i) }),
+    );
+    const { mostImproved } = computeImprovement([], attempts, 'all', { now: NOW });
+    const item = mostImproved.find((i) => i.id === 'w-odd');
+    expect(item).toBeDefined();
+    expect(item!.earlyAvg).toBeCloseTo(20); // mean(10,20,30)
+    expect(item!.recentAvg).toBeCloseTo(40); // mean(30,40,50)
+  });
+
+  it('caps each list at topN', () => {
+    const attempts: WordPracticeAttempt[] = [];
+    for (let n = 0; n < 12; n++) {
+      [40, 50, 60, 90].forEach((score, i) => {
+        attempts.push(
+          word({ wordId: `w-${n}`, overallScore: score, createdAt: daysAgo(4 - i) }),
+        );
+      });
+    }
+    const { mostImproved } = computeImprovement([], attempts, 'all', { now: NOW, topN: 6 });
+    expect(mostImproved.length).toBeLessThanOrEqual(6);
+  });
+});
+
+describe('generateInsights', () => {
+  it('returns nothing when there is too little data', () => {
+    expect(generateInsights([sentence()], [], 'all', NOW)).toEqual([]);
+  });
+
+  it('is deterministic for identical input', () => {
+    const sentences = ['s1', 's2', 's3'].flatMap((id) => [
+      sentence({ sentenceId: id, sessionId: 'sess-1', overallScore: 60, createdAt: daysAgo(2) }),
+      sentence({ sentenceId: id, sessionId: 'sess-1', overallScore: 82, createdAt: daysAgo(2, 60_000) }),
+    ]);
+    const a = generateInsights(sentences, [], 'all', NOW);
+    const b = generateInsights(sentences, [], 'all', NOW);
+    expect(a).toEqual(b);
+    expect(a.some((i) => i.id === 'improves-with-repetition')).toBe(true);
+  });
+});
+
+describe('buildRecommendations', () => {
+  it('only recommends content that exists, grounded in real weaknesses', () => {
+    const allWords = [makeWord('w1', 'pão', ['AN_NASAL']), makeWord('w2', 'não', ['AN_NASAL'])];
+    const allSentences = [makeSentence('s1', 'Tudo bem', ['AN_NASAL'])];
+
+    const wordAttempts = [0, 1, 2].map((i) =>
+      word({
+        wordId: 'w1',
+        overallScore: 45,
+        accuracyScore: 45,
+        phonemeScores: [{ phonemeId: 'AN_NASAL', overallScore: 45 }],
+        createdAt: daysAgo(3 - i),
+      }),
+    );
+
+    const recs = buildRecommendations([], wordAttempts, allWords, allSentences);
+
+    for (const rec of recs) {
+      if (rec.kind === 'word') {
+        expect(allWords.some((w) => w.id === rec.id)).toBe(true);
+      }
+      if (rec.kind === 'sentence') {
+        expect(allSentences.some((s) => s.id === rec.id)).toBe(true);
+      }
+    }
+    expect(recs.some((r) => r.kind === 'phoneme' && r.id === 'AN_NASAL')).toBe(true);
+    expect(recs.some((r) => r.kind === 'word' && r.id === 'w1')).toBe(true);
+  });
+});

--- a/src/lib/practiceAnalytics.ts
+++ b/src/lib/practiceAnalytics.ts
@@ -22,7 +22,16 @@ import type {
   PhonemeId,
   DifficultyLevel,
   ContentCategory,
+  AnalyticsWindow,
+  TrendMetric,
+  TrendPoint,
+  ImprovementItem,
+  AnalyticsInsight,
+  PracticeRecommendation,
+  Word,
+  Sentence,
 } from './types';
+import { getPhonemeById } from './phonemeMetadata';
 
 /**
  * Determines the status of a sentence/word based on practice history.
@@ -985,5 +994,609 @@ export function buildReviewQueue(
 
   queue.sort((a, b) => b.reviewPriority - a.reviewPriority);
   return queue.slice(0, maxItems);
+}
+
+// ============================================================================
+// Progress Analytics: time windows, trends, improvement, insights, recommendations
+// ============================================================================
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** All trend metrics, in stable display order. */
+export const TREND_METRICS: TrendMetric[] = [
+  'overall',
+  'accuracy',
+  'fluency',
+  'completeness',
+  'prosody',
+];
+
+const WINDOW_DAYS: Record<Exclude<AnalyticsWindow, 'all'>, number> = {
+  '7d': 7,
+  '30d': 30,
+  '90d': 90,
+};
+
+type AnyAttempt = SentencePracticeAttempt | WordPracticeAttempt;
+
+function startOfDayMs(date: Date): number {
+  const d = new Date(date);
+  d.setHours(0, 0, 0, 0);
+  return d.getTime();
+}
+
+/**
+ * Filters any list of timestamped items to those within the given analytics window.
+ *
+ * The cutoff is inclusive (`>=`), matching the rolling-window convention used by
+ * computeUserGlobalStats. `now` is injectable for deterministic tests.
+ */
+export function filterByWindow<T extends { createdAt: string }>(
+  items: T[],
+  window: AnalyticsWindow,
+  now: Date = new Date(),
+): T[] {
+  if (window === 'all') return items;
+  const cutoff = now.getTime() - WINDOW_DAYS[window] * DAY_MS;
+  return items.filter((item) => new Date(item.createdAt).getTime() >= cutoff);
+}
+
+/** Extracts a single metric value from an attempt, or undefined when not recorded. */
+function metricValue(attempt: AnyAttempt, metric: TrendMetric): number | undefined {
+  switch (metric) {
+    case 'overall':
+      return attempt.overallScore;
+    case 'accuracy':
+      return attempt.accuracyScore;
+    case 'fluency':
+      return attempt.fluencyScore;
+    case 'completeness':
+      // completenessScore is required on sentences, optional on words.
+      return (attempt as SentencePracticeAttempt).completenessScore;
+    case 'prosody':
+      return attempt.prosodyScore;
+  }
+}
+
+interface BucketSpec {
+  bucketCount: number;
+  bucketMs: number;
+}
+
+/** Resolves bucket sizing for a window. Daily for short windows, weekly/monthly for long. */
+function resolveBuckets(
+  window: AnalyticsWindow,
+  attempts: AnyAttempt[],
+  now: Date,
+): BucketSpec {
+  if (window === '7d') return { bucketCount: 7, bucketMs: DAY_MS };
+  if (window === '30d') return { bucketCount: 30, bucketMs: DAY_MS };
+  if (window === '90d') return { bucketCount: 13, bucketMs: 7 * DAY_MS };
+
+  // 'all' — size buckets to the span of practice history.
+  if (attempts.length === 0) return { bucketCount: 0, bucketMs: DAY_MS };
+  const earliest = Math.min(
+    ...attempts.map((a) => new Date(a.createdAt).getTime()),
+  );
+  const endOfToday = startOfDayMs(now) + DAY_MS;
+  const spanDays = Math.max(1, Math.ceil((endOfToday - earliest) / DAY_MS));
+  if (spanDays <= 14) return { bucketCount: spanDays, bucketMs: DAY_MS };
+  const weeks = Math.ceil(spanDays / 7);
+  if (weeks <= 26) return { bucketCount: weeks, bucketMs: 7 * DAY_MS };
+  const months = Math.ceil(spanDays / 28);
+  return { bucketCount: months, bucketMs: 28 * DAY_MS };
+}
+
+function formatBucketLabel(startMs: number): string {
+  const d = new Date(startMs);
+  return `${d.getMonth() + 1}/${d.getDate()}`;
+}
+
+/**
+ * Builds a multi-metric trend series over the given window.
+ *
+ * Generalizes the rolling-7-day chart logic to all four (+prosody) metrics and to
+ * 7/30/90/all windows. Buckets are anchored to the end of the current day and walk
+ * backwards. Each bucket collects the raw scores recorded within it per metric;
+ * optional metrics (fluency/completeness/prosody) only contribute when present.
+ */
+export function buildMultiMetricTrend(
+  sentenceAttempts: SentencePracticeAttempt[],
+  wordAttempts: WordPracticeAttempt[],
+  window: AnalyticsWindow,
+  now: Date = new Date(),
+): TrendPoint[] {
+  const all: AnyAttempt[] = [
+    ...filterByWindow(sentenceAttempts, window, now),
+    ...filterByWindow(wordAttempts, window, now),
+  ];
+
+  const { bucketCount, bucketMs } = resolveBuckets(window, all, now);
+  if (bucketCount === 0) return [];
+
+  const rangeEnd = startOfDayMs(now) + DAY_MS; // end of today
+  const rangeStart = rangeEnd - bucketCount * bucketMs;
+
+  const points: TrendPoint[] = [];
+  for (let i = 0; i < bucketCount; i++) {
+    const bucketStart = rangeStart + i * bucketMs;
+    points.push({
+      date: new Date(bucketStart).toISOString().split('T')[0],
+      label: formatBucketLabel(bucketStart),
+      values: { overall: [], accuracy: [], fluency: [], completeness: [], prosody: [] },
+    });
+  }
+
+  for (const attempt of all) {
+    const ts = new Date(attempt.createdAt).getTime();
+    if (ts < rangeStart || ts >= rangeEnd) continue;
+    let idx = Math.floor((ts - rangeStart) / bucketMs);
+    if (idx < 0) idx = 0;
+    if (idx >= bucketCount) idx = bucketCount - 1;
+    const bucket = points[idx];
+    for (const metric of TREND_METRICS) {
+      const v = metricValue(attempt, metric);
+      if (typeof v === 'number' && !Number.isNaN(v)) {
+        bucket.values[metric].push(v);
+      }
+    }
+  }
+
+  return points;
+}
+
+export interface ImprovementOptions {
+  /** Minimum number of attempts for an item to qualify (default 4). */
+  minAttempts?: number;
+  /** Minimum days between first and last attempt (default 0 = no span requirement). */
+  minSpanDays?: number;
+  /** Max items returned per list (default 6). */
+  topN?: number;
+  /** Minimum positive delta to be "most improved" (default 2). */
+  minDeltaForImproved?: number;
+  /** recentAvg below this counts as "needs practice" (default 70). */
+  needsPracticeThreshold?: number;
+}
+
+interface ScoredEntry {
+  score: number;
+  createdAt: string;
+}
+
+function buildImprovementItem(
+  id: string,
+  kind: ImprovementItem['kind'],
+  entries: ScoredEntry[],
+  minAttempts: number,
+  minSpanDays: number,
+): ImprovementItem | null {
+  const n = entries.length;
+  if (n < minAttempts) return null;
+
+  const sorted = [...entries].sort(
+    (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
+  );
+  const firstAt = sorted[0].createdAt;
+  const lastAt = sorted[n - 1].createdAt;
+  const spanDays =
+    (new Date(lastAt).getTime() - new Date(firstAt).getTime()) / DAY_MS;
+  if (spanDays < minSpanDays) return null;
+
+  const half = Math.ceil(n / 2);
+  const earlyScores = sorted.slice(0, half).map((e) => e.score);
+  const recentScores = sorted.slice(n - half).map((e) => e.score);
+  const mean = (xs: number[]) => xs.reduce((s, x) => s + x, 0) / xs.length;
+  const earlyAvg = mean(earlyScores);
+  const recentAvg = mean(recentScores);
+
+  return {
+    id,
+    kind,
+    label: id,
+    earlyAvg,
+    recentAvg,
+    delta: recentAvg - earlyAvg,
+    attempts: n,
+    firstPracticedAt: firstAt,
+    lastPracticedAt: lastAt,
+    scores: sorted.map((e) => e.score),
+  };
+}
+
+/**
+ * Computes "most improved" and "needs more practice" items across words, sentences,
+ * and phonemes, comparing the earlier half of attempts to the recent half.
+ *
+ * A noise guard requires at least `minAttempts` attempts (and optionally a minimum
+ * day span); items below threshold appear in neither list.
+ */
+export function computeImprovement(
+  sentenceAttempts: SentencePracticeAttempt[],
+  wordAttempts: WordPracticeAttempt[],
+  window: AnalyticsWindow,
+  options?: ImprovementOptions & { now?: Date },
+): { mostImproved: ImprovementItem[]; needsPractice: ImprovementItem[] } {
+  const minAttempts = options?.minAttempts ?? 4;
+  const minSpanDays = options?.minSpanDays ?? 0;
+  const topN = options?.topN ?? 6;
+  const minDeltaForImproved = options?.minDeltaForImproved ?? 2;
+  const needsPracticeThreshold = options?.needsPracticeThreshold ?? 70;
+  const now = options?.now ?? new Date();
+
+  const sentences = filterByWindow(sentenceAttempts, window, now);
+  const words = filterByWindow(wordAttempts, window, now);
+
+  // Group scored entries by item.
+  const wordEntries = new Map<string, ScoredEntry[]>();
+  const sentenceEntries = new Map<string, ScoredEntry[]>();
+  const phonemeEntries = new Map<string, ScoredEntry[]>();
+
+  const push = (map: Map<string, ScoredEntry[]>, key: string, entry: ScoredEntry) => {
+    const arr = map.get(key);
+    if (arr) arr.push(entry);
+    else map.set(key, [entry]);
+  };
+
+  for (const a of sentences) {
+    push(sentenceEntries, a.sentenceId, { score: a.overallScore, createdAt: a.createdAt });
+    if (a.wordScores) {
+      for (const ws of a.wordScores) {
+        if (ws.phonemeScores) {
+          for (const ps of ws.phonemeScores) {
+            push(phonemeEntries, ps.phonemeId, {
+              score: ps.overallScore,
+              createdAt: a.createdAt,
+            });
+          }
+        }
+      }
+    }
+  }
+  for (const a of words) {
+    push(wordEntries, a.wordId, { score: a.overallScore, createdAt: a.createdAt });
+    if (a.phonemeScores) {
+      for (const ps of a.phonemeScores) {
+        push(phonemeEntries, ps.phonemeId, {
+          score: ps.overallScore,
+          createdAt: a.createdAt,
+        });
+      }
+    }
+  }
+
+  const items: ImprovementItem[] = [];
+  const collect = (map: Map<string, ScoredEntry[]>, kind: ImprovementItem['kind']) => {
+    for (const [id, entries] of map.entries()) {
+      const item = buildImprovementItem(id, kind, entries, minAttempts, minSpanDays);
+      if (item) items.push(item);
+    }
+  };
+  collect(wordEntries, 'word');
+  collect(sentenceEntries, 'sentence');
+  collect(phonemeEntries, 'phoneme');
+
+  const mostImproved = items
+    .filter((it) => it.delta >= minDeltaForImproved)
+    .sort((a, b) => b.delta - a.delta || a.id.localeCompare(b.id))
+    .slice(0, topN);
+
+  const needsPractice = items
+    .filter((it) => it.recentAvg < needsPracticeThreshold || it.delta <= 0)
+    .sort((a, b) => a.recentAvg - b.recentAvg || a.id.localeCompare(b.id))
+    .slice(0, topN);
+
+  return { mostImproved, needsPractice };
+}
+
+/** Average of a numeric array, or undefined when empty. */
+function avg(xs: number[]): number | undefined {
+  return xs.length > 0 ? xs.reduce((s, x) => s + x, 0) / xs.length : undefined;
+}
+
+/**
+ * Generates deterministic, data-grounded insights for the learner.
+ *
+ * Rules run in a fixed order and each is guarded by a minimum-sample check, so the
+ * output is fully deterministic for a given input (no randomness; `now` injectable).
+ */
+export function generateInsights(
+  sentenceAttempts: SentencePracticeAttempt[],
+  wordAttempts: WordPracticeAttempt[],
+  window: AnalyticsWindow,
+  now: Date = new Date(),
+): AnalyticsInsight[] {
+  const sentences = filterByWindow(sentenceAttempts, window, now);
+  const words = filterByWindow(wordAttempts, window, now);
+  const insights: AnalyticsInsight[] = [];
+
+  const allOverall = [
+    ...sentences.map((a) => a.overallScore),
+    ...words.map((a) => a.overallScore),
+  ];
+  const overallMean = avg(allOverall);
+  const MIN_TOTAL = 5;
+  if (overallMean === undefined || allOverall.length < MIN_TOTAL) {
+    return insights; // Not enough data for trustworthy insights.
+  }
+
+  // Rule 1: a phoneme category consistently below the user's overall average.
+  const phonemeStats = computePhonemeStats(sentences, words);
+  const categoryAgg = new Map<string, { sum: number; count: number }>();
+  for (const ps of phonemeStats) {
+    const meta = getPhonemeById(ps.phonemeId);
+    if (!meta || ps.avgOverallScore === undefined) continue;
+    const agg = categoryAgg.get(meta.category) ?? { sum: 0, count: 0 };
+    agg.sum += ps.avgOverallScore * ps.attempts;
+    agg.count += ps.attempts;
+    categoryAgg.set(meta.category, agg);
+  }
+  const weakestCategory = [...categoryAgg.entries()]
+    .filter(([, agg]) => agg.count >= 6)
+    .map(([category, agg]) => ({ category, mean: agg.sum / agg.count }))
+    .sort((a, b) => a.mean - b.mean || a.category.localeCompare(b.category))[0];
+  if (weakestCategory && weakestCategory.mean <= overallMean - 8) {
+    insights.push({
+      id: 'phoneme-category-below-average',
+      severity: 'attention',
+      title: `${capitalize(weakestCategory.category)} sounds need attention`,
+      detail: `Your ${weakestCategory.category} sounds average ${Math.round(
+        weakestCategory.mean,
+      )}, below your overall pronunciation average of ${Math.round(overallMean)}.`,
+    });
+  }
+
+  // Rule 2: short vs long phrases.
+  const shortScores: number[] = [];
+  const longScores: number[] = [];
+  for (const a of sentences) {
+    const wordCount = a.wordScores?.length;
+    if (!wordCount) continue;
+    if (wordCount <= 4) shortScores.push(a.overallScore);
+    else if (wordCount >= 8) longScores.push(a.overallScore);
+  }
+  const shortMean = avg(shortScores);
+  const longMean = avg(longScores);
+  if (
+    shortMean !== undefined &&
+    longMean !== undefined &&
+    shortScores.length >= 3 &&
+    longScores.length >= 3 &&
+    shortMean - longMean >= 8
+  ) {
+    insights.push({
+      id: 'short-vs-long-phrases',
+      severity: 'neutral',
+      title: 'You do better on short phrases',
+      detail: `Short phrases average ${Math.round(
+        shortMean,
+      )} versus ${Math.round(longMean)} on longer ones — extra reps on longer phrases will close the gap.`,
+    });
+  }
+
+  // Rule 3: scores improve with repeated attempts within the same session.
+  const sessionItem = new Map<string, ScoredEntry[]>();
+  for (const a of sentences) {
+    const key = `${a.sessionId}::s::${a.sentenceId}`;
+    const arr = sessionItem.get(key);
+    if (arr) arr.push({ score: a.overallScore, createdAt: a.createdAt });
+    else sessionItem.set(key, [{ score: a.overallScore, createdAt: a.createdAt }]);
+  }
+  for (const a of words) {
+    const key = `${a.sessionId}::w::${a.wordId}`;
+    const arr = sessionItem.get(key);
+    if (arr) arr.push({ score: a.overallScore, createdAt: a.createdAt });
+    else sessionItem.set(key, [{ score: a.overallScore, createdAt: a.createdAt }]);
+  }
+  const firstScores: number[] = [];
+  const lastScores: number[] = [];
+  for (const entries of sessionItem.values()) {
+    if (entries.length < 2) continue;
+    const sorted = [...entries].sort(
+      (x, y) => new Date(x.createdAt).getTime() - new Date(y.createdAt).getTime(),
+    );
+    firstScores.push(sorted[0].score);
+    lastScores.push(sorted[sorted.length - 1].score);
+  }
+  const firstMean = avg(firstScores);
+  const lastMean = avg(lastScores);
+  if (
+    firstMean !== undefined &&
+    lastMean !== undefined &&
+    firstScores.length >= 3 &&
+    lastMean - firstMean >= 3
+  ) {
+    insights.push({
+      id: 'improves-with-repetition',
+      severity: 'positive',
+      title: 'Repetition is paying off',
+      detail: `When you retry an item in a session, your score rises by about ${Math.round(
+        lastMean - firstMean,
+      )} points on average — keep using retries.`,
+    });
+  }
+
+  // Rule 4: difficulty gradient.
+  const diffStats = computeDifficultyStats(sentences, words);
+  const easy = diffStats.find((d) => d.difficulty === 2);
+  const hard = diffStats.find((d) => d.difficulty === 4);
+  if (
+    easy?.avgOverallScore !== undefined &&
+    hard?.avgOverallScore !== undefined &&
+    easy.sentenceAttempts + easy.wordAttempts >= 3 &&
+    hard.sentenceAttempts + hard.wordAttempts >= 3 &&
+    easy.avgOverallScore - hard.avgOverallScore >= 12
+  ) {
+    insights.push({
+      id: 'difficulty-gradient',
+      severity: 'neutral',
+      title: 'Harder content is challenging you',
+      detail: `You average ${Math.round(
+        easy.avgOverallScore,
+      )} on easy items but ${Math.round(
+        hard.avgOverallScore,
+      )} on hard ones. That gap is normal — it shows where to push next.`,
+    });
+  }
+
+  // Rule 5: momentum over the window.
+  const trend = buildMultiMetricTrend(sentenceAttempts, wordAttempts, window, now);
+  const bucketMeans = trend
+    .map((p) => avg(p.values.overall))
+    .filter((m): m is number => m !== undefined);
+  if (bucketMeans.length >= 4) {
+    const third = Math.max(1, Math.floor(bucketMeans.length / 3));
+    const firstThird = avg(bucketMeans.slice(0, third)) ?? 0;
+    const lastThird = avg(bucketMeans.slice(bucketMeans.length - third)) ?? 0;
+    const momentum = lastThird - firstThird;
+    if (momentum >= 3) {
+      insights.push({
+        id: 'momentum-up',
+        severity: 'positive',
+        title: 'Your scores are trending up',
+        detail: `Your overall pronunciation rose about ${Math.round(
+          momentum,
+        )} points across this period. Keep it going!`,
+      });
+    } else if (momentum <= -3) {
+      insights.push({
+        id: 'momentum-down',
+        severity: 'attention',
+        title: 'Your scores have dipped recently',
+        detail: `Your overall pronunciation is down about ${Math.round(
+          Math.abs(momentum),
+        )} points across this period. A few focused sessions can turn it around.`,
+      });
+    }
+  }
+
+  return insights;
+}
+
+function capitalize(s: string): string {
+  return s.length === 0 ? s : s[0].toUpperCase() + s.slice(1);
+}
+
+/** Resolves an Azure/dataset phoneme id to its canonical metadata id, for matching. */
+function canonicalPhonemeId(id: string): string {
+  return getPhonemeById(id)?.id ?? id.trim().toUpperCase();
+}
+
+export interface RecommendationOptions {
+  /** Max recommendations per kind (default 5). */
+  perKind?: number;
+}
+
+/**
+ * Builds practice recommendations grounded in stored assessment data and real content.
+ *
+ * Returns a flat list spanning sounds, words, and phrases; every recommendation points
+ * to an item that exists in the supplied content (or a practiced item). Reuses
+ * computePhonemeStats, buildWordProgress/getWeakWordIds, and buildReviewQueue.
+ */
+export function buildRecommendations(
+  sentenceAttempts: SentencePracticeAttempt[],
+  wordAttempts: WordPracticeAttempt[],
+  allWords: Word[],
+  allSentences: Sentence[],
+  options?: RecommendationOptions,
+): PracticeRecommendation[] {
+  const perKind = options?.perKind ?? 5;
+  const recs: PracticeRecommendation[] = [];
+
+  const wordById = new Map(allWords.map((w) => [w.id, w]));
+  const sentenceById = new Map(allSentences.map((s) => [s.id, s]));
+
+  // --- Weak sounds ---
+  const phonemeStats = computePhonemeStats(sentenceAttempts, wordAttempts);
+  const weakPhonemes = phonemeStats
+    .filter((p) => p.weaknessLabel === 'weak' && p.avgOverallScore !== undefined)
+    .sort((a, b) => (a.avgOverallScore ?? 0) - (b.avgOverallScore ?? 0))
+    .slice(0, perKind);
+  for (const p of weakPhonemes) {
+    recs.push({
+      kind: 'phoneme',
+      id: p.phonemeId,
+      label: getPhonemeById(p.phonemeId)?.ipa ?? p.phonemeId,
+      reason: `Averaging ${Math.round(
+        p.avgOverallScore ?? 0,
+      )}% across ${p.attempts} reps — one of your weakest sounds.`,
+      score: 100 - (p.avgOverallScore ?? 0),
+      to: '/progress#resources',
+    });
+  }
+  const weakCanonical = new Set(weakPhonemes.map((p) => canonicalPhonemeId(p.phonemeId)));
+
+  // --- Weak words (grounded in practiced content, supplemented by content w/ weak sounds) ---
+  const { perWord } = buildWordProgress(wordAttempts, allWords.length || 1);
+  const weakWordIds = getWeakWordIds(perWord)
+    .map((id) => ({ id, weakness: perWord[id]?.weaknessScore ?? 0 }))
+    .sort((a, b) => b.weakness - a.weakness)
+    .slice(0, perKind);
+  for (const { id, weakness } of weakWordIds) {
+    const word = wordById.get(id);
+    recs.push({
+      kind: 'word',
+      id,
+      label: word?.textPt ?? id,
+      reason: `Practiced ${perWord[id]?.attempts ?? 0} times, still below target — worth another round.`,
+      score: weakness,
+      to: '/?tab=words',
+    });
+  }
+  // Supplement with content words that contain a weak sound, if we have spare slots.
+  if (weakWordIds.length < perKind && weakCanonical.size > 0) {
+    const taken = new Set(weakWordIds.map((w) => w.id));
+    for (const w of allWords) {
+      if (recs.filter((r) => r.kind === 'word').length >= perKind) break;
+      if (taken.has(w.id)) continue;
+      const hasWeak = (w.phonemes ?? []).some((ph) => weakCanonical.has(canonicalPhonemeId(ph)));
+      if (!hasWeak) continue;
+      const weakSound = (w.phonemes ?? []).find((ph) => weakCanonical.has(canonicalPhonemeId(ph)));
+      recs.push({
+        kind: 'word',
+        id: w.id,
+        label: w.textPt,
+        reason: `Practises your weak ${getPhonemeById(weakSound ?? '')?.ipa ?? weakSound} sound.`,
+        score: 40,
+        to: '/?tab=words',
+      });
+      taken.add(w.id);
+    }
+  }
+
+  // --- Weak phrases (from review queue, supplemented by content w/ weak sounds) ---
+  const lowSentences = buildReviewQueue(sentenceAttempts, [], { maxItems: perKind })
+    .filter((q) => q.itemType === 'sentence');
+  for (const q of lowSentences) {
+    const sentence = sentenceById.get(q.itemId);
+    recs.push({
+      kind: 'sentence',
+      id: q.itemId,
+      label: sentence?.textPt ?? q.itemId,
+      reason: `Best score ${Math.round(q.bestScore)} — revisit to push it higher.`,
+      score: 100 - q.bestScore,
+      to: '/',
+    });
+  }
+  if (lowSentences.length < perKind && weakCanonical.size > 0) {
+    const taken = new Set(lowSentences.map((q) => q.itemId));
+    for (const s of allSentences) {
+      if (recs.filter((r) => r.kind === 'sentence').length >= perKind) break;
+      if (taken.has(s.id)) continue;
+      const hasWeak = (s.phonemes ?? []).some((ph) => weakCanonical.has(canonicalPhonemeId(ph)));
+      if (!hasWeak) continue;
+      recs.push({
+        kind: 'sentence',
+        id: s.id,
+        label: s.textPt,
+        reason: 'Includes sounds you are working on.',
+        score: 30,
+        to: '/',
+      });
+      taken.add(s.id);
+    }
+  }
+
+  return recs;
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -400,3 +400,92 @@ export interface PhonemeStats {
   lastPracticedAt?: string; // ISO timestamp
   weaknessLabel?: "weak" | "ok" | "strong";
 }
+
+// ============================================================================
+// Progress Analytics Dashboard Types
+// ============================================================================
+
+/**
+ * Time window for analytics computations.
+ */
+export type AnalyticsWindow = "7d" | "30d" | "90d" | "all";
+
+/**
+ * One of the four Azure pronunciation assessment metrics (plus optional prosody).
+ */
+export type TrendMetric =
+  | "overall"
+  | "accuracy"
+  | "fluency"
+  | "completeness"
+  | "prosody";
+
+/**
+ * A single time bucket holding the raw scores recorded in that bucket per metric.
+ * Consumers (charts) average the arrays to produce a trend line.
+ */
+export interface TrendPoint {
+  /** ISO date (YYYY-MM-DD) marking the start of the bucket. */
+  date: string;
+  /** Human-friendly bucket label (e.g. "6/17"). */
+  label: string;
+  /** Raw scores recorded within the bucket, keyed by metric. */
+  values: Record<TrendMetric, number[]>;
+}
+
+/**
+ * An item (word / sentence / phoneme) whose score changed over the window.
+ * Used for "Most Improved" and "Needs More Practice" lists.
+ */
+export interface ImprovementItem {
+  id: string;
+  kind: "word" | "sentence" | "phoneme";
+  /** Display label; for words/sentences this is the id (UI resolves to text). */
+  label: string;
+  /** Mean score of the earlier half of attempts. */
+  earlyAvg: number;
+  /** Mean score of the recent half of attempts. */
+  recentAvg: number;
+  /** recentAvg - earlyAvg (positive = improving). */
+  delta: number;
+  attempts: number;
+  firstPracticedAt: string;
+  lastPracticedAt: string;
+  /** Chronological scores, for sparkline rendering. */
+  scores: number[];
+}
+
+/**
+ * A deterministic, data-grounded insight surfaced to the learner.
+ */
+export interface AnalyticsInsight {
+  /** Stable key (e.g. "phoneme-category-below-average"). */
+  id: string;
+  severity: "positive" | "neutral" | "attention";
+  title: string;
+  detail: string;
+}
+
+/**
+ * A practice recommendation grounded in stored assessment data.
+ */
+export interface PracticeRecommendation {
+  kind: "phoneme" | "word" | "sentence";
+  id: string;
+  label: string;
+  /** Human-readable justification tying the recommendation to the data. */
+  reason: string;
+  /** Priority score (higher = more important). */
+  score: number;
+  /** In-app route to act on the recommendation. */
+  to: string;
+}
+
+/**
+ * A pronunciation learning resource (e.g. tutorial video search) for a sound or word.
+ */
+export interface LearningResource {
+  label: string;
+  url: string;
+  source: "youtube-search" | "curated" | "forvo";
+}

--- a/src/pages/ProgressPage.tsx
+++ b/src/pages/ProgressPage.tsx
@@ -1,25 +1,48 @@
 import { useEffect, useState, useMemo } from 'react';
-import { Link } from 'react-router-dom';
-import { Clock, Flame, ClipboardList } from 'lucide-react';
 import { usePracticeLogStore } from '@/state/practiceLogStore';
 import { useProgressStore } from '@/state/progressStore';
 import { loadAllSentences, loadAllWords } from '@/lib/data';
-import { computeUserGlobalStats, computePhonemeStats } from '@/lib/practiceAnalytics';
-import Rolling7DayChart from '@/components/dashboard/Rolling7DayChart';
+import type { AnalyticsWindow, Sentence, Word } from '@/lib/types';
+import {
+  computeUserGlobalStats,
+  computePhonemeStats,
+  buildMultiMetricTrend,
+  computeImprovement,
+  generateInsights,
+  buildRecommendations,
+} from '@/lib/practiceAnalytics';
 import PageScaffold from '@/components/common/PageScaffold';
-import MetricTile from '@/components/common/MetricTile';
 import ActionPanel from '@/components/common/ActionPanel';
-import ChartContainer from '@/components/common/ChartContainer';
 import LoadingSpinner from '@/components/common/LoadingSpinner';
 import ErrorMessage from '@/components/common/ErrorMessage';
+import AnalyticsTabs from '@/components/analytics/AnalyticsTabs';
+import OverviewSection from '@/components/analytics/OverviewSection';
+import ProgressTrendSection from '@/components/analytics/ProgressTrendSection';
+import StrengthsSection from '@/components/analytics/StrengthsSection';
+import FocusAreasSection, {
+  type MispronouncedWord,
+  type RetriedPhrase,
+} from '@/components/analytics/FocusAreasSection';
+import RecommendationsSection from '@/components/analytics/RecommendationsSection';
+import LearningResourcesSection from '@/components/analytics/LearningResourcesSection';
+
+const SECTION_IDS = [
+  'overview',
+  'progress',
+  'strengths',
+  'focus',
+  'recommendations',
+  'resources',
+];
 
 export default function ProgressPage() {
   const { sessions, sentenceAttempts, wordAttempts, storageError } = usePracticeLogStore();
   const { getDueCount } = useProgressStore();
-  const [sentences, setSentences] = useState<{ id: string }[]>([]);
-  const [words, setWords] = useState<{ id: string }[]>([]);
+  const [sentences, setSentences] = useState<Sentence[]>([]);
+  const [words, setWords] = useState<Word[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [window, setWindow] = useState<AnalyticsWindow>('30d');
 
   useEffect(() => {
     async function loadData() {
@@ -31,18 +54,25 @@ export default function ProgressPage() {
         ]);
         setSentences(sentencesData);
         setWords(wordsData);
-      } catch (error) {
-        console.error('Error loading progress data:', error);
-        const message = error instanceof Error
-          ? error.message
-          : 'Failed to load progress data';
-        setError(message);
+      } catch (err) {
+        console.error('Error loading progress data:', err);
+        setError(err instanceof Error ? err.message : 'Failed to load progress data');
       } finally {
         setLoading(false);
       }
     }
     loadData();
   }, []);
+
+  // Lookup maps for resolving ids to display text.
+  const wordLabels = useMemo(
+    () => new Map(words.map((w) => [w.id, w.textPt])),
+    [words],
+  );
+  const sentenceLabels = useMemo(
+    () => new Map(sentences.map((s) => [s.id, s.textPt])),
+    [sentences],
+  );
 
   const userStats = useMemo(() => {
     if (loading || sentences.length === 0 || words.length === 0) return null;
@@ -60,47 +90,118 @@ export default function ProgressPage() {
     const todaySessions = sessions.filter(
       (s) => new Date(s.startedAt).toISOString().split('T')[0] === todayStr,
     );
-    return Math.round(
-      todaySessions.reduce((sum, s) => sum + s.durationSeconds, 0) / 60,
-    );
+    return Math.round(todaySessions.reduce((sum, s) => sum + s.durationSeconds, 0) / 60);
   }, [sessions]);
 
-  const weakPhonemes = useMemo(() => {
-    if (sentenceAttempts.length === 0 && wordAttempts.length === 0) return [];
-    return computePhonemeStats(sentenceAttempts, wordAttempts)
-      .filter((p) => p.weaknessLabel === 'weak')
-      .sort((a, b) => (a.avgOverallScore ?? 0) - (b.avgOverallScore ?? 0))
-      .slice(0, 3);
-  }, [sentenceAttempts, wordAttempts]);
+  // All-time phoneme stats power strengths, focus, recommendations, and resources.
+  const phonemeStats = useMemo(
+    () => computePhonemeStats(sentenceAttempts, wordAttempts),
+    [sentenceAttempts, wordAttempts],
+  );
 
-  const rolling7DayData = useMemo(() => {
-    const now = new Date();
-    const days: Array<{ date: string; values: number[] }> = [];
-    for (let i = 6; i >= 0; i--) {
-      const date = new Date(now);
-      date.setDate(date.getDate() - i);
-      date.setHours(0, 0, 0, 0);
-      const dateStr = date.toISOString().split('T')[0];
-      const dayScores = [
-        ...sentenceAttempts.filter(
-          (a) => new Date(a.createdAt).toISOString().split('T')[0] === dateStr,
-        ),
-        ...wordAttempts.filter(
-          (a) => new Date(a.createdAt).toISOString().split('T')[0] === dateStr,
-        ),
-      ].map((a) => a.overallScore);
-      days.push({ date: dateStr, values: dayScores });
+  const weakPhonemes = useMemo(
+    () =>
+      phonemeStats
+        .filter((p) => p.weaknessLabel === 'weak')
+        .sort((a, b) => (a.avgOverallScore ?? 0) - (b.avgOverallScore ?? 0))
+        .slice(0, 5),
+    [phonemeStats],
+  );
+
+  const strongPhonemes = useMemo(
+    () =>
+      phonemeStats
+        .filter((p) => p.weaknessLabel === 'strong' && p.attempts >= 2)
+        .sort((a, b) => (b.avgOverallScore ?? 0) - (a.avgOverallScore ?? 0))
+        .slice(0, 5),
+    [phonemeStats],
+  );
+
+  const trendData = useMemo(
+    () => buildMultiMetricTrend(sentenceAttempts, wordAttempts, window),
+    [sentenceAttempts, wordAttempts, window],
+  );
+
+  const { mostImproved, needsPractice } = useMemo(
+    () => computeImprovement(sentenceAttempts, wordAttempts, window),
+    [sentenceAttempts, wordAttempts, window],
+  );
+
+  const insights = useMemo(
+    () => generateInsights(sentenceAttempts, wordAttempts, window),
+    [sentenceAttempts, wordAttempts, window],
+  );
+
+  const recommendations = useMemo(() => {
+    if (sentences.length === 0 || words.length === 0) return [];
+    return buildRecommendations(sentenceAttempts, wordAttempts, words, sentences);
+  }, [sentenceAttempts, wordAttempts, words, sentences]);
+
+  // Frequently mispronounced words (from sentence word-level scores).
+  const mispronouncedWords = useMemo<MispronouncedWord[]>(() => {
+    const counts = new Map<string, number>();
+    for (const attempt of sentenceAttempts) {
+      for (const ws of attempt.wordScores ?? []) {
+        const isWeak = ws.errorType === 'mispronounced' || ws.overallScore < 60;
+        if (!isWeak) continue;
+        const token = ws.token.trim();
+        if (!token) continue;
+        counts.set(token, (counts.get(token) ?? 0) + 1);
+      }
     }
-    return days;
-  }, [sentenceAttempts, wordAttempts]);
+    return [...counts.entries()]
+      .filter(([, count]) => count >= 2)
+      .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+      .slice(0, 8)
+      .map(([token, count]) => ({ token, count }));
+  }, [sentenceAttempts]);
+
+  // Phrases that were repeatedly retried (in-session retries + repeated attempts).
+  const retriedPhrases = useMemo<RetriedPhrase[]>(() => {
+    const retriesById = new Map<string, number>();
+    const attemptsById = new Map<string, number>();
+    for (const attempt of sentenceAttempts) {
+      retriesById.set(
+        attempt.sentenceId,
+        (retriesById.get(attempt.sentenceId) ?? 0) + (attempt.retriesInThisSession ?? 0),
+      );
+      attemptsById.set(
+        attempt.sentenceId,
+        (attemptsById.get(attempt.sentenceId) ?? 0) + 1,
+      );
+    }
+    return [...attemptsById.keys()]
+      .map((id) => ({
+        id,
+        label: sentenceLabels.get(id) ?? id,
+        retries: (retriesById.get(id) ?? 0) + ((attemptsById.get(id) ?? 1) - 1),
+      }))
+      .filter((p) => p.retries > 0)
+      .sort((a, b) => b.retries - a.retries || a.id.localeCompare(b.id))
+      .slice(0, 5);
+  }, [sentenceAttempts, sentenceLabels]);
+
+  const focusWords = useMemo(
+    () =>
+      recommendations
+        .filter((r) => r.kind === 'word')
+        .slice(0, 4)
+        .map((r) => ({ textPt: r.label })),
+    [recommendations],
+  );
+
+  const weakPhonemeIds = useMemo(
+    () => weakPhonemes.slice(0, 4).map((p) => p.phonemeId),
+    [weakPhonemes],
+  );
 
   const dueCount = getDueCount();
-  const hasData = sessions.length > 0 || sentenceAttempts.length > 0 || wordAttempts.length > 0;
-  const hasChartData = rolling7DayData.some((d) => d.values.length > 0);
+  const totalAttempts = sentenceAttempts.length + wordAttempts.length;
+  const hasData = sessions.length > 0 || totalAttempts > 0;
 
   if (loading) {
     return (
-      <PageScaffold title="Progress" subtitle="Your pronunciation practice at a glance">
+      <PageScaffold title="Progress" subtitle="Your pronunciation analytics at a glance">
         <LoadingSpinner message="Loading progress..." />
       </PageScaffold>
     );
@@ -108,7 +209,7 @@ export default function ProgressPage() {
 
   if (error) {
     return (
-      <PageScaffold title="Progress" subtitle="Your pronunciation practice at a glance">
+      <PageScaffold title="Progress" subtitle="Your pronunciation analytics at a glance">
         <ErrorMessage
           title="Failed to Load Data"
           message={error}
@@ -116,7 +217,11 @@ export default function ProgressPage() {
             setLoading(true);
             setError(null);
             Promise.all([loadAllSentences(), loadAllWords()])
-              .then(([s, w]) => { setSentences(s); setWords(w); setLoading(false); })
+              .then(([s, w]) => {
+                setSentences(s);
+                setWords(w);
+                setLoading(false);
+              })
               .catch((err) => {
                 setError(err instanceof Error ? err.message : 'Failed to reload data');
                 setLoading(false);
@@ -128,7 +233,7 @@ export default function ProgressPage() {
   }
 
   return (
-    <PageScaffold title="Progress" subtitle="Your pronunciation practice at a glance">
+    <PageScaffold title="Progress" subtitle="Am I improving, and what should I practice next?">
       {storageError && (
         <ErrorMessage
           title="Storage Full"
@@ -136,7 +241,6 @@ export default function ProgressPage() {
         />
       )}
 
-      {/* CTA */}
       <ActionPanel
         heading={hasData ? 'Continue Practicing' : 'Start Practicing'}
         description={
@@ -148,74 +252,45 @@ export default function ProgressPage() {
         secondaryAction={dueCount > 0 ? { label: 'Review Items', to: '/review' } : undefined}
       />
 
-      {/* Hero Metrics */}
-      {hasData && (
-        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
-          <MetricTile
-            label="Today's Practice"
-            value={`${todayMinutes} min`}
-            icon={Clock}
-            description="Practice time today"
+      {!hasData ? (
+        <OverviewSection
+          userStats={userStats}
+          totalAttempts={totalAttempts}
+          todayMinutes={todayMinutes}
+          dueCount={dueCount}
+          insights={insights}
+        />
+      ) : (
+        <>
+          <AnalyticsTabs sections={SECTION_IDS} />
+          <OverviewSection
+            userStats={userStats}
+            totalAttempts={totalAttempts}
+            todayMinutes={todayMinutes}
+            dueCount={dueCount}
+            insights={insights}
           />
-          <MetricTile
-            label="Current Streak"
-            value={userStats?.currentDailyStreak ?? 0}
-            icon={Flame}
-            description="Days in a row"
+          <ProgressTrendSection data={trendData} window={window} onWindowChange={setWindow} />
+          <StrengthsSection
+            mostImproved={mostImproved}
+            strongPhonemes={strongPhonemes}
+            wordLabels={wordLabels}
+            sentenceLabels={sentenceLabels}
           />
-          <MetricTile
-            label="Items Due"
-            value={dueCount}
-            icon={ClipboardList}
-            description="Ready for review"
-            action={dueCount > 0 ? { label: 'Start review', to: '/review' } : undefined}
+          <FocusAreasSection
+            weakPhonemes={weakPhonemes}
+            needsPractice={needsPractice}
+            mispronouncedWords={mispronouncedWords}
+            retriedPhrases={retriedPhrases}
+            wordLabels={wordLabels}
+            sentenceLabels={sentenceLabels}
           />
-        </div>
-      )}
-
-      {/* Weekly Trend Chart */}
-      {hasData && (
-        <ChartContainer
-          title="Weekly Trend"
-          isEmpty={!hasChartData}
-          emptyMessage="Practice some sentences or words to see your weekly trend."
-        >
-          <Rolling7DayChart title="Overall Score" data={rolling7DayData} />
-        </ChartContainer>
-      )}
-
-      {/* Weak Phonemes */}
-      {weakPhonemes.length > 0 && (
-        <section className="card">
-          <div className="flex items-center justify-between mb-4">
-            <h2 className="text-xl font-bold text-gray-900 dark:text-gray-100">
-              Areas to Improve
-            </h2>
-            <Link to="/review" className="text-sm text-primary-600 dark:text-primary-400 hover:underline">
-              Review weak items
-            </Link>
-          </div>
-          <div className="space-y-2">
-            {weakPhonemes.map((phoneme) => (
-              <div
-                key={phoneme.phonemeId}
-                className="flex items-center justify-between p-3 bg-gray-50 dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700"
-              >
-                <div>
-                  <span className="font-mono text-sm font-medium text-gray-900 dark:text-gray-100">
-                    {phoneme.phonemeId}
-                  </span>
-                  <span className="text-xs text-gray-500 dark:text-gray-400 ml-2">
-                    {phoneme.attempts} attempts
-                  </span>
-                </div>
-                <span className="text-sm font-semibold text-red-600 dark:text-red-400">
-                  {phoneme.avgOverallScore?.toFixed(0) ?? 'N/A'}
-                </span>
-              </div>
-            ))}
-          </div>
-        </section>
+          <RecommendationsSection recommendations={recommendations} />
+          <LearningResourcesSection
+            weakPhonemeIds={weakPhonemeIds}
+            focusWords={focusWords}
+          />
+        </>
       )}
     </PageScaffold>
   );


### PR DESCRIPTION
Expand the Progress page into a sectioned speech-assessment analytics
experience answering "Am I improving?" and "What should I practice next?".

- practiceAnalytics: add filterByWindow, buildMultiMetricTrend (7/30/90/all),
  computeImprovement (most improved / needs practice with noise guard),
  generateInsights (deterministic, data-grounded), and buildRecommendations
  (grounded in real content) — all pure and unit-tested.
- learningResources: deterministic phoneme/word -> tutorial resolver using
  dynamic YouTube search + Forvo links, with a tiny optional curated override
  map (no manual video curation, no API key).
- UI: new src/components/analytics sections (Overview, Progress, Strengths,
  Focus Areas, Recommendations, Learning Resources) + sticky in-page tabs and a
  responsive multi-metric trend chart; ProgressPage owns the computations.
- docs: add analytics-pipeline.md; update FEATURES.md.

Reuses existing computePhonemeStats, buildWordProgress/getWeakWordIds,
buildReviewQueue, phoneme metadata, and content loaders.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XZSG5LySCdDi9QSDrTWkr6