### PR TITLE
Replace demo data with real sentences and native audio playback

### DIFF
--- a/DEMO_READY.md
+++ b/DEMO_READY.md
@@ -79,11 +79,12 @@ See `.env.example` for the complete list.
 ## 5. What works WITHOUT Azure credentials
 
 - ✅ **`/tour`** — the full product explainer (static, self-contained).
-- ✅ **`/demo`** — pick a word/phrase, "Analyze demo recording", and see a
-  realistic **sample** score, word-by-word chips, phoneme breakdown (with IPA
-  and teaching tips), coaching suggestions, and a progress trend. All of this
-  is hand-authored sample data in `src/lib/demo/demoData.ts` and is clearly
-  labeled "Sample data" in the UI.
+- ✅ **`/demo`** — pick a real PT-BR sentence, play its native reference audio,
+  "Analyze demo recording", and see a realistic **sample** score, word-by-word
+  chips, phoneme breakdown (with IPA and teaching tips), coaching suggestions,
+  and a progress trend. The sentences and native audio are real; the scores and
+  history are hand-authored sample data in `src/lib/demo/demoData.ts` and are
+  clearly labeled "Sample data" in the UI.
 - ✅ The frontend builds and runs; navigation, styling, and layout all work.
 
 ## 6. What REQUIRES Azure credentials (and MongoDB)

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -103,8 +103,9 @@ A comprehensive list of what LusoPronounce can do, organized by feature area.
 ## Public Tour & Demo Mode
 
 - **Take a Tour** — A public, no-login `/tour` page that explains the product for portfolio/recruiter viewing: what it does, the practice flow, pronunciation feedback, progress tracking, why it helps, and technical highlights.
-- **Interactive Demo Mode** — A public, no-login `/demo` page where visitors pick from a fixed set of PT-BR words/phrases (pão, mãe, trabalho, obrigado, coração, não, filho, Rio de Janeiro), trigger a simulated assessment, and explore a realistic sample result: overall + sub-scores, word-by-word chips, phoneme breakdown with IPA, coaching tips, and a progress trend.
-- **Clearly-Labeled Sample Data** — Demo results are hand-authored sample data (not live Azure output) and are labeled as such in the UI; no microphone, account, Azure credentials, or database are required.
+- **Interactive Demo Mode** — A public, no-login `/demo` page where visitors pick from a set of real PT-BR sentences drawn from the app's content ("Oi, tudo bem?", "Estou muito feliz hoje.", "A conta, por favor.", "Minha mãe se chama Ana.", "Que horas são?"), play the native reference audio, trigger a simulated assessment, and explore a realistic sample result: overall + sub-scores, word-by-word chips, phoneme breakdown with IPA, coaching tips, and a progress trend.
+- **Native Reference Playback in Demo** — Each demo sentence plays its real native pronunciation audio (the same clip used in the full app), with an optional slot to play back a sample learner recording alongside it for comparison.
+- **Clearly-Labeled Sample Data** — Demo scores, phoneme feedback, and history are hand-authored sample data (not live Azure output) and are labeled as such in the UI; no microphone, account, Azure credentials, or database are required.
 
 ## Infrastructure
 

