### PR TITLE
feat(word-practice): redesign practice word page to match mockup

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -27,7 +27,7 @@ A comprehensive list of what LusoPronounce can do, organized by feature area.
 
 - **Multiple Practice Modes** — Pronunciation recording, text multiple-choice (PT-to-EN, EN-to-PT, mixed directions), listening multiple-choice, and self-rating (Know It / Review Later).
 - **Multiple View Modes** — List/glossary view (card grid for browsing), drill view (single-card focus for active practice), and weak words focus (filters to bottom 50 words by score).
-- **Word Phoneme Panel** — Displays phoneme breakdown with IPA symbols and pronunciation tips from the phoneme metadata dataset.
+- **Word Phoneme Panel** — Pronunciation breakdown with per-phoneme sound tiles, teaching tips, and example words from the phoneme metadata dataset, plus a Show IPA toggle and per-row playback of the word's native audio.
 
 ## Custom Sentence Builder
 

--- a/src/components/practice/PhonemePanel.tsx
+++ b/src/components/practice/PhonemePanel.tsx
@@ -1,8 +1,38 @@
+import { useState } from 'react';
+import { AudioLines, Eye, EyeOff } from 'lucide-react';
 import { getPhonemeById } from '@/lib/phonemeMetadata';
 import type { Word } from '@/lib/types';
+import { useSettingsStore } from '@/state/settingsStore';
+import { useAudioPlayer } from '@/hooks/useAudioPlayer';
 
 interface PhonemePanelProps {
   word: Word;
+}
+
+/**
+ * Small circular "hear it" button rendered on each phoneme row.
+ * Plays the word's native pronunciation as context for the phoneme.
+ */
+function PhonemeSoundButton({ audioUrl }: { audioUrl: string | null | undefined }) {
+  const { play, pause, isPlaying, isLoading } = useAudioPlayer(audioUrl || null);
+
+  return (
+    <button
+      type="button"
+      onClick={isPlaying ? pause : play}
+      disabled={!audioUrl || isLoading}
+      aria-label={isPlaying ? 'Stop sound' : 'Play sound'}
+      className={`shrink-0 w-10 h-10 rounded-full border flex items-center justify-center transition-colors
+        ${
+          isPlaying
+            ? 'border-primary-500 text-primary-600 bg-primary-50 dark:bg-primary-900/30 dark:text-primary-300'
+            : 'border-gray-200 text-gray-400 hover:text-primary-600 hover:border-primary-300 dark:border-gray-600 dark:text-gray-500 dark:hover:text-primary-300'
+        }
+        disabled:opacity-40 disabled:cursor-not-allowed`}
+    >
+      <AudioLines size={16} className={isPlaying ? 'animate-pulse' : ''} />
+    </button>
+  );
 }
 
 /**
@@ -10,6 +40,9 @@ interface PhonemePanelProps {
  * Uses canonical phoneme metadata from data/phoneme_metadata.json.
  */
 export function PhonemePanel({ word }: PhonemePanelProps) {
+  const { selectedVoice } = useSettingsStore();
+  const [showIpa, setShowIpa] = useState(false);
+
   if (!word.phonemes || word.phonemes.length === 0) {
     return null;
   }
@@ -22,44 +55,62 @@ export function PhonemePanel({ word }: PhonemePanelProps) {
     return null;
   }
 
+  const audioUrl = selectedVoice === 'male' ? word.audioMaleUrl : word.audioFemaleUrl;
+
   return (
-    <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-4 space-y-3">
-      <h4 className="text-sm font-medium text-gray-700 dark:text-gray-300">
-        Pronunciation Breakdown
-      </h4>
-      
-      <div className="space-y-3">
-        {phonemeItems.map((p) => (
-          <div key={p.id} className="bg-gray-50 dark:bg-gray-700/50 rounded-md p-3 border border-gray-100 dark:border-gray-600">
-            <div className="flex items-baseline gap-2 mb-1">
-              <span className="text-lg font-semibold text-primary-600 dark:text-primary-400 font-mono">
+    <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-4 sm:p-5 space-y-4">
+      <div className="flex items-center justify-between gap-2">
+        <h4 className="text-base font-semibold text-gray-900 dark:text-gray-100">
+          Pronunciation Breakdown
+        </h4>
+        <button
+          type="button"
+          onClick={() => setShowIpa((v) => !v)}
+          aria-pressed={showIpa}
+          className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium border border-gray-200 dark:border-gray-600 text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+        >
+          {showIpa ? <EyeOff size={14} /> : <Eye size={14} />}
+          {showIpa ? 'Hide IPA' : 'Show IPA'}
+        </button>
+      </div>
+
+      <div className="space-y-2.5">
+        {phonemeItems.map((p, index) => (
+          <div
+            key={`${p.id}-${index}`}
+            className="flex items-center gap-3 bg-gray-50 dark:bg-gray-700/40 rounded-xl p-3 border border-gray-100 dark:border-gray-700"
+          >
+            {/* Phoneme symbol tile */}
+            <div className="shrink-0 w-14 h-14 rounded-lg bg-primary-50 dark:bg-primary-900/30 border border-primary-100 dark:border-primary-800/50 flex flex-col items-center justify-center leading-none">
+              <span className="text-xl font-bold text-primary-700 dark:text-primary-300 font-mono">
                 {p.ipa}
               </span>
-              <span className="text-xs text-gray-500 dark:text-gray-400 font-mono">
-                ({p.id})
+              <span className="mt-0.5 text-[10px] text-primary-600/80 dark:text-primary-400/80 font-mono">
+                {showIpa ? `/${p.ipa}/` : `(${p.id})`}
               </span>
             </div>
 
-            {p.teachingTips && p.teachingTips.length > 0 && (
-              <div className="text-sm text-gray-700 dark:text-gray-300 mb-2">
-                {p.teachingTips[0]}
-              </div>
-            )}
-
-            {p.exampleWords && p.exampleWords.length > 0 && (
-              <div className="text-xs text-gray-500 dark:text-gray-400">
-                <span className="font-medium">Ex: </span>
-                {p.exampleWords.slice(0, 2).map((ex, i) => (
-                  <span key={i}>
-                    {ex.pt} {i < Math.min(p.exampleWords.length, 2) - 1 ? ', ' : ''}
+            {/* Tip + examples */}
+            <div className="flex-1 min-w-0">
+              {p.teachingTips && p.teachingTips.length > 0 && (
+                <p className="text-sm text-gray-800 dark:text-gray-200">
+                  {p.teachingTips[0]}
+                </p>
+              )}
+              {p.exampleWords && p.exampleWords.length > 0 && (
+                <p className="mt-0.5 text-xs text-gray-500 dark:text-gray-400">
+                  <span className="font-medium">Ex: </span>
+                  <span className="font-mono">
+                    {p.exampleWords.slice(0, 2).map((ex) => ex.pt).join(' , ')}
                   </span>
-                ))}
-              </div>
-            )}
+                </p>
+              )}
+            </div>
+
+            <PhonemeSoundButton audioUrl={audioUrl} />
           </div>
         ))}
       </div>
     </div>
   );
 }
-

--- a/src/components/practice/WordCard.tsx
+++ b/src/components/practice/WordCard.tsx
@@ -1,7 +1,6 @@
 import { memo, useCallback, useState, useEffect, useRef } from 'react';
 import type { Word } from '@/lib/types';
 import type { AttemptScore } from '@/types/pronunciation';
-import AudioPlayerButton from './AudioPlayerButton';
 import WordAudioButton from './WordAudioButton';
 import WordStatusBar from './WordStatusBar';
 import { useMicrophoneRecorder } from '@/hooks/useMicrophoneRecorder';
@@ -13,7 +12,8 @@ import { usePracticeLogStore } from '@/state/practiceLogStore';
 import { useAudioPlayer } from '@/hooks/useAudioPlayer';
 import { PhonemePanel } from './PhonemePanel';
 import PremiumRecordButton from '@/components/common/PremiumRecordButton';
-import { ChevronDown, ChevronUp } from 'lucide-react';
+import PremiumPlayButton from '@/components/common/PremiumPlayButton';
+import { ChevronDown, ChevronUp, Lightbulb, Volume2, Check, HelpCircle } from 'lucide-react';
 
 interface WordCardProps {
   word: Word;
@@ -55,7 +55,12 @@ function WordCard({ word, sessionId, status, showTranslation = false, onToggleTr
 
   // Track native audio plays using useAudioPlayer hook
   const nativeAudioUrl = selectedVoice === 'male' ? word.audioMaleUrl : word.audioFemaleUrl;
-  const { isPlaying: isNativePlaying } = useAudioPlayer(nativeAudioUrl || null);
+  const {
+    isPlaying: isNativePlaying,
+    play: playNative,
+    pause: pauseNative,
+    isLoading: isNativeLoading,
+  } = useAudioPlayer(nativeAudioUrl || null);
   const prevIsNativePlayingRef = useRef(false);
 
   // Track when native audio starts playing
@@ -283,10 +288,19 @@ function WordCard({ word, sessionId, status, showTranslation = false, onToggleTr
     return 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200';
   };
 
+  const handlePlayNative = useCallback(() => {
+    if (!nativeAudioUrl) return;
+    if (isNativePlaying) {
+      pauseNative();
+    } else {
+      playNative();
+    }
+  }, [nativeAudioUrl, isNativePlaying, playNative, pauseNative]);
+
   return (
-    <div className="card card-hover card-compact relative">
+    <div className="card card-hover relative">
       {/* Header with status, category and difficulty */}
-      <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2 mb-4">
+      <div className="flex flex-wrap items-center justify-between gap-2 mb-6">
         <div className="flex items-center gap-2 flex-wrap">
           {status && <WordStatusBar status={status} />}
           <span className="badge badge-secondary">
@@ -312,108 +326,122 @@ function WordCard({ word, sessionId, status, showTranslation = false, onToggleTr
         </div>
       </div>
 
-      {/* Portuguese word - large and prominent */}
-      <div className="mb-3">
-        <div className="flex flex-col items-center gap-y-2">
-          <p className="text-2xl md:text-3xl font-bold text-gray-900 dark:text-gray-100">
+      {/* Portuguese word - large and prominent, with inline speaker */}
+      <div className="flex flex-col items-center gap-y-2 mb-2">
+        <div className="flex items-center gap-3">
+          <p className="text-4xl md:text-5xl font-bold text-gray-900 dark:text-gray-100 tracking-tight">
             {word.textPt}
           </p>
-
-          {/* Translation toggle chevron */}
-          {word.translationEn && (
+          {nativeAudioUrl ? (
             <button
               type="button"
-              onClick={() => {
-                if (onToggleTranslation) {
-                  onToggleTranslation();
+              onClick={handlePlayNative}
+              disabled={isNativeLoading}
+              aria-label={isNativePlaying ? 'Stop pronunciation' : 'Hear pronunciation'}
+              className={`shrink-0 w-11 h-11 rounded-full border flex items-center justify-center transition-colors
+                ${
+                  isNativePlaying
+                    ? 'border-primary-500 text-primary-600 bg-primary-50 dark:bg-primary-900/30 dark:text-primary-300'
+                    : 'border-gray-200 text-gray-500 hover:text-primary-600 hover:border-primary-300 dark:border-gray-600 dark:text-gray-400 dark:hover:text-primary-300'
                 }
-              }}
-              className="text-gray-300 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-400 cursor-pointer transition-colors"
-              aria-pressed={showTranslation}
-              aria-label={showTranslation ? 'Hide translation' : 'Show translation'}
+                disabled:opacity-40 disabled:cursor-not-allowed`}
             >
-              {showTranslation ? (
-                <ChevronUp size={20} className="w-5 h-5" />
-              ) : (
-                <ChevronDown size={20} className="w-5 h-5" />
-              )}
+              <Volume2 size={20} className={isNativePlaying ? 'animate-pulse' : ''} />
             </button>
-          )}
-
-          {/* English translation - shown conditionally */}
-          {word.translationEn && showTranslation && (
-            <p className="text-base md:text-lg text-gray-500 dark:text-gray-400 italic text-center">
-              {word.translationEn}
-            </p>
+          ) : (
+            word.id && <WordAudioButton wordId={word.id} compact />
           )}
         </div>
-      </div>
 
-      {/* Part of speech */}
-      {word.partOfSpeech && (
-        <div className="mb-4">
-          <p className="text-xs text-gray-400 dark:text-gray-500">
+        {/* Part of speech */}
+        {word.partOfSpeech && (
+          <p className="text-sm text-gray-400 dark:text-gray-500">
             {word.partOfSpeech}
           </p>
-        </div>
-      )}
+        )}
 
-      {/* Pronunciation notes - track as hint usage */}
+        {/* Translation toggle chevron */}
+        {word.translationEn && (
+          <button
+            type="button"
+            onClick={() => {
+              if (onToggleTranslation) {
+                onToggleTranslation();
+              }
+            }}
+            className="text-gray-300 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-400 cursor-pointer transition-colors"
+            aria-pressed={showTranslation}
+            aria-label={showTranslation ? 'Hide translation' : 'Show translation'}
+          >
+            {showTranslation ? (
+              <ChevronUp size={20} className="w-5 h-5" />
+            ) : (
+              <ChevronDown size={20} className="w-5 h-5" />
+            )}
+          </button>
+        )}
+
+        {/* English translation - shown conditionally */}
+        {word.translationEn && showTranslation && (
+          <p className="text-base md:text-lg text-gray-500 dark:text-gray-400 italic text-center">
+            {word.translationEn}
+          </p>
+        )}
+      </div>
+
+      {/* Pronunciation notes / tip - track as hint usage */}
       {word.pronunciationNotes && (
-        <div 
-          className="mb-4 p-3 bg-blue-50 dark:bg-blue-900/20 border-l-4 border-blue-400 dark:border-blue-500 rounded text-sm cursor-pointer"
+        <div
+          className="mb-5 flex items-start gap-2 p-3.5 bg-primary-50 dark:bg-primary-900/20 border border-primary-100 dark:border-primary-800/50 rounded-xl text-sm cursor-pointer"
           onClick={() => setHintUsedForCurrentAttempt(true)}
           title="Click to mark as hint used"
         >
-          <p className="text-blue-800 dark:text-blue-300">{word.pronunciationNotes}</p>
+          <Lightbulb size={18} className="shrink-0 mt-0.5 text-primary-600 dark:text-primary-400" />
+          <p className="text-primary-800 dark:text-primary-200 font-medium">{word.pronunciationNotes}</p>
         </div>
       )}
 
-      {/* Phoneme Panel (Metadata/Tips) */}
-      <div className="mb-4">
-        <PhonemePanel word={word} />
-      </div>
-
-      {/* Audio playback controls - uses global voice setting */}
-      <div className="mb-4 flex gap-2">
-        {(() => {
-          const audioUrl = selectedVoice === 'male' ? word.audioMaleUrl : word.audioFemaleUrl;
-          
-          if (audioUrl) {
-            return (
-              <AudioPlayerButton
-                audioUrl={audioUrl}
-                label="Play"
-                icon="▶"
-                variant={selectedVoice}
-                compact={true}
+      {/* Listen + Record panel */}
+      <div className="mb-5 rounded-xl border border-gray-200 dark:border-gray-700 p-5">
+        <div className="grid grid-cols-1 sm:grid-cols-2 divide-y sm:divide-y-0 sm:divide-x divide-gray-200 dark:divide-gray-700">
+          {/* Listen */}
+          <div className="flex flex-col items-center text-center gap-2 pb-5 sm:pb-0 sm:pr-4">
+            {nativeAudioUrl ? (
+              <PremiumPlayButton
+                isPlaying={isNativePlaying}
+                onClick={handlePlayNative}
+                disabled={isNativeLoading}
+                size="md"
               />
-            );
-          } else if (word.id) {
-            return <WordAudioButton wordId={word.id} compact={true} />;
-          }
-          return null;
-        })()}
-      </div>
+            ) : (
+              word.id && <WordAudioButton wordId={word.id} compact />
+            )}
+            <span className="text-sm font-semibold text-gray-900 dark:text-gray-100">Listen</span>
+            <span className="text-xs text-gray-500 dark:text-gray-400">Hear native pronunciation</span>
+          </div>
 
-      {/* Recording controls */}
-      <div className="mb-4">
-        <div className="flex items-center gap-4">
-          <PremiumRecordButton
-            isRecording={isRecording}
-            onClick={handleRecordToggle}
-            disabled={isSubmitting}
-            size="md"
-          />
-          {isRecording && (
-            <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
-              Recording...
+          {/* Record */}
+          <div className="flex flex-col items-center text-center gap-2 pt-5 sm:pt-0 sm:pl-4">
+            <PremiumRecordButton
+              isRecording={isRecording}
+              onClick={handleRecordToggle}
+              disabled={isSubmitting}
+              size="md"
+            />
+            <span className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+              {isRecording ? 'Recording…' : isSubmitting ? 'Assessing…' : 'Tap to record'}
             </span>
-          )}
+            <span className="text-xs text-gray-500 dark:text-gray-400">Speak clearly at a natural pace</span>
+          </div>
         </div>
         {recorderError && (
-          <p className="mt-2 text-sm text-red-600 dark:text-red-400">{recorderError}</p>
+          <p className="mt-3 text-sm text-red-600 dark:text-red-400 text-center">{recorderError}</p>
         )}
+      </div>
+
+      {/* Pronunciation Breakdown */}
+      <div className="mb-5">
+        <PhonemePanel word={word} />
       </div>
 
       {/* Submit error banner */}
@@ -432,7 +460,7 @@ function WordCard({ word, sessionId, status, showTranslation = false, onToggleTr
 
       {/* Pronunciation Feedback - show feedback for the most recent attempt */}
       {latestAttempt && (
-        <SentenceFeedback 
+        <SentenceFeedback
           currentAttempt={latestAttempt}
           fallbackText={word.textPt}
           fallbackTranslation={word.translationEn}
@@ -441,18 +469,24 @@ function WordCard({ word, sessionId, status, showTranslation = false, onToggleTr
       )}
 
       {/* Action buttons */}
-      <div className="flex flex-col sm:flex-row gap-2 mt-4 pt-4 border-t border-gray-200 dark:border-gray-700">
+      <div className="flex flex-col sm:flex-row gap-3 mt-4">
         <button
           onClick={handleKnowIt}
-          className="btn btn-success btn-sm flex-1"
+          className="btn btn-success flex-1 flex flex-col items-center py-3"
         >
-          ✓ Know it
+          <span className="flex items-center gap-2 text-base font-semibold">
+            <Check size={18} /> Know it
+          </span>
+          <span className="text-xs font-normal opacity-90">I pronounced this correctly</span>
         </button>
         <button
           onClick={handleReviewLater}
-          className="btn btn-secondary btn-sm flex-1"
+          className="btn btn-secondary flex-1 flex flex-col items-center py-3"
         >
-          ❓ Don't know it yet
+          <span className="flex items-center gap-2 text-base font-semibold">
+            <HelpCircle size={18} /> Don't know it yet
+          </span>
+          <span className="text-xs font-normal opacity-80">I need more practice</span>
         </button>
       </div>
     </div>

--- a/src/pages/WordPractice.tsx
+++ b/src/pages/WordPractice.tsx
@@ -415,15 +415,27 @@ export default function WordPractice({ headerElement }: { headerElement?: React.
         </div>
 
       {/* Global status summary */}
-      <div className="mb-4 text-sm text-gray-600 dark:text-gray-400">
-        <span className="font-medium">Progress: </span>
-        <span>New: {statusCounts.new}</span>
-        <span className="mx-1">•</span>
-        <span>Learning: {statusCounts.learning}</span>
-        <span className="mx-1">•</span>
-        <span>Review: {statusCounts.review}</span>
-        <span className="mx-1">•</span>
-        <span>Mastered: {statusCounts.known}</span>
+      <div className="mb-6 card card-compact">
+        <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-3">Your Progress</h2>
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+          {[
+            { label: 'New', value: statusCounts.new, dot: 'bg-gray-400' },
+            { label: 'Learning', value: statusCounts.learning, dot: 'bg-yellow-400' },
+            { label: 'Review', value: statusCounts.review, dot: 'bg-orange-400' },
+            { label: 'Mastered', value: statusCounts.known, dot: 'bg-primary-500' },
+          ].map((stat) => (
+            <div
+              key={stat.label}
+              className="rounded-xl border border-gray-200 dark:border-gray-700 bg-gray-50/60 dark:bg-gray-800/40 px-4 py-3"
+            >
+              <div className="flex items-center gap-1.5 text-xs font-medium text-gray-600 dark:text-gray-400">
+                <span className={`inline-block w-2 h-2 rounded-full ${stat.dot}`} />
+                {stat.label}
+              </div>
+              <div className="mt-1 text-xl font-bold text-gray-900 dark:text-gray-100">{stat.value}</div>
+            </div>
+          ))}
+        </div>
       </div>
 
       {/* Practice Mode Selector */}


### PR DESCRIPTION
## Summary

Reworks the **Practice → Words** page to match the new design mockup. Changes are presentational — all existing recording, scoring, self-rating, and navigation logic is untouched.

### What changed

- **"Your Progress" card** — replaced the plain `Progress: New: … • Learning: …` text line with a titled card of four labeled stat tiles (New / Learning / Review / Mastered), each with a colored status dot.
- **Word card layout** — larger, centered headword with an inline speaker button; part-of-speech and translation toggle kept beneath it.
- **Pronunciation tip** — the pronunciation note now renders as a green lightbulb callout (still tracked as hint usage).
- **Listen / Record panel** — a dedicated bordered panel with a blue **Listen** play button and green **Tap to record** mic side by side, each with a descriptive caption.
- **Pronunciation Breakdown** — rebuilt with phoneme sound tiles (symbol + code), teaching tip, example words, a per-row native-audio playback button, and a new **Show IPA** toggle that switches the tile sub-label between the ARPABET code `(OW)` and IPA notation `/o/`.
- **Action buttons** — enlarged **Know it** / **Don't know it yet** buttons with supporting subtitles.

### Notes

- `WordCard` is also rendered by the Review page; its props are unchanged, so that usage continues to work.
- `PhonemePanel` (the practice variant) is only consumed by `WordCard`, so its restyle is self-contained.

## Testing

- `npx tsc --noEmit` — passes
- `npm run build` — passes
- `npx vitest run src/components/practice src/pages` — 9 passed
- Visual verification via Vite preview + Playwright screenshots in light and dark mode; confirmed the **Show IPA** toggle flips the tile sub-label and updates the button label.

## Docs

- Updated `FEATURES.md` Word Phoneme Panel entry to mention the Show IPA toggle and per-row playback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012J86rMLJjpvJTtsxHNZNzt)_