### PR TITLE
feat(demo): mirror real practice page with three selectable audio examples

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -103,8 +103,8 @@ A comprehensive list of what LusoPronounce can do, organized by feature area.
 ## Public Tour & Demo Mode
 
 - **Take a Tour** — A public, no-login `/tour` page that explains the product for portfolio/recruiter viewing: what it does, the practice flow, pronunciation feedback, progress tracking, why it helps, and technical highlights.
-- **Interactive Demo Mode** — A public, no-login `/demo` page where visitors pick from a set of real PT-BR sentences drawn from the app's content ("Oi, tudo bem?", "Estou muito feliz hoje.", "A conta, por favor.", "Minha mãe se chama Ana.", "Que horas são?"), play the native reference audio, trigger a simulated assessment, and explore a realistic sample result: overall + sub-scores, word-by-word chips, phoneme breakdown with IPA, coaching tips, and a progress trend.
-- **Native Reference Playback in Demo** — Each demo sentence plays its real native pronunciation audio (the same clip used in the full app), with an optional slot to play back a sample learner recording alongside it for comparison.
+- **Interactive Demo Mode** — A public, no-login `/demo` page that mirrors the real sentence practice page (interactive full-sentence display, score strip, sound details, focus areas, coaching, progress trend) for a set of real PT-BR sentences ("Oi, tudo bem?", "Estou muito feliz hoje.", "A conta, por favor.", "Minha mãe se chama Ana.", "Que horas são?").
+- **Demo Audio Examples** — Instead of recording, visitors compare three selectable audio examples per sentence — the native speaker (scores near-perfect), an intentionally bad attempt, and a best-effort attempt — each with its own full sample assessment. Native reference audio always plays; learner recordings are optional uploads under `public/demo-audio/attempts/` that appear automatically once present.
 - **Clearly-Labeled Sample Data** — Demo scores, phoneme feedback, and history are hand-authored sample data (not live Azure output) and are labeled as such in the UI; no microphone, account, Azure credentials, or database are required.
 
 ## Infrastructure

--- a/public/demo-audio/attempts/README.md
+++ b/public/demo-audio/attempts/README.md
@@ -1,0 +1,30 @@
+# Demo learner recordings
+
+Drop the uploaded learner recordings for the `/demo` page's audio examples in
+this folder. The demo probes for these files at runtime and only shows the
+playback button once a file exists, so missing recordings degrade gracefully
+(scores still display).
+
+## Naming convention
+
+One WAV per demo sentence and example kind:
+
+```
+<sentenceId>.bad.wav    # intentionally poor pronunciation
+<sentenceId>.best.wav   # best-effort pronunciation
+```
+
+The sentence ids are the real ids from `data/masterSentences.json` used by
+`src/lib/demo/demoData.ts`:
+
+- `gemini_small_talk_001` — "Oi, tudo bem?"
+- `gemini_feelings_001` — "Estou muito feliz hoje."
+- `gemini_food_003` — "A conta, por favor."
+- `gemini_family_friends_001` — "Minha mãe se chama Ana."
+- `gemini_questions_005` — "Que horas são?"
+
+Example: `gemini_food_003.bad.wav`, `gemini_food_003.best.wav`.
+
+Keep files small (16 kHz mono WAV is plenty). This folder ships with the
+public static deploy — unlike `public/audio/`, it is NOT excluded by
+`.vercelignore`, so anything placed here is publicly downloadable.

--- a/src/components/pronunciation/PronunciationFeedbackPanel.tsx
+++ b/src/components/pronunciation/PronunciationFeedbackPanel.tsx
@@ -46,6 +46,8 @@ export interface PronunciationFeedbackPanelProps {
   // Audio
   sentenceAudio?: NormalizedAudioVariant[]; // native/user variants
   wordAudios?: NormalizedWordAudioVariant[]; // optional per-word audio
+  /** Custom label for the user audio button (e.g. "Bad attempt" in the demo). */
+  userAudioLabel?: string;
 
   // Word-level feedback
   words?: NormalizedWordFeedback[];
@@ -74,6 +76,7 @@ export default function PronunciationFeedbackPanel({
   difficulty,
   sentenceAudio,
   wordAudios,
+  userAudioLabel,
   words,
   title,
   showDevControls = false,
@@ -278,6 +281,7 @@ export default function PronunciationFeedbackPanel({
               audioRef={sentenceAudioRef}
               onStart={handleSentenceStart}
               onStop={handleSentenceStop}
+              userLabel={userAudioLabel}
             />
           )}
         </>

--- a/src/components/pronunciation/shared/SentenceAudioControls.tsx
+++ b/src/components/pronunciation/shared/SentenceAudioControls.tsx
@@ -7,6 +7,10 @@ interface SentenceAudioControlsProps {
   audioRef?: React.RefObject<HTMLAudioElement | null>;
   onStart?: (type: 'native' | 'user') => void;
   onStop?: () => void;
+  /** Label for the native audio button (defaults to "Native Sentence"). */
+  nativeLabel?: string;
+  /** Label for the user audio button (defaults to "Your Recording"). */
+  userLabel?: string;
 }
 
 /**
@@ -20,6 +24,8 @@ export default function SentenceAudioControls({
   audioRef: externalAudioRef,
   onStart,
   onStop,
+  nativeLabel = 'Native Sentence',
+  userLabel = 'Your Recording',
 }: SentenceAudioControlsProps) {
   const internalAudioRef = useRef<HTMLAudioElement>(null);
   const audioRef = externalAudioRef || internalAudioRef;
@@ -115,7 +121,7 @@ export default function SentenceAudioControls({
                 <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor">
                   <path d="M8 5v14l11-7z" />
                 </svg>
-                <span>Native Sentence</span>
+                <span>{nativeLabel}</span>
               </>
             )}
           </button>
@@ -128,7 +134,7 @@ export default function SentenceAudioControls({
             <svg className="w-5 h-5 inline mr-2" viewBox="0 0 24 24" fill="currentColor">
               <path d="M3 9v6h4l5 5V4L7 9H3zm13.5 3c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM14 3.23v2.06c2.89.86 5 3.54 5 6.71s-2.11 5.85-5 6.71v2.06c4.01-.91 7-4.49 7-8.77s-2.99-7.86-7-8.77z" />
             </svg>
-            Native Sentence
+            {nativeLabel}
           </button>
         )}
 
@@ -153,7 +159,7 @@ export default function SentenceAudioControls({
                 <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor">
                   <path d="M3 9v6h4l5 5V4L7 9H3zm13.5 3c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM14 3.23v2.06c2.89.86 5 3.54 5 6.71s-2.11 5.85-5 6.71v2.06c4.01-.91 7-4.49 7-8.77s-2.99-7.86-7-8.77z" />
                 </svg>
-                <span>Your Recording</span>
+                <span>{userLabel}</span>
               </>
             )}
           </button>

--- a/src/lib/demo/demoAudioAvailability.ts
+++ b/src/lib/demo/demoAudioAvailability.ts
@@ -1,0 +1,54 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Runtime probe for optional demo audio files (the uploaded learner
+ * recordings under `public/demo-audio/attempts/`). Both the Vite dev server
+ * and the static deploy fall back to `index.html` for unknown paths, so a
+ * plain `fetch().ok` check would report missing WAVs as present — we also
+ * require a non-HTML content type before treating the file as available.
+ *
+ * Results are cached per URL for the lifetime of the page so switching
+ * between demo sentences/examples doesn't re-probe.
+ */
+const availabilityCache = new Map<string, Promise<boolean>>();
+
+export function checkDemoAudioAvailable(url: string): Promise<boolean> {
+  let cached = availabilityCache.get(url);
+  if (!cached) {
+    cached = fetch(url, { method: 'HEAD' })
+      .then((res) => {
+        if (!res.ok) return false;
+        const contentType = res.headers.get('content-type') ?? '';
+        return !contentType.includes('text/html');
+      })
+      .catch(() => false);
+    availabilityCache.set(url, cached);
+  }
+  return cached;
+}
+
+/**
+ * React hook wrapper around {@link checkDemoAudioAvailable}.
+ * Returns `null` while the probe is in flight, then true/false.
+ * Pass `true` for `assumeAvailable` to skip probing (bundled assets).
+ */
+export function useDemoAudioAvailability(url: string, assumeAvailable = false): boolean | null {
+  const [available, setAvailable] = useState<boolean | null>(assumeAvailable ? true : null);
+
+  useEffect(() => {
+    if (assumeAvailable) {
+      setAvailable(true);
+      return;
+    }
+    let active = true;
+    setAvailable(null);
+    checkDemoAudioAvailable(url).then((result) => {
+      if (active) setAvailable(result);
+    });
+    return () => {
+      active = false;
+    };
+  }, [url, assumeAvailable]);
+
+  return available;
+}

--- a/src/lib/demo/demoData.test.ts
+++ b/src/lib/demo/demoData.test.ts
@@ -1,0 +1,63 @@
+import {
+  DEMO_ITEMS,
+  getDemoAttemptAudioUrl,
+  getDemoNativeAudioUrl,
+} from './demoData';
+
+/**
+ * Guardrails for the public /demo experience. The demo regressed once to
+ * showing a single word instead of the full sentence — these invariants keep
+ * the demo data sentence-shaped and the three audio examples coherent.
+ */
+describe('demoData', () => {
+  it('uses full sentences (multiple words, word feedback aligned to tokens)', () => {
+    for (const item of DEMO_ITEMS) {
+      const tokens = item.text.trim().split(/\s+/);
+      expect(tokens.length).toBeGreaterThan(1);
+      // Word feedback must cover every token so the interactive sentence
+      // display colors the whole sentence, not a single word.
+      expect(item.words.map((w) => w.text)).toEqual(tokens);
+      for (const example of item.examples) {
+        expect(example.words.map((w) => w.text)).toEqual(tokens);
+        expect(example.attempt.wordScores.map((w) => w.word)).toEqual(tokens);
+      }
+    }
+  });
+
+  it('provides native, bad, and best examples for every sentence', () => {
+    for (const item of DEMO_ITEMS) {
+      expect(item.examples.map((e) => e.kind)).toEqual(['native', 'bad', 'best']);
+    }
+  });
+
+  it('scores the native example near-perfect (95–100)', () => {
+    for (const item of DEMO_ITEMS) {
+      const native = item.examples.find((e) => e.kind === 'native')!;
+      expect(native.attempt.overallAccuracy).toBeGreaterThanOrEqual(95);
+      expect(native.attempt.overallAccuracy).toBeLessThanOrEqual(100);
+      for (const word of native.words) {
+        expect(word.score).toBeGreaterThanOrEqual(95);
+        expect(word.score).toBeLessThanOrEqual(100);
+        expect(word.errorType).toBeUndefined();
+      }
+    }
+  });
+
+  it('orders example scores native > best > bad', () => {
+    for (const item of DEMO_ITEMS) {
+      const [native, bad, best] = item.examples;
+      expect(native.attempt.overallAccuracy).toBeGreaterThan(best.attempt.overallAccuracy);
+      expect(best.attempt.overallAccuracy).toBeGreaterThan(bad.attempt.overallAccuracy);
+    }
+  });
+
+  it('points every example at the expected static audio path', () => {
+    for (const item of DEMO_ITEMS) {
+      const [native, bad, best] = item.examples;
+      expect(native.audioUrl).toBe(getDemoNativeAudioUrl(item.id));
+      expect(native.audioBundled).toBe(true);
+      expect(bad.audioUrl).toBe(getDemoAttemptAudioUrl(item.id, 'bad'));
+      expect(best.audioUrl).toBe(getDemoAttemptAudioUrl(item.id, 'best'));
+    }
+  });
+});

--- a/src/lib/demo/demoData.ts
+++ b/src/lib/demo/demoData.ts
@@ -41,6 +41,16 @@ export function getDemoNativeAudioUrl(id: string): string {
   return `/demo-audio/${DEMO_VOICE}/${id}.wav`;
 }
 
+/**
+ * Resolve the URL for an uploaded learner recording of a demo sentence.
+ * Recordings live under `public/demo-audio/attempts/<id>.<kind>.wav` (see the
+ * README in that folder). Files are optional — the demo probes availability
+ * at runtime and hides the playback button until a recording is uploaded.
+ */
+export function getDemoAttemptAudioUrl(id: string, kind: 'bad' | 'best'): string {
+  return `/demo-audio/attempts/${id}.${kind}.wav`;
+}
+
 /** A single phoneme within a demo word, with its illustrative score. */
 export interface DemoPhonemeScore {
   /** Phoneme id matching data/phoneme_metadata.json (e.g. "LH", "AN_NASAL"). */
@@ -56,6 +66,37 @@ export interface DemoWordFeedback {
   phonemes: DemoPhonemeScore[];
   /** Short coaching note surfaced when the word is expanded. */
   tip?: string;
+}
+
+/** Which of the three demo audio examples an assessment belongs to. */
+export type DemoExampleKind = 'native' | 'bad' | 'best';
+
+/**
+ * One selectable audio example for a demo sentence — the synthesized native
+ * reference, an intentionally bad learner attempt, or a best-effort learner
+ * attempt. Each carries its own full sample assessment so the demo can show
+ * how scoring reacts to very different pronunciations of the same sentence.
+ */
+export interface DemoExample {
+  kind: DemoExampleKind;
+  /** Selector button label, e.g. "Native speaker". */
+  label: string;
+  /** One-line explanation shown when the example is selected. */
+  description: string;
+  /**
+   * Audio for this example. The native example always resolves to the shipped
+   * reference WAV; learner examples point at `public/demo-audio/attempts/`
+   * and may not exist yet — the UI probes availability before offering play.
+   */
+  audioUrl: string;
+  /** True when the audio is guaranteed to ship with the deploy (native TTS). */
+  audioBundled: boolean;
+  /** Sample assessment for this example. */
+  attempt: AttemptScore;
+  /** Word-by-word breakdown with phonemes for this example. */
+  words: DemoWordFeedback[];
+  /** Coaching notes tailored to this example. */
+  coaching: string[];
 }
 
 /** A complete demo item: a real sentence plus its sample assessment. */
@@ -74,24 +115,24 @@ export interface DemoItem {
   cefr?: string;
   /** Human-friendly labels for the tricky sounds in this item. */
   focusSounds: string[];
-  /** Sample assessment shown in the score card. */
+  /** Sample assessment shown in the score card (the best-effort attempt). */
   attempt: AttemptScore;
-  /** Word-by-word breakdown with phonemes. */
+  /** Word-by-word breakdown with phonemes (the best-effort attempt). */
   words: DemoWordFeedback[];
   /** Illustrative history of overall scores across prior attempts (oldest → newest). */
   history: number[];
   /** Coaching suggestions surfaced after the sample attempt. */
   coaching: string[];
   /**
-   * Optional URL to a real learner recording of this sentence, so the
-   * demo can play back "a sample attempt" alongside the native voice.
-   * Drop a WAV/MP3 in `public/demo-audio/` and point this at it, e.g.
-   * `/demo-audio/gemini_food_003.wav`. (Use `public/demo-audio/`, not
-   * `public/audio/`, so it ships with the public static deploy.) Left
-   * undefined when no recording is available yet.
+   * The three selectable audio examples — native TTS, an intentionally bad
+   * attempt, and a best-effort attempt — ordered for display. The best
+   * example reuses `attempt`/`words`/`coaching`; the other two are derived.
    */
-  learnerAudioUrl?: string;
+  examples: DemoExample[];
 }
+
+/** A demo item before its three audio examples are derived. */
+type DemoItemBase = Omit<DemoItem, 'examples'>;
 
 function attempt(
   id: string,
@@ -121,12 +162,112 @@ function attempt(
 }
 
 /**
+ * Score transforms used to derive the native and bad examples from the
+ * hand-authored best-effort assessment. Deterministic (no randomness) so
+ * the demo renders identically on every visit:
+ *
+ * - Native: clamped into 96–100. The reference audio *is* the target, so
+ *   assessing it against itself scores near-perfect. Uses the original
+ *   score's low bits for a little natural-looking variation.
+ * - Bad: scaled down to roughly 60% (floored at 28) — an intentionally
+ *   rough attempt where the tricky sounds fall apart.
+ */
+function toNativeScore(score: number): number {
+  return Math.min(100, 96 + (score % 4));
+}
+
+function toBadScore(score: number): number {
+  return Math.max(28, Math.round(score * 0.6));
+}
+
+function averageWordScore(words: DemoWordFeedback[]): number {
+  return Math.round(words.reduce((sum, w) => sum + w.score, 0) / words.length);
+}
+
+function mapWordScores(
+  words: DemoWordFeedback[],
+  transform: (score: number) => number,
+  errorFloor: number | null,
+): DemoWordFeedback[] {
+  return words.map((w) => {
+    const score = transform(w.score);
+    return {
+      text: w.text,
+      score,
+      errorType: errorFloor !== null && score < errorFloor ? 'mispronounced' : undefined,
+      phonemes: w.phonemes.map((p) => ({ symbol: p.symbol, score: transform(p.score) })),
+      tip: w.tip,
+    };
+  });
+}
+
+/** Derive the three selectable audio examples for a demo sentence. */
+function buildExamples(item: DemoItemBase): DemoExample[] {
+  const nativeWords = mapWordScores(item.words, toNativeScore, null);
+  const nativeOverall = averageWordScore(nativeWords);
+
+  const badWords = mapWordScores(item.words, toBadScore, 65);
+  const badOverall = averageWordScore(badWords);
+
+  const focus = item.focusSounds.join(' and ');
+
+  return [
+    {
+      kind: 'native',
+      label: 'Native speaker',
+      description:
+        'Synthesized native-speaker audio — the reference the app compares every attempt against. Assessed against itself, it scores near-perfect.',
+      audioUrl: getDemoNativeAudioUrl(item.id),
+      audioBundled: true,
+      attempt: attempt(`${item.attempt.attemptId}-native`, nativeOverall, 98, 100, 97, nativeWords),
+      words: nativeWords,
+      coaching: [
+        'This is the synthesized native reference — the same voice the full app plays before you record.',
+        `Listen for the ${focus}, then switch to the sample attempts to hear how the scoring reacts when they slip.`,
+      ],
+    },
+    {
+      kind: 'bad',
+      label: 'My bad attempt',
+      description:
+        'A deliberately poor pronunciation of the same sentence, so you can see how the scoring pinpoints trouble.',
+      audioUrl: getDemoAttemptAudioUrl(item.id, 'bad'),
+      audioBundled: false,
+      attempt: attempt(
+        `${item.attempt.attemptId}-bad`,
+        badOverall,
+        Math.max(35, badOverall - 8),
+        100,
+        Math.max(30, badOverall - 12),
+        badWords,
+      ),
+      words: badWords,
+      coaching: [
+        `An intentionally rough attempt — the ${focus} drift far from the native targets, and the word scores show exactly where.`,
+        'Toggle between this attempt and the native speaker to hear the contrast the scores are picking up.',
+      ],
+    },
+    {
+      kind: 'best',
+      label: 'My best attempt',
+      description:
+        'A realistic best effort — strong scores overall, with a few tricky sounds still left to polish.',
+      audioUrl: getDemoAttemptAudioUrl(item.id, 'best'),
+      audioBundled: false,
+      attempt: item.attempt,
+      words: item.words,
+      coaching: item.coaching,
+    },
+  ];
+}
+
+/**
  * The fixed demo sentence set. Ordered strongest → trickiest so the demo
  * tells a coherent story: an easy greeting first, then progressively
  * harder PT-BR sounds (nasal diphthongs, the palatal "lh/nh", the tapped
  * "r"). Every `id` is a real sentence id, so native audio plays.
  */
-export const DEMO_ITEMS: DemoItem[] = [
+const BASE_ITEMS: DemoItemBase[] = [
   (() => {
     const words: DemoWordFeedback[] = [
       {
@@ -428,6 +569,11 @@ export const DEMO_ITEMS: DemoItem[] = [
     };
   })(),
 ];
+
+export const DEMO_ITEMS: DemoItem[] = BASE_ITEMS.map((item) => ({
+  ...item,
+  examples: buildExamples(item),
+}));
 
 export function getDemoItem(id: string): DemoItem | undefined {
   return DEMO_ITEMS.find((item) => item.id === id);

--- a/src/pages/DemoPage.tsx
+++ b/src/pages/DemoPage.tsx
@@ -1,20 +1,31 @@
-import { useMemo, useRef, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
-import { Volume2, Mic, Loader2, RotateCcw, Info, ArrowRight, Pause, Headphones } from 'lucide-react';
+import { Volume2, Mic, Info, ArrowRight, Headphones } from 'lucide-react';
 import PublicPageShell from '@/components/demo/PublicPageShell';
-import PhraseScoreOverview from '@/components/pronunciation/PhraseScoreOverview';
+import PronunciationFeedbackPanel from '@/components/pronunciation/PronunciationFeedbackPanel';
+import ScoringPanel from '@/components/pronunciation/ScoringPanel';
 import PhraseTrendSparkline from '@/components/pronunciation/PhraseTrendSparkline';
-import PhonemeChip from '@/components/pronunciation/PhonemeChip';
-import { useAudioPlayer, stopAllAudio } from '@/hooks/useAudioPlayer';
-import { getScoreColor, getScoreBorderColor } from '@/lib/pronunciationDisplay';
+import {
+  FocusAreasCard,
+  type NormalizedAudioVariant,
+  type NormalizedWordFeedback,
+} from '@/components/pronunciation/shared';
+import { stopAllAudio } from '@/hooks/useAudioPlayer';
+import { useDemoAudioAvailability } from '@/lib/demo/demoAudioAvailability';
 import {
   DEMO_ITEMS,
   getDemoNativeAudioUrl,
+  type DemoExample,
+  type DemoExampleKind,
   type DemoItem,
   type DemoWordFeedback,
 } from '@/lib/demo/demoData';
 
-type DemoPhase = 'idle' | 'analyzing' | 'result';
+const EXAMPLE_ICONS: Record<DemoExampleKind, typeof Volume2> = {
+  native: Volume2,
+  bad: Mic,
+  best: Headphones,
+};
 
 function DemoBadge() {
   return (
@@ -28,45 +39,133 @@ function DemoBadge() {
   );
 }
 
+/** Score chip shown inside each example selector button. */
+function scoreChipClasses(score: number): string {
+  if (score >= 80) return 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-200';
+  if (score >= 60) return 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200';
+  return 'bg-rose-100 text-rose-800 dark:bg-rose-900/40 dark:text-rose-200';
+}
+
+/**
+ * Adapt the demo's hand-authored word feedback to the normalized shape the
+ * real practice components consume. The word-level tip is attached to the
+ * word's lowest-scoring phoneme so it surfaces in Sound Details/Focus Areas.
+ */
+function toNormalizedWords(words: DemoWordFeedback[]): NormalizedWordFeedback[] {
+  return words.map((w, index) => {
+    const lowestIdx = w.phonemes.reduce(
+      (low, p, i) => (p.score < w.phonemes[low].score ? i : low),
+      0,
+    );
+    return {
+      id: String(index),
+      index,
+      text: w.text,
+      accuracyScore: w.score,
+      score: w.score,
+      errorType: w.errorType ?? null,
+      phonemes: w.phonemes.map((p, i) => ({
+        symbol: p.symbol,
+        score: p.score,
+        isProblem: p.score < 75,
+        tip: i === lowestIdx ? w.tip : undefined,
+      })),
+    };
+  });
+}
+
+/** The demo counterpart of the practice page's main sentence card. */
+function DemoPracticeCard({ item, example }: { item: DemoItem; example: DemoExample }) {
+  // Learner recordings are uploaded separately (public/demo-audio/attempts/)
+  // and may not exist yet — probe before offering playback. Bundled native
+  // audio skips the probe.
+  const exampleAudioAvailable = useDemoAudioAvailability(example.audioUrl, example.audioBundled);
+
+  const normalizedWords = useMemo(() => toNormalizedWords(example.words), [example.words]);
+
+  // Native reference is always offered; the selected learner example's
+  // recording rides in the "user" audio slot, exactly like a fresh recording
+  // does on the real practice page.
+  const sentenceAudio = useMemo<NormalizedAudioVariant[]>(() => {
+    const variants: NormalizedAudioVariant[] = [
+      { type: 'native', url: getDemoNativeAudioUrl(item.id) },
+    ];
+    if (example.kind !== 'native' && exampleAudioAvailable) {
+      variants.push({ type: 'user', url: example.audioUrl });
+    }
+    return variants;
+  }, [item.id, example.kind, example.audioUrl, exampleAudioAvailable]);
+
+  return (
+    <div className="space-y-6">
+      {example.kind !== 'native' && exampleAudioAvailable === false && (
+        <p className="text-center text-xs text-gray-500 dark:text-gray-400">
+          The recording for this sample attempt hasn&apos;t been uploaded yet — the scores below
+          still show how the app would assess it.
+        </p>
+      )}
+
+      {/* Score strip — same component the practice page shows after scoring */}
+      <ScoringPanel currentAttempt={example.attempt} variant="strip" />
+
+      {/* Full sentence, translation toggle, audio controls, and Sound Details.
+          Keyed by example so word selection and scores reset when switching. */}
+      <PronunciationFeedbackPanel
+        key={`${item.id}:${example.kind}`}
+        attempts={[example.attempt]}
+        currentAttempt={example.attempt}
+        sentenceText={item.text}
+        translationText={item.translation}
+        difficulty={item.difficulty}
+        sentenceAudio={sentenceAudio}
+        userAudioLabel={example.kind === 'bad' ? 'Bad Attempt' : 'Best Attempt'}
+        words={normalizedWords}
+        showDifficultyBadge={false}
+      />
+
+      {/* Focus Areas — problem phonemes across the sentence (empty for native) */}
+      <FocusAreasCard words={normalizedWords} />
+
+      {/* Coaching — tailored to the selected example */}
+      <div className="rounded-xl border border-gray-200/70 dark:border-gray-700 p-5">
+        <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3">
+          Coaching — what to work on next
+        </h3>
+        <ul className="space-y-2">
+          {example.coaching.map((tip, i) => (
+            <li key={i} className="flex items-start gap-2 text-sm text-gray-700 dark:text-gray-300">
+              <ArrowRight size={16} className="text-primary-500 mt-0.5 flex-shrink-0" />
+              <span>{tip}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}
+
 export default function DemoPage() {
   const [activeId, setActiveId] = useState<string>(DEMO_ITEMS[0].id);
-  const [phase, setPhase] = useState<DemoPhase>('idle');
-  const [selectedWord, setSelectedWord] = useState<DemoWordFeedback | null>(null);
-  const analyzeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [exampleKind, setExampleKind] = useState<DemoExampleKind>('native');
 
   const item = useMemo<DemoItem>(
     () => DEMO_ITEMS.find((d) => d.id === activeId) ?? DEMO_ITEMS[0],
     [activeId],
   );
+  const example = useMemo<DemoExample>(
+    () => item.examples.find((e) => e.kind === exampleKind) ?? item.examples[0],
+    [item, exampleKind],
+  );
 
-  // Native reference audio — the same WAV the full app plays.
-  const nativeAudioUrl = useMemo(() => getDemoNativeAudioUrl(item.id), [item.id]);
-  const native = useAudioPlayer(nativeAudioUrl);
-  // Optional sample learner recording (present only when one has been added).
-  const learner = useAudioPlayer(item.learnerAudioUrl);
-
-  const resetTo = (id: string) => {
-    if (analyzeTimer.current) clearTimeout(analyzeTimer.current);
+  const selectSentence = (id: string) => {
     stopAllAudio();
     setActiveId(id);
-    setPhase('idle');
-    setSelectedWord(null);
+    setExampleKind('native');
   };
 
-  const toggleNative = () => {
-    if (native.isPlaying) native.pause();
-    else native.play();
-  };
-
-  const runAnalysis = () => {
-    setPhase('analyzing');
-    setSelectedWord(null);
-    if (analyzeTimer.current) clearTimeout(analyzeTimer.current);
-    // Brief simulated latency so the "assessment" feels real.
-    analyzeTimer.current = setTimeout(() => {
-      setPhase('result');
-      setSelectedWord(item.words[0] ?? null);
-    }, 1100);
+  const selectExample = (kind: DemoExampleKind) => {
+    stopAllAudio();
+    setExampleKind(kind);
   };
 
   return (
@@ -77,20 +176,21 @@ export default function DemoPage() {
           <div className="flex items-start gap-3">
             <Info size={18} className="text-amber-600 dark:text-amber-300 mt-0.5 flex-shrink-0" />
             <div className="text-sm text-amber-800 dark:text-amber-200">
-              <p className="font-semibold">Interactive demo — real sentences, sample scores</p>
+              <p className="font-semibold">Interactive demo — the real practice page, minus the microphone</p>
               <p className="mt-1">
-                These are <strong>real sentences</strong> from the app, with the same native
-                reference audio you hear in the full experience — press{' '}
-                <strong>Listen</strong> to play it. The scores, phoneme feedback, and history below
-                are realistic <strong>samples</strong>, not live Azure Speech results. No microphone,
-                account, or API keys are used. In the full app, you record your own voice and Azure
-                Speech scores it in real time.
+                This is the same sentence-practice experience the full app gives you, with{' '}
+                <strong>real sentences</strong> and the same native reference audio. Instead of
+                recording yourself, compare three audio examples — the{' '}
+                <strong>native speaker</strong>, an intentionally <strong>bad attempt</strong>, and
+                a <strong>best-effort attempt</strong> — and see how each one scores. The scores and
+                phoneme feedback are realistic <strong>samples</strong>, not live Azure Speech
+                results. No microphone, account, or API keys are used.
               </p>
             </div>
           </div>
         </div>
 
-        {/* Word / phrase picker */}
+        {/* Sentence picker */}
         <div>
           <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2">
             Pick a sentence
@@ -100,7 +200,7 @@ export default function DemoPage() {
               <button
                 key={d.id}
                 type="button"
-                onClick={() => resetTo(d.id)}
+                onClick={() => selectSentence(d.id)}
                 className={`chip ${d.id === activeId ? 'chip-active' : 'chip-inactive'}`}
                 aria-pressed={d.id === activeId}
               >
@@ -110,215 +210,86 @@ export default function DemoPage() {
           </div>
         </div>
 
-        {/* Prompt card */}
+        {/* Main practice card — mirrors the real sentence practice page */}
         <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200/70 dark:border-gray-700 p-6">
-          <div className="flex flex-wrap items-center justify-center gap-2 mb-3">
-            <span className="badge badge-secondary">Difficulty {item.difficulty}</span>
-            {item.cefr && <span className="badge badge-secondary">{item.cefr}</span>}
-            {item.focusSounds.map((s) => (
-              <span key={s} className="chip-soft">{s}</span>
-            ))}
-          </div>
-          <div className="text-center">
-            <p className="text-2xl sm:text-3xl font-bold text-gray-900 dark:text-gray-100 leading-snug">
-              {item.text}
-            </p>
-            <p className="mt-2 font-mono text-primary-600 dark:text-primary-400">/{item.ipa}/</p>
-            <p className="mt-1 text-gray-500 dark:text-gray-400 italic">{item.translation}</p>
+          <div className="mb-4 flex flex-wrap items-center justify-between gap-2">
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="badge badge-secondary">Difficulty {item.difficulty}</span>
+              {item.cefr && <span className="badge badge-secondary">{item.cefr}</span>}
+              {item.focusSounds.map((s) => (
+                <span key={s} className="chip-soft">{s}</span>
+              ))}
+            </div>
+            <DemoBadge />
           </div>
 
-          <div className="mt-6 flex flex-col sm:flex-row items-center justify-center gap-3">
-            <button
-              type="button"
-              className="btn btn-secondary btn-md inline-flex items-center gap-2"
-              title="Play the native reference pronunciation for this sentence."
-              onClick={toggleNative}
-              aria-pressed={native.isPlaying}
-            >
-              {native.isLoading ? (
-                <Loader2 size={18} className="animate-spin" />
-              ) : native.isPlaying ? (
-                <Pause size={18} />
-              ) : (
-                <Volume2 size={18} />
-              )}
-              {native.isPlaying ? 'Playing…' : 'Listen (native voice)'}
-            </button>
-
-            {phase === 'idle' && (
-              <button
-                type="button"
-                onClick={runAnalysis}
-                className="btn btn-primary btn-md inline-flex items-center gap-2"
-              >
-                <Mic size={18} />
-                Analyze demo recording
-              </button>
-            )}
-            {phase === 'analyzing' && (
-              <button
-                type="button"
-                disabled
-                className="btn btn-primary btn-md inline-flex items-center gap-2"
-              >
-                <Loader2 size={18} className="animate-spin" />
-                Analyzing…
-              </button>
-            )}
-            {phase === 'result' && (
-              <button
-                type="button"
-                onClick={runAnalysis}
-                className="btn btn-secondary btn-md inline-flex items-center gap-2"
-              >
-                <RotateCcw size={18} />
-                Try again
-              </button>
-            )}
+          {/* Audio example selector — the demo's stand-in for the record button */}
+          <div className="mb-6">
+            <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2">
+              Audio examples — pick one to hear it and see how it scores
+            </h3>
+            <div className="grid gap-2 sm:grid-cols-3" role="group" aria-label="Audio examples">
+              {item.examples.map((ex) => {
+                const Icon = EXAMPLE_ICONS[ex.kind];
+                const isActive = ex.kind === example.kind;
+                const overall = Math.round(ex.attempt.overallAccuracy);
+                return (
+                  <button
+                    key={ex.kind}
+                    type="button"
+                    onClick={() => selectExample(ex.kind)}
+                    aria-pressed={isActive}
+                    className={`flex items-center justify-between gap-2 px-4 py-3 rounded-xl border-2 text-sm font-medium transition-all ${
+                      isActive
+                        ? 'border-primary-500 bg-primary-50 dark:bg-primary-900/30 text-primary-700 dark:text-primary-300'
+                        : 'border-gray-200 dark:border-gray-700 text-gray-700 dark:text-gray-300 hover:border-gray-300 dark:hover:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700/50'
+                    }`}
+                  >
+                    <span className="inline-flex items-center gap-2">
+                      <Icon size={16} />
+                      {ex.label}
+                    </span>
+                    <span
+                      className={`px-2 py-0.5 rounded-full text-xs font-bold ${scoreChipClasses(overall)}`}
+                      title={`Sample overall score: ${overall}/100`}
+                    >
+                      {overall}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+            <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">{example.description}</p>
           </div>
 
-          {native.error && (
-            <p className="mt-3 text-center text-xs text-rose-500 dark:text-rose-400">
-              Couldn&apos;t play the reference audio. Please try again.
-            </p>
-          )}
-
-          {phase === 'idle' && (
-            <p className="mt-4 text-center text-sm text-gray-500 dark:text-gray-400">
-              Press <strong>Listen</strong> to hear the native voice, then{' '}
-              <strong>Analyze demo recording</strong> to see how a scored attempt looks.
-            </p>
-          )}
+          <DemoPracticeCard item={item} example={example} />
         </div>
 
-        {/* Result state */}
-        {phase === 'result' && (
-          <div className="space-y-6 animate-in">
-            <div className="flex items-center justify-between">
-              <h2 className="text-lg font-bold text-gray-900 dark:text-gray-100">Your sample result</h2>
-              <DemoBadge />
-            </div>
-
-            {/* Compare recordings — only shown when a sample learner recording exists */}
-            {item.learnerAudioUrl && (
-              <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200/70 dark:border-gray-700 p-4">
-                <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3">
-                  Hear it back — native vs. this sample attempt
-                </h3>
-                <div className="flex flex-wrap gap-3">
-                  <button
-                    type="button"
-                    onClick={toggleNative}
-                    className="btn btn-secondary btn-sm inline-flex items-center gap-2"
-                  >
-                    {native.isPlaying ? <Pause size={16} /> : <Volume2 size={16} />}
-                    Native voice
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => (learner.isPlaying ? learner.pause() : learner.play())}
-                    className="btn btn-secondary btn-sm inline-flex items-center gap-2"
-                  >
-                    {learner.isPlaying ? <Pause size={16} /> : <Headphones size={16} />}
-                    Sample attempt
-                  </button>
-                </div>
-              </div>
-            )}
-
-            {/* Score overview (reuses the real app component) */}
-            <PhraseScoreOverview attemptScore={item.attempt} />
-
-            {/* Word-by-word strip */}
-            <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200/70 dark:border-gray-700 p-6">
-              <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3">
-                Word-by-word — tap a word to see its sounds
-              </h3>
-              <div className="flex flex-wrap gap-2">
-                {item.words.map((w, i) => {
-                  const isSelected = selectedWord?.text === w.text && selectedWord === w;
-                  return (
-                    <button
-                      key={`${w.text}-${i}`}
-                      type="button"
-                      onClick={() => setSelectedWord(w)}
-                      className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-base font-medium border-2 transition-all ${getScoreColor(
-                        w.score,
-                      )} ${getScoreBorderColor(w.score)} ${
-                        isSelected ? 'ring-2 ring-primary-500 ring-offset-1 dark:ring-offset-gray-800' : ''
-                      }`}
-                    >
-                      {w.text}
-                      <span className="text-xs opacity-75">{w.score}</span>
-                    </button>
-                  );
-                })}
-              </div>
-
-              {/* Phoneme breakdown for the selected word */}
-              {selectedWord && (
-                <div className="mt-5 pt-5 border-t border-gray-200 dark:border-gray-700">
-                  <div className="flex items-center gap-2 mb-3">
-                    <span className="text-sm font-semibold text-gray-900 dark:text-gray-100">
-                      Sounds in “{selectedWord.text}”
-                    </span>
-                  </div>
-                  <div className="flex flex-wrap gap-2">
-                    {selectedWord.phonemes.map((p, i) => (
-                      <PhonemeChip key={`${p.symbol}-${i}`} symbol={p.symbol} score={p.score} />
-                    ))}
-                  </div>
-                  {selectedWord.tip && (
-                    <p className="mt-3 text-sm text-gray-600 dark:text-gray-400">
-                      💡 {selectedWord.tip}
-                    </p>
-                  )}
-                </div>
-              )}
-            </div>
-
-            {/* Coaching */}
-            <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200/70 dark:border-gray-700 p-6">
-              <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3">
-                Coaching — what to work on next
-              </h3>
-              <ul className="space-y-2">
-                {item.coaching.map((tip, i) => (
-                  <li key={i} className="flex items-start gap-2 text-sm text-gray-700 dark:text-gray-300">
-                    <ArrowRight size={16} className="text-primary-500 mt-0.5 flex-shrink-0" />
-                    <span>{tip}</span>
-                  </li>
-                ))}
-              </ul>
-            </div>
-
-            {/* Progress over time */}
-            <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200/70 dark:border-gray-700 p-6">
-              <div className="flex items-center justify-between mb-3">
-                <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300">
-                  Progress on “{item.text}”
-                </h3>
-                <DemoBadge />
-              </div>
-              <PhraseTrendSparkline scores={item.history} />
-              <div className="mt-4 space-y-1.5">
-                {item.history.map((score, i) => (
-                  <div
-                    key={i}
-                    className="flex items-center justify-between text-sm text-gray-600 dark:text-gray-400"
-                  >
-                    <span>Attempt {i + 1}</span>
-                    <span className="font-semibold text-gray-900 dark:text-gray-100">{score}</span>
-                  </div>
-                ))}
-              </div>
-              <p className="mt-3 text-xs text-gray-500 dark:text-gray-400">
-                +{item.history[item.history.length - 1] - item.history[0]} points across{' '}
-                {item.history.length} attempts.
-              </p>
-            </div>
+        {/* Progress over time */}
+        <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200/70 dark:border-gray-700 p-6">
+          <div className="flex items-center justify-between mb-3">
+            <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300">
+              Progress on “{item.text}”
+            </h3>
+            <DemoBadge />
           </div>
-        )}
+          <PhraseTrendSparkline scores={item.history} />
+          <div className="mt-4 space-y-1.5">
+            {item.history.map((score, i) => (
+              <div
+                key={i}
+                className="flex items-center justify-between text-sm text-gray-600 dark:text-gray-400"
+              >
+                <span>Attempt {i + 1}</span>
+                <span className="font-semibold text-gray-900 dark:text-gray-100">{score}</span>
+              </div>
+            ))}
+          </div>
+          <p className="mt-3 text-xs text-gray-500 dark:text-gray-400">
+            +{item.history[item.history.length - 1] - item.history[0]} points across{' '}
+            {item.history.length} attempts.
+          </p>
+        </div>
 
         {/* Footer CTA */}
         <div className="text-center pt-2">


### PR DESCRIPTION
The public /demo now reuses the actual sentence-practice components
(PronunciationFeedbackPanel, ScoringPanel strip, FocusAreasCard) so it
looks and behaves like the real practice page, minus the microphone.

Each demo sentence offers three comparable audio examples, each with its
own full sample assessment:
- Native speaker: bundled TTS reference, scores 95-100
- My bad attempt: intentionally poor pronunciation, low scores
- My best attempt: realistic strong scores (existing authored data)

Learner recordings are optional uploads under public/demo-audio/attempts/
(see its README); the page probes availability at runtime (content-type
aware, since the SPA fallback serves index.html for missing files) and
shows playback automatically once a file exists.

Also adds configurable button labels to SentenceAudioControls and unit
tests guarding the demo data invariants (full-sentence word alignment,
near-perfect native scores, native > best > bad ordering).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Qd4asCnL2SkMDLMshJGwWt