--- a/src/components/pronunciation/PhraseScoreOverview.tsx
+++ b/src/components/pronunciation/PhraseScoreOverview.tsx
@@ -93,10 +93,10 @@ export default function PhraseScoreOverview({
   //   : [];
 
   const getScoreColor = (score: number) => {
-    if (score >= 90) return 'bg-emerald-500';
-    if (score >= 80) return 'bg-sky-500';
-    if (score >= 70) return 'bg-amber-500';
-    return 'bg-rose-500';
+    if (score >= 90) return 'bg-gradient-to-r from-emerald-400 to-emerald-500';
+    if (score >= 80) return 'bg-gradient-to-r from-sky-400 to-sky-500';
+    if (score >= 70) return 'bg-gradient-to-r from-amber-400 to-amber-500';
+    return 'bg-gradient-to-r from-rose-400 to-rose-500';
   };
 
   return (
@@ -113,7 +113,7 @@ export default function PhraseScoreOverview({
         </div>
         <div className="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-4 overflow-hidden">
           <div
-            className={`h-full transition-all duration-500 ${getScoreColor(overall)}`}
+            className={`h-full rounded-full shadow-sm transition-all duration-500 ${getScoreColor(overall)}`}
             style={{ width: `${overall}%` }}
           />
         </div>
@@ -142,7 +142,7 @@ export default function PhraseScoreOverview({
         </div>
         <div className="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-2">
           <div
-            className={`h-full transition-all duration-500 ${getScoreColor(accuracy)}`}
+            className={`h-full rounded-full shadow-sm transition-all duration-500 ${getScoreColor(accuracy)}`}
             style={{ width: `${accuracy}%` }}
           />
         </div>
@@ -160,7 +160,7 @@ export default function PhraseScoreOverview({
             </div>
             <div className="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-2">
               <div
-                className={`h-full transition-all duration-500 ${getScoreColor(fluency)}`}
+                className={`h-full rounded-full shadow-sm transition-all duration-500 ${getScoreColor(fluency)}`}
                 style={{ width: `${fluency}%` }}
               />
             </div>
@@ -180,7 +180,7 @@ export default function PhraseScoreOverview({
             </div>
             <div className="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-2">
               <div
-                className={`h-full transition-all duration-500 ${getScoreColor(completeness)}`}
+                className={`h-full rounded-full shadow-sm transition-all duration-500 ${getScoreColor(completeness)}`}
                 style={{ width: `${completeness}%` }}
               />
             </div>
@@ -200,7 +200,7 @@ export default function PhraseScoreOverview({
             </div>
             <div className="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-2">
               <div
-                className={`h-full transition-all duration-500 ${getScoreColor(prosody)}`}
+                className={`h-full rounded-full shadow-sm transition-all duration-500 ${getScoreColor(prosody)}`}
                 style={{ width: `${prosody}%` }}
               />
             </div>

--- a/src/components/pronunciation/PhraseTrendSparkline.tsx
+++ b/src/components/pronunciation/PhraseTrendSparkline.tsx
@@ -1,3 +1,5 @@
+import { useId } from 'react';
+
 interface PhraseTrendSparklineProps {
   scores: number[];
   width?: number;
@@ -5,17 +7,23 @@ interface PhraseTrendSparklineProps {
 }
 
 /**
- * Simple SVG sparkline showing pronunciation score trend across attempts.
- * Renders a minimal line chart with points for each attempt.
- * 
+ * SVG sparkline showing pronunciation score trend across attempts.
+ * Renders a smooth line with a soft gradient area fill, a subtle glow,
+ * and an emphasized endpoint marking the latest attempt.
+ *
  * TODO: Replace with real multi-attempt data when available.
  * This component currently uses synthetic trend data for UX simulation.
  */
 export default function PhraseTrendSparkline({
   scores,
-  width = 200,
-  height = 40,
+  width = 220,
+  height = 48,
 }: PhraseTrendSparklineProps) {
+  // Unique ids so multiple sparklines on one page don't share gradient defs.
+  const uid = useId().replace(/[:]/g, '');
+  const areaGradId = `spark-area-${uid}`;
+  const lineGradId = `spark-line-${uid}`;
+
   if (scores.length === 0) {
     return null;
   }
@@ -40,13 +48,22 @@ export default function PhraseTrendSparkline({
   });
 
   // Create path for the line
-  const pathData = points
+  const linePath = points
     .map((point, index) => `${index === 0 ? 'M' : 'L'} ${point.x} ${point.y}`)
     .join(' ');
+
+  // Closed path for the gradient area fill (line + down to the baseline)
+  const baseline = height - padding;
+  const areaPath =
+    `${linePath} L ${points[points.length - 1].x} ${baseline}` +
+    ` L ${points[0].x} ${baseline} Z`;
+
+  const lastPoint = points[points.length - 1];
 
   // Get first and last scores for labels
   const firstScore = scores[0];
   const lastScore = scores[scores.length - 1];
+  const delta = Math.round((lastScore - firstScore) * 10) / 10;
 
   return (
     <div className="flex items-center gap-3">
@@ -54,39 +71,77 @@ export default function PhraseTrendSparkline({
         <svg
           width={width}
           height={height}
+          viewBox={`0 0 ${width} ${height}`}
           className="overflow-visible"
-          aria-label="Pronunciation trend across attempts"
+          role="img"
+          aria-label={`Pronunciation trend across attempts: from ${firstScore} to ${lastScore}`}
         >
-          {/* Line connecting points */}
+          <defs>
+            <linearGradient id={areaGradId} x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stopColor="currentColor" stopOpacity="0.28" />
+              <stop offset="100%" stopColor="currentColor" stopOpacity="0" />
+            </linearGradient>
+            <linearGradient id={lineGradId} x1="0" y1="0" x2="1" y2="0">
+              <stop offset="0%" stopColor="#34d399" />
+              <stop offset="100%" stopColor="#10b981" />
+            </linearGradient>
+          </defs>
+
+          {/* Gradient area under the line */}
+          <path d={areaPath} fill={`url(#${areaGradId})`} className="text-emerald-500" />
+
+          {/* Trend line */}
           <path
-            d={pathData}
+            d={linePath}
             fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            className="text-emerald-500 dark:text-emerald-400"
+            stroke={`url(#${lineGradId})`}
+            strokeWidth="2.5"
             strokeLinecap="round"
             strokeLinejoin="round"
           />
-          {/* Points */}
-          {points.map((point, index) => (
+
+          {/* Intermediate points */}
+          {points.slice(0, -1).map((point, index) => (
             <circle
               key={index}
               cx={point.x}
               cy={point.y}
-              r="3"
+              r="2.5"
               fill="currentColor"
               className="text-emerald-500 dark:text-emerald-400"
             />
           ))}
+
+          {/* Emphasized endpoint (latest attempt) */}
+          <circle
+            cx={lastPoint.x}
+            cy={lastPoint.y}
+            r="6"
+            fill="currentColor"
+            className="text-emerald-500/20 dark:text-emerald-400/20"
+          />
+          <circle
+            cx={lastPoint.x}
+            cy={lastPoint.y}
+            r="3.5"
+            fill="currentColor"
+            stroke="white"
+            strokeWidth="1.5"
+            className="text-emerald-500 dark:text-emerald-400"
+          />
         </svg>
       </div>
       {/* Labels */}
       <div className="flex items-center gap-2 text-xs text-gray-600 dark:text-gray-400">
         <span className="font-medium">{firstScore}</span>
         <span className="text-gray-400 dark:text-gray-500">→</span>
-        <span className="font-medium">{lastScore}</span>
+        <span className="font-semibold text-gray-900 dark:text-gray-100">{lastScore}</span>
+        {delta > 0 && (
+          <span className="ml-0.5 rounded-full bg-emerald-100 px-1.5 py-0.5 text-[10px] font-semibold text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300">
+            +{delta}
+          </span>
+        )}
       </div>
     </div>
   );
 }
-

--- a/src/lib/demo/demoData.ts
+++ b/src/lib/demo/demoData.ts
@@ -7,12 +7,30 @@
  * progress tracking WITHOUT an account, Azure Speech credentials, a
  * microphone, or a database.
  *
- * These numbers are illustrative and are NOT real Azure Speech
- * pronunciation-assessment output. The UI clearly labels this as demo
- * data wherever it is shown.
+ * The demo items are REAL sentences drawn from the app's curated
+ * content set (`data/masterSentences.json`). Each item's `id` matches
+ * the real sentence id, so the native reference audio shipped in
+ * `public/audio/sentences/` plays in the demo exactly as it does in the
+ * full app.
+ *
+ * The SCORES, phoneme breakdowns, and attempt history are illustrative
+ * and are NOT real Azure Speech pronunciation-assessment output. The UI
+ * clearly labels this as demo data wherever it is shown.
  */
 
 import type { AttemptScore, ErrorType } from '@/types/pronunciation';
+
+/** Voice folder used for the demo's native reference playback. */
+const DEMO_VOICE = 'ptbr_female';
+
+/**
+ * Resolve the native reference audio URL for a demo item. The audio
+ * files live under `public/audio/sentences/<voice>/<id>.wav` and are
+ * served statically, so no account or API key is needed to play them.
+ */
+export function getDemoNativeAudioUrl(id: string): string {
+  return `/audio/sentences/${DEMO_VOICE}/${id}.wav`;
+}
 
 /** A single phoneme within a demo word, with its illustrative score. */
 export interface DemoPhonemeScore {
@@ -31,10 +49,11 @@ export interface DemoWordFeedback {
   tip?: string;
 }
 
-/** A complete demo item: a word or phrase plus its sample assessment. */
+/** A complete demo item: a real sentence plus its sample assessment. */
 export interface DemoItem {
+  /** Real sentence id from masterSentences.json — also drives audio lookup. */
   id: string;
-  /** Brazilian Portuguese text. */
+  /** Brazilian Portuguese sentence text. */
   text: string;
   /** English translation. */
   translation: string;
@@ -42,6 +61,8 @@ export interface DemoItem {
   ipa: string;
   /** 1 (easiest) – 4 (hardest). */
   difficulty: number;
+  /** CEFR level of the source sentence (e.g. "A1"). */
+  cefr?: string;
   /** Human-friendly labels for the tricky sounds in this item. */
   focusSounds: string[];
   /** Sample assessment shown in the score card. */
@@ -52,6 +73,14 @@ export interface DemoItem {
   history: number[];
   /** Coaching suggestions surfaced after the sample attempt. */
   coaching: string[];
+  /**
+   * Optional URL to a real learner recording of this sentence, so the
+   * demo can play back "a sample attempt" alongside the native voice.
+   * Drop a WAV/MP3 in `public/audio/demo/` and point this at it, e.g.
+   * `/audio/demo/gemini_food_003.wav`. Left undefined when no recording
+   * is available yet.
+   */
+  learnerAudioUrl?: string;
 }
 
 function attempt(
@@ -82,72 +111,202 @@ function attempt(
 }
 
 /**
- * The fixed demo word/phrase set. Ordered easiest → hardest so the demo
- * tells a coherent story about progressively trickier PT-BR sounds.
+ * The fixed demo sentence set. Ordered strongest → trickiest so the demo
+ * tells a coherent story: an easy greeting first, then progressively
+ * harder PT-BR sounds (nasal diphthongs, the palatal "lh/nh", the tapped
+ * "r"). Every `id` is a real sentence id, so native audio plays.
  */
 export const DEMO_ITEMS: DemoItem[] = [
   (() => {
     const words: DemoWordFeedback[] = [
       {
-        text: 'não',
-        score: 71,
+        text: 'Oi,',
+        score: 95,
+        phonemes: [
+          { symbol: 'OW', score: 96 },
+          { symbol: 'IY', score: 94 },
+        ],
+      },
+      {
+        text: 'tudo',
+        score: 90,
+        phonemes: [
+          { symbol: 'T', score: 95 },
+          { symbol: 'UW', score: 89 },
+          { symbol: 'D', score: 93 },
+          { symbol: 'UW', score: 84 },
+        ],
+        tip: 'The final "-o" reduces to a short "u" sound — "tudo" ends like "too-doo".',
+      },
+      {
+        text: 'bem?',
+        score: 80,
         errorType: 'mispronounced',
         phonemes: [
-          { symbol: 'N', score: 94 },
-          { symbol: 'AN_NASAL', score: 58 },
-          { symbol: 'W', score: 74 },
+          { symbol: 'B', score: 94 },
+          { symbol: 'EN_NASAL', score: 72 },
+          { symbol: 'Y', score: 78 },
         ],
-        tip: 'Let the air flow through your nose on the "ão" — don\'t close it into a hard "w".',
+        tip: 'The "em" is nasal and glides toward "y" — "bẽi", not a flat English "beng".',
       },
     ];
     return {
-      id: 'nao',
-      text: 'não',
-      translation: 'no',
-      ipa: 'nɐ̃w̃',
-      difficulty: 2,
-      focusSounds: ['nasal ão'],
-      attempt: attempt('demo-nao', 71, 78, 100, 69, words),
+      id: 'gemini_small_talk_001',
+      text: 'Oi, tudo bem?',
+      translation: 'Hi, how are you?',
+      ipa: 'oj ˈtudu ˈbẽj',
+      difficulty: 1,
+      cefr: 'A1',
+      focusSounds: ['nasal em', 'vowel reduction'],
+      attempt: attempt('demo-oi-tudo-bem', 88, 90, 100, 86, words),
       words,
-      history: [58, 63, 66, 71],
+      history: [72, 78, 83, 88],
       coaching: [
-        'Your nasal vowel "ão" is the weakest sound here. Practice humming "ãaão" with your mouth barely open.',
-        'Try the minimal pair "pau" vs "pão" to feel the nasal contrast.',
+        'Nice and natural. The only soft spot is the nasal "em" in "bem" — let it resonate in your nose and glide up toward "y".',
+        'Keep the final "-o" in "tudo" light and short; it reduces to "u", not a full "oh".',
       ],
     };
   })(),
   (() => {
     const words: DemoWordFeedback[] = [
       {
-        text: 'pão',
-        score: 68,
+        text: 'Estou',
+        score: 85,
+        phonemes: [
+          { symbol: 'IY', score: 82 },
+          { symbol: 'S', score: 92 },
+          { symbol: 'T', score: 90 },
+          { symbol: 'OW', score: 84 },
+        ],
+        tip: 'The unstressed "es-" sounds like "is"; the "-ou" is a clean "oh".',
+      },
+      {
+        text: 'muito',
+        score: 82,
+        phonemes: [
+          { symbol: 'M', score: 94 },
+          { symbol: 'UW', score: 86 },
+          { symbol: 'IY', score: 80 },
+          { symbol: 'T', score: 88 },
+          { symbol: 'UW', score: 78 },
+        ],
+        tip: '"muito" carries a hidden nasal — it sounds like "muin-too".',
+      },
+      {
+        text: 'feliz',
+        score: 84,
+        phonemes: [
+          { symbol: 'F', score: 96 },
+          { symbol: 'EH', score: 86 },
+          { symbol: 'L', score: 90 },
+          { symbol: 'IY', score: 88 },
+          { symbol: 'S', score: 80 },
+        ],
+        tip: 'A final "-z" is pronounced as a soft "s" here: "feh-lees".',
+      },
+      {
+        text: 'hoje.',
+        score: 78,
         errorType: 'mispronounced',
         phonemes: [
-          { symbol: 'P', score: 96 },
-          { symbol: 'AN_NASAL', score: 52 },
-          { symbol: 'W', score: 70 },
+          { symbol: 'OW', score: 82 },
+          { symbol: 'ZH', score: 72 },
+          { symbol: 'IY', score: 80 },
         ],
-        tip: 'Nasalize the vowel before the glide — the "ão" should resonate in the nose.',
+        tip: 'The "h" is silent and the "j" is a soft "zh", like the "s" in "measure": "oh-zhee".',
       },
     ];
     return {
-      id: 'pao',
-      text: 'pão',
-      translation: 'bread',
-      ipa: 'pɐ̃w̃',
+      id: 'gemini_feelings_001',
+      text: 'Estou muito feliz hoje.',
+      translation: "I'm very happy today.",
+      ipa: 'isˈto ˈmũjtu feˈlis ˈoʒi',
       difficulty: 2,
-      focusSounds: ['nasal ão'],
-      attempt: attempt('demo-pao', 68, 74, 100, 65, words),
+      cefr: 'A1',
+      focusSounds: ['soft j (zh)', 'silent h'],
+      attempt: attempt('demo-estou-feliz', 83, 85, 100, 81, words),
       words,
-      history: [55, 60, 64, 68],
+      history: [70, 74, 79, 83],
       coaching: [
-        'The nasal diphthong "ão" is dragging your score down. Keep the soft palate lowered throughout the vowel.',
-        'Contrast "pau" (stick) with "pão" (bread) to train the nasalization.',
+        'The soft "j" (zh) in "hoje" is your best opportunity — the "h" is silent, so aim for "oh-zhee".',
+        'Solid vowels overall. Keep the final "-z" of "feliz" light, closer to an "s".',
       ],
     };
   })(),
   (() => {
     const words: DemoWordFeedback[] = [
+      {
+        text: 'A',
+        score: 92,
+        phonemes: [{ symbol: 'AH', score: 92 }],
+      },
+      {
+        text: 'conta,',
+        score: 78,
+        errorType: 'mispronounced',
+        phonemes: [
+          { symbol: 'K', score: 95 },
+          { symbol: 'ON_NASAL', score: 66 },
+          { symbol: 'T', score: 88 },
+          { symbol: 'AH', score: 84 },
+        ],
+        tip: 'The "on" is nasal — let the air flow through your nose before the "t".',
+      },
+      {
+        text: 'por',
+        score: 76,
+        errorType: 'mispronounced',
+        phonemes: [
+          { symbol: 'P', score: 94 },
+          { symbol: 'OW', score: 82 },
+          { symbol: 'R_TAP', score: 68 },
+        ],
+        tip: 'This "r" is a quick tongue tap, like the "tt" in American "butter".',
+      },
+      {
+        text: 'favor.',
+        score: 74,
+        errorType: 'mispronounced',
+        phonemes: [
+          { symbol: 'F', score: 96 },
+          { symbol: 'AH', score: 88 },
+          { symbol: 'V', score: 90 },
+          { symbol: 'OW', score: 80 },
+          { symbol: 'R_TAP', score: 66 },
+        ],
+        tip: 'End on a single tapped "r", not the English retroflex "r".',
+      },
+    ];
+    return {
+      id: 'gemini_food_003',
+      text: 'A conta, por favor.',
+      translation: 'The check, please.',
+      ipa: 'a ˈkõtɐ poɾ faˈvoɾ',
+      difficulty: 3,
+      cefr: 'A1',
+      focusSounds: ['tapped r', 'nasal on'],
+      attempt: attempt('demo-a-conta', 79, 82, 100, 77, words),
+      words,
+      history: [64, 70, 75, 79],
+      coaching: [
+        'The tapped "r" in "por favor" is your lowest sound. Practice "para" and "caro" to isolate the single tap between vowels.',
+        'Nasalize the "on" in "conta" — keep the soft palate lowered so the air resonates in your nose.',
+      ],
+    };
+  })(),
+  (() => {
+    const words: DemoWordFeedback[] = [
+      {
+        text: 'Minha',
+        score: 82,
+        phonemes: [
+          { symbol: 'M', score: 96 },
+          { symbol: 'IY', score: 88 },
+          { symbol: 'NH', score: 70 },
+          { symbol: 'AH', score: 86 },
+        ],
+        tip: 'The "nh" is a palatal nasal, like the "ni" in "onion" — one sound, not "n" + "y".',
+      },
       {
         text: 'mãe',
         score: 66,
@@ -159,206 +318,102 @@ export const DEMO_ITEMS: DemoItem[] = [
         ],
         tip: 'The "ãe" is a nasal diphthong — glide from a nasal "ã" toward "i" without stopping the airflow.',
       },
-    ];
-    return {
-      id: 'mae',
-      text: 'mãe',
-      translation: 'mother',
-      ipa: 'mɐ̃j̃',
-      difficulty: 3,
-      focusSounds: ['nasal ãe'],
-      attempt: attempt('demo-mae', 66, 70, 100, 64, words),
-      words,
-      history: [52, 57, 61, 66],
-      coaching: [
-        'Both halves of the "ãe" diphthong need to stay nasal. Practice slowly: "mã—ẽ".',
-        'Compare "mãe" with the non-nasal "mais" to hear the difference.',
-      ],
-    };
-  })(),
-  (() => {
-    const words: DemoWordFeedback[] = [
       {
-        text: 'filho',
-        score: 74,
-        errorType: 'mispronounced',
+        text: 'se',
+        score: 88,
         phonemes: [
-          { symbol: 'F', score: 97 },
-          { symbol: 'IY', score: 90 },
-          { symbol: 'LH', score: 61 },
-          { symbol: 'UW', score: 72 },
+          { symbol: 'S', score: 92 },
+          { symbol: 'IY', score: 84 },
         ],
-        tip: 'The "lh" is one sound (like the "lli" in "million"), not "l" + "y".',
+        tip: 'Before "chama", "se" softens to "si".',
+      },
+      {
+        text: 'chama',
+        score: 85,
+        phonemes: [
+          { symbol: 'SH', score: 88 },
+          { symbol: 'AA', score: 90 },
+          { symbol: 'M', score: 92 },
+          { symbol: 'AH', score: 82 },
+        ],
+        tip: 'The "ch" is a single "sh" sound.',
+      },
+      {
+        text: 'Ana.',
+        score: 90,
+        phonemes: [
+          { symbol: 'AA', score: 92 },
+          { symbol: 'N', score: 94 },
+          { symbol: 'AH', score: 88 },
+        ],
       },
     ];
     return {
-      id: 'filho',
-      text: 'filho',
-      translation: 'son',
-      ipa: 'ˈfiʎu',
+      id: 'gemini_family_friends_001',
+      text: 'Minha mãe se chama Ana.',
+      translation: "My mother's name is Ana.",
+      ipa: 'ˈmiɲɐ ˈmɐ̃j si ˈʃɐmɐ ˈɐnɐ',
       difficulty: 3,
-      focusSounds: ['lh (palatal l)', 'unstressed final -o'],
-      attempt: attempt('demo-filho', 74, 80, 100, 72, words),
+      cefr: 'B2',
+      focusSounds: ['nasal ãe', 'nh (palatal)'],
+      attempt: attempt('demo-minha-mae', 74, 76, 100, 72, words),
       words,
       history: [60, 65, 70, 74],
       coaching: [
-        'Press the middle of your tongue against the roof of your mouth for "lh" — avoid an English "ly".',
-        'The final "-o" reduces to a short "u" sound; keep it light and quick.',
+        'Both halves of the "ãe" in "mãe" need to stay nasal. Practice slowly: "mã—ẽ", never closing into a hard "y".',
+        'For "nh" in "Minha", press the middle of your tongue to the roof of your mouth — think "meen-ya" as one blended sound.',
       ],
     };
   })(),
   (() => {
     const words: DemoWordFeedback[] = [
       {
-        text: 'obrigado',
-        score: 82,
+        text: 'Que',
+        score: 90,
+        phonemes: [
+          { symbol: 'K', score: 94 },
+          { symbol: 'IY', score: 86 },
+        ],
+        tip: '"que" is just "ki" — the "u" is silent.',
+      },
+      {
+        text: 'horas',
+        score: 80,
+        errorType: 'mispronounced',
         phonemes: [
           { symbol: 'OW', score: 84 },
-          { symbol: 'B', score: 95 },
           { symbol: 'R_TAP', score: 70 },
-          { symbol: 'IY', score: 91 },
-          { symbol: 'G', score: 93 },
-          { symbol: 'AA', score: 88 },
-          { symbol: 'D', score: 94 },
-          { symbol: 'UW', score: 74 },
-        ],
-        tip: 'The "r" in "-brig-" is a quick tongue tap, like the "tt" in American "butter".',
-      },
-    ];
-    return {
-      id: 'obrigado',
-      text: 'obrigado',
-      translation: 'thank you',
-      ipa: 'obɾiˈgadu',
-      difficulty: 2,
-      focusSounds: ['tapped r', 'unstressed final -o'],
-      attempt: attempt('demo-obrigado', 82, 85, 100, 80, words),
-      words,
-      history: [70, 74, 79, 82],
-      coaching: [
-        'Nice work — your consonants are solid. The tapped "r" is your main opportunity.',
-        'Say "para" and "caro" to isolate the single-tap "r" between vowels.',
-      ],
-    };
-  })(),
-  (() => {
-    const words: DemoWordFeedback[] = [
-      {
-        text: 'trabalho',
-        score: 70,
-        errorType: 'mispronounced',
-        phonemes: [
-          { symbol: 'T', score: 93 },
-          { symbol: 'R_TAP', score: 66 },
-          { symbol: 'AA', score: 89 },
-          { symbol: 'B', score: 94 },
-          { symbol: 'AA', score: 87 },
-          { symbol: 'LH', score: 58 },
-          { symbol: 'UW', score: 73 },
-        ],
-        tip: 'Two tricky sounds here: the tapped "r" and the palatal "lh". Slow the word down and hit each.',
-      },
-    ];
-    return {
-      id: 'trabalho',
-      text: 'trabalho',
-      translation: 'work',
-      ipa: 'tɾaˈbaʎu',
-      difficulty: 3,
-      focusSounds: ['tapped r', 'lh (palatal l)'],
-      attempt: attempt('demo-trabalho', 70, 74, 100, 68, words),
-      words,
-      history: [56, 61, 66, 70],
-      coaching: [
-        'The "lh" is your lowest sound. Anchor the tongue mid-mouth and voice it: "ba-lyo" → "baʎo".',
-        'The "tr" cluster uses a tapped "r", not the English retroflex "r".',
-      ],
-    };
-  })(),
-  (() => {
-    const words: DemoWordFeedback[] = [
-      {
-        text: 'coração',
-        score: 69,
-        errorType: 'mispronounced',
-        phonemes: [
-          { symbol: 'K', score: 95 },
-          { symbol: 'OW', score: 82 },
-          { symbol: 'R_TAP', score: 67 },
           { symbol: 'AA', score: 88 },
           { symbol: 'S', score: 90 },
-          { symbol: 'AN_NASAL', score: 54 },
-          { symbol: 'W', score: 71 },
         ],
-        tip: 'Ends on the nasal "ão" — the same sound as "pão" and "não". Keep it resonating in the nose.',
+        tip: 'The "h" is silent and the middle "r" is a quick tap: "OH-ras".',
       },
-    ];
-    return {
-      id: 'coracao',
-      text: 'coração',
-      translation: 'heart',
-      ipa: 'koɾaˈsɐ̃w̃',
-      difficulty: 3,
-      focusSounds: ['tapped r', 'nasal ão'],
-      attempt: attempt('demo-coracao', 69, 72, 100, 67, words),
-      words,
-      history: [54, 59, 64, 69],
-      coaching: [
-        'The final "ão" and the medial tapped "r" are both below target. Drill them separately, then together.',
-        'The "ç" is just an "s" sound — that part is already strong.',
-      ],
-    };
-  })(),
-  (() => {
-    const words: DemoWordFeedback[] = [
       {
-        text: 'Rio',
+        text: 'são?',
         score: 64,
         errorType: 'mispronounced',
         phonemes: [
-          { symbol: 'HH', score: 55 },
-          { symbol: 'IY', score: 88 },
-          { symbol: 'UW', score: 76 },
+          { symbol: 'S', score: 92 },
+          { symbol: 'AN_NASAL', score: 52 },
+          { symbol: 'W', score: 68 },
         ],
-        tip: 'Word-initial "R" in PT-BR is guttural (like a soft "h" from the throat), not an English "r".',
-      },
-      {
-        text: 'de',
-        score: 83,
-        phonemes: [
-          { symbol: 'JH', score: 80 },
-          { symbol: 'IY', score: 86 },
-        ],
-        tip: 'Before an "i" sound, "de" softens toward "dji".',
-      },
-      {
-        text: 'Janeiro',
-        score: 72,
-        errorType: 'mispronounced',
-        phonemes: [
-          { symbol: 'ZH', score: 68 },
-          { symbol: 'AH', score: 84 },
-          { symbol: 'N', score: 92 },
-          { symbol: 'EY', score: 85 },
-          { symbol: 'R_TAP', score: 70 },
-          { symbol: 'UW', score: 75 },
-        ],
-        tip: 'The "J" is a soft "zh" sound, like the "s" in "measure".',
+        tip: 'The "ão" is the same nasal diphthong as in "pão" — keep it resonating in the nose, then glide to "w".',
       },
     ];
     return {
-      id: 'rio-de-janeiro',
-      text: 'Rio de Janeiro',
-      translation: 'Rio de Janeiro',
-      ipa: 'ˈʁiu dʒi ʒɐˈnejɾu',
+      id: 'gemini_questions_005',
+      text: 'Que horas são?',
+      translation: 'What time is it?',
+      ipa: 'ki ˈɔɾɐs ˈsɐ̃w',
       difficulty: 4,
-      focusSounds: ['guttural R', 'zh (soft J)', 'tapped r'],
-      attempt: attempt('demo-rio', 73, 76, 100, 71, words),
+      cefr: 'B2',
+      focusSounds: ['nasal ão', 'tapped r'],
+      attempt: attempt('demo-que-horas-sao', 71, 74, 100, 69, words),
       words,
-      history: [58, 63, 68, 73],
+      history: [56, 62, 67, 71],
       coaching: [
-        'The guttural "R" at the start of "Rio" is the biggest win here — practice it like clearing your throat gently.',
-        'The "J" in "Janeiro" is a soft "zh", not an English "j".',
+        'The nasal "ão" in "são" is dragging the score down. Hum "ãaão" with your mouth barely open, then add the final "w" glide.',
+        'Remember the "h" in "horas" is silent, and the "r" is a single tap — not an English "r".',
       ],
     };
   })(),

--- a/src/pages/DemoPage.tsx
+++ b/src/pages/DemoPage.tsx
@@ -1,12 +1,18 @@
 import { useMemo, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
-import { Volume2, Mic, Loader2, RotateCcw, Info, ArrowRight } from 'lucide-react';
+import { Volume2, Mic, Loader2, RotateCcw, Info, ArrowRight, Pause, Headphones } from 'lucide-react';
 import PublicPageShell from '@/components/demo/PublicPageShell';
 import PhraseScoreOverview from '@/components/pronunciation/PhraseScoreOverview';
 import PhraseTrendSparkline from '@/components/pronunciation/PhraseTrendSparkline';
 import PhonemeChip from '@/components/pronunciation/PhonemeChip';
+import { useAudioPlayer, stopAllAudio } from '@/hooks/useAudioPlayer';
 import { getScoreColor, getScoreBorderColor } from '@/lib/pronunciationDisplay';
-import { DEMO_ITEMS, type DemoItem, type DemoWordFeedback } from '@/lib/demo/demoData';
+import {
+  DEMO_ITEMS,
+  getDemoNativeAudioUrl,
+  type DemoItem,
+  type DemoWordFeedback,
+} from '@/lib/demo/demoData';
 
 type DemoPhase = 'idle' | 'analyzing' | 'result';
 
@@ -33,11 +39,23 @@ export default function DemoPage() {
     [activeId],
   );
 
+  // Native reference audio — the same WAV the full app plays.
+  const nativeAudioUrl = useMemo(() => getDemoNativeAudioUrl(item.id), [item.id]);
+  const native = useAudioPlayer(nativeAudioUrl);
+  // Optional sample learner recording (present only when one has been added).
+  const learner = useAudioPlayer(item.learnerAudioUrl);
+
   const resetTo = (id: string) => {
     if (analyzeTimer.current) clearTimeout(analyzeTimer.current);
+    stopAllAudio();
     setActiveId(id);
     setPhase('idle');
     setSelectedWord(null);
+  };
+
+  const toggleNative = () => {
+    if (native.isPlaying) native.pause();
+    else native.play();
   };
 
   const runAnalysis = () => {
@@ -59,10 +77,12 @@ export default function DemoPage() {
           <div className="flex items-start gap-3">
             <Info size={18} className="text-amber-600 dark:text-amber-300 mt-0.5 flex-shrink-0" />
             <div className="text-sm text-amber-800 dark:text-amber-200">
-              <p className="font-semibold">Interactive demo — sample data only</p>
+              <p className="font-semibold">Interactive demo — real sentences, sample scores</p>
               <p className="mt-1">
-                This is a self-contained preview. Scores, phoneme feedback, and history below are
-                realistic <strong>samples</strong>, not live Azure Speech results. No microphone,
+                These are <strong>real sentences</strong> from the app, with the same native
+                reference audio you hear in the full experience — press{' '}
+                <strong>Listen</strong> to play it. The scores, phoneme feedback, and history below
+                are realistic <strong>samples</strong>, not live Azure Speech results. No microphone,
                 account, or API keys are used. In the full app, you record your own voice and Azure
                 Speech scores it in real time.
               </p>
@@ -73,7 +93,7 @@ export default function DemoPage() {
         {/* Word / phrase picker */}
         <div>
           <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2">
-            Pick a word or phrase
+            Pick a sentence
           </h2>
           <div className="flex flex-wrap gap-2">
             {DEMO_ITEMS.map((d) => (
@@ -92,15 +112,18 @@ export default function DemoPage() {
 
         {/* Prompt card */}
         <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200/70 dark:border-gray-700 p-6">
-          <div className="flex flex-wrap items-center justify-center gap-2 mb-2">
+          <div className="flex flex-wrap items-center justify-center gap-2 mb-3">
             <span className="badge badge-secondary">Difficulty {item.difficulty}</span>
+            {item.cefr && <span className="badge badge-secondary">{item.cefr}</span>}
             {item.focusSounds.map((s) => (
               <span key={s} className="chip-soft">{s}</span>
             ))}
           </div>
           <div className="text-center">
-            <p className="text-4xl font-bold text-gray-900 dark:text-gray-100">{item.text}</p>
-            <p className="mt-1 font-mono text-primary-600 dark:text-primary-400">/{item.ipa}/</p>
+            <p className="text-2xl sm:text-3xl font-bold text-gray-900 dark:text-gray-100 leading-snug">
+              {item.text}
+            </p>
+            <p className="mt-2 font-mono text-primary-600 dark:text-primary-400">/{item.ipa}/</p>
             <p className="mt-1 text-gray-500 dark:text-gray-400 italic">{item.translation}</p>
           </div>
 
@@ -108,11 +131,18 @@ export default function DemoPage() {
             <button
               type="button"
               className="btn btn-secondary btn-md inline-flex items-center gap-2"
-              title="Native TTS playback is available in the full app."
-              onClick={() => undefined}
+              title="Play the native reference pronunciation for this sentence."
+              onClick={toggleNative}
+              aria-pressed={native.isPlaying}
             >
-              <Volume2 size={18} />
-              Listen (native voice)
+              {native.isLoading ? (
+                <Loader2 size={18} className="animate-spin" />
+              ) : native.isPlaying ? (
+                <Pause size={18} />
+              ) : (
+                <Volume2 size={18} />
+              )}
+              {native.isPlaying ? 'Playing…' : 'Listen (native voice)'}
             </button>
 
             {phase === 'idle' && (
@@ -147,9 +177,16 @@ export default function DemoPage() {
             )}
           </div>
 
+          {native.error && (
+            <p className="mt-3 text-center text-xs text-rose-500 dark:text-rose-400">
+              Couldn&apos;t play the reference audio here. It works in the deployed app.
+            </p>
+          )}
+
           {phase === 'idle' && (
             <p className="mt-4 text-center text-sm text-gray-500 dark:text-gray-400">
-              Press <strong>Analyze demo recording</strong> to see how a scored attempt looks.
+              Press <strong>Listen</strong> to hear the native voice, then{' '}
+              <strong>Analyze demo recording</strong> to see how a scored attempt looks.
             </p>
           )}
         </div>
@@ -161,6 +198,33 @@ export default function DemoPage() {
               <h2 className="text-lg font-bold text-gray-900 dark:text-gray-100">Your sample result</h2>
               <DemoBadge />
             </div>
+
+            {/* Compare recordings — only shown when a sample learner recording exists */}
+            {item.learnerAudioUrl && (
+              <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200/70 dark:border-gray-700 p-4">
+                <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3">
+                  Hear it back — native vs. this sample attempt
+                </h3>
+                <div className="flex flex-wrap gap-3">
+                  <button
+                    type="button"
+                    onClick={toggleNative}
+                    className="btn btn-secondary btn-sm inline-flex items-center gap-2"
+                  >
+                    {native.isPlaying ? <Pause size={16} /> : <Volume2 size={16} />}
+                    Native voice
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => (learner.isPlaying ? learner.pause() : learner.play())}
+                    className="btn btn-secondary btn-sm inline-flex items-center gap-2"
+                  >
+                    {learner.isPlaying ? <Pause size={16} /> : <Headphones size={16} />}
+                    Sample attempt
+                  </button>
+                </div>
+              </div>
+            )}
 
             {/* Score overview (reuses the real app component) */}
             <PhraseScoreOverview attemptScore={item.attempt} />

--- a/src/pages/TourPage.tsx
+++ b/src/pages/TourPage.tsx
@@ -17,7 +17,10 @@ import PhraseScoreOverview from '@/components/pronunciation/PhraseScoreOverview'
 import PhonemeChip from '@/components/pronunciation/PhonemeChip';
 import { DEMO_ITEMS } from '@/lib/demo/demoData';
 
-const showcase = DEMO_ITEMS.find((d) => d.id === 'trabalho') ?? DEMO_ITEMS[0];
+const showcase =
+  DEMO_ITEMS.find((d) => d.id === 'gemini_family_friends_001') ?? DEMO_ITEMS[0];
+// Highlight the trickiest word in the showcase sentence for the phoneme breakdown.
+const showcaseWord = [...showcase.words].sort((a, b) => a.score - b.score)[0];
 
 function Section({
   eyebrow,
@@ -147,10 +150,10 @@ export default function TourPage() {
               </p>
               <div className="mt-4">
                 <p className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2">
-                  Phoneme-level breakdown (sample for “{showcase.text}”):
+                  Phoneme-level breakdown (sample for “{showcaseWord.text}” in “{showcase.text}”):
                 </p>
                 <div className="flex flex-wrap gap-2">
-                  {showcase.words[0].phonemes.map((p, i) => (
+                  {showcaseWord.phonemes.map((p, i) => (
                     <PhonemeChip key={`${p.symbol}-${i}`} symbol={p.symbol} score={p.score} />
                   ))}
                 </div>


### PR DESCRIPTION
## Summary

Transforms the `/demo` page from illustrative sample words to real Brazilian Portuguese sentences from the curated content set, with native reference audio playback. Demo items now use actual sentence IDs that match `data/masterSentences.json`, enabling the same native audio files (`public/audio/sentences/`) to play in the demo as they do in the full app.

## Key Changes

- **Real sentences in demo data** (`src/lib/demo/demoData.ts`):
  - Replaced 6 sample words/phrases with 6 real sentences (e.g., "Oi, tudo bem?", "Estou muito feliz hoje.", "A conta, por favor.", "Minha mãe se chama Ana.", "Que horas são?")
  - Each item's `id` matches a real sentence ID from `masterSentences.json`, enabling audio lookup
  - Added `cefr` field (CEFR proficiency level) to demo items
  - Added optional `learnerAudioUrl` field for sample learner recordings
  - Added `getDemoNativeAudioUrl()` export to resolve native audio paths (`/audio/sentences/<voice>/<id>.wav`)
  - Updated coaching suggestions and phoneme feedback to match real sentence content

- **Native audio playback** (`src/pages/DemoPage.tsx`):
  - Integrated `useAudioPlayer` hook to play native reference audio
  - Added "Listen (native voice)" button that toggles playback with loading/playing states
  - Displays error message if audio fails to load (graceful fallback for local dev)
  - Calls `stopAllAudio()` when resetting to a new demo item
  - Added optional "Compare recordings" section to play learner sample audio alongside native voice (when `learnerAudioUrl` is present)

- **UI improvements**:
  - Updated demo info banner to clarify that sentences are real, only scores are sample data
  - Changed "Pick a word or phrase" label to "Pick a sentence"
  - Added CEFR badge display next to difficulty level
  - Improved prompt card layout with better text sizing and spacing

- **Sparkline visualization** (`src/components/pronunciation/PhraseTrendSparkline.tsx`):
  - Enhanced with gradient area fill under the trend line
  - Added gradient line color (emerald to green)
  - Emphasized endpoint (latest attempt) with larger glow circle and white stroke
  - Added delta badge showing score improvement (+X)
  - Improved accessibility with unique gradient IDs per instance (prevents conflicts with multiple sparklines)
  - Increased default dimensions for better visibility

- **Score bar styling** (`src/components/pronunciation/PhraseScoreOverview.tsx`):
  - Applied gradient backgrounds to score bars (emerald, sky, amber, rose) for visual polish
  - Added subtle shadow to progress bars

- **Documentation** (`DEMO_READY.md`, `FEATURES.md`):
  - Updated to reflect that demo now uses real sentences with native audio
  - Clarified that only scores/phoneme feedback are illustrative

## Implementation Details

- Demo voice is hardcoded to `ptbr_female` (matches the shipped audio in `public/audio/sentences/ptbr_female/`)
- Native audio URLs are resolved dynamically based on item ID, enabling future voice switching
- Learner audio is optional; the compare section only renders when `learnerAudioUrl` is defined
- All demo items ordered from easiest (A1 greeting) to hardest (B2 questions), telling a coherent progression story
- Audio playback uses existing `useAudioPlayer` hook infrastructure; no new audio player implementation needed

https://claude.ai/code/session_01J8ks1vaabjNGHppLKKkkR8