### PR TITLE
fix(demo): fix phoneme badge overflow and rehome progress sparkline

### DIFF
--- a/src/components/pronunciation/ScoringPanel.tsx
+++ b/src/components/pronunciation/ScoringPanel.tsx
@@ -4,6 +4,12 @@ import type { AttemptScore } from '@/types/pronunciation';
 interface ScoringPanelProps {
   currentAttempt: AttemptScore | null;
   variant?: 'card' | 'banner' | 'strip';
+  /**
+   * Optional content rendered inside the hero column of the `strip` variant,
+   * below the overall-score interpretation (e.g. a progress sparkline). When
+   * present, the sub-metrics spread vertically to keep the two columns balanced.
+   */
+  heroExtra?: React.ReactNode;
 }
 
 /**
@@ -310,7 +316,7 @@ export function getScoreColor(score: number): ScoreTheme {
  * 
  * @param variant - 'card' for vertical card layout (default), 'banner' for horizontal banner layout
  */
-export default function ScoringPanel({ currentAttempt, variant = 'card' }: ScoringPanelProps) {
+export default function ScoringPanel({ currentAttempt, variant = 'card', heroExtra }: ScoringPanelProps) {
   if (!currentAttempt) {
     if (variant === 'banner') {
       return null; // Don't render banner if no attempt
@@ -368,7 +374,7 @@ export default function ScoringPanel({ currentAttempt, variant = 'card' }: Scori
         <div className="absolute top-3 right-3 z-10">
           <AllMetricsInfoIcon prosodyAvailable={prosody !== null} />
         </div>
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 sm:gap-6 items-center">
+        <div className={`grid grid-cols-1 sm:grid-cols-2 gap-4 sm:gap-6 ${heroExtra ? 'items-stretch' : 'items-center'}`}>
           {/* Hero: overall score + interpretation */}
           <div className="pr-8 sm:pr-0">
             <div className="text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-1">
@@ -400,10 +406,11 @@ export default function ScoringPanel({ currentAttempt, variant = 'card' }: Scori
             <p className="mt-2 text-sm text-gray-600 dark:text-gray-300">
               {getScoreInterpretation(overall)}
             </p>
+            {heroExtra && <div className="mt-4">{heroExtra}</div>}
           </div>
 
           {/* Sub-metrics */}
-          <div className="space-y-3 pr-8 sm:border-l sm:border-gray-200/70 sm:dark:border-gray-700 sm:pl-6">
+          <div className={`pr-8 sm:border-l sm:border-gray-200/70 sm:dark:border-gray-700 sm:pl-6 ${heroExtra ? 'flex flex-col justify-between gap-3' : 'space-y-3'}`}>
             {subMetrics.map((metric) => {
               const available = metric.value !== null;
               return (

--- a/src/components/pronunciation/shared/PhonemePanel.tsx
+++ b/src/components/pronunciation/shared/PhonemePanel.tsx
@@ -159,8 +159,8 @@ export default function PhonemePanel({ word, onClose, trustLevel = 'trusted' }: 
                     key={index}
                     className="bg-white dark:bg-gray-800 rounded-xl p-3 sm:p-4 border border-gray-200/70 dark:border-gray-700 flex items-center gap-3 sm:gap-4"
                   >
-                    <div className="shrink-0 w-10 h-10 sm:w-12 sm:h-12 rounded-full bg-primary-50 dark:bg-primary-900/30 flex items-center justify-center">
-                      <span className="text-lg font-bold text-primary-700 dark:text-primary-300 font-mono">
+                    <div className="shrink-0 min-w-10 h-10 sm:min-w-12 sm:h-12 px-2 rounded-full bg-primary-50 dark:bg-primary-900/30 flex items-center justify-center">
+                      <span className={`font-bold text-primary-700 dark:text-primary-300 font-mono whitespace-nowrap ${phoneme.symbol.length > 3 ? 'text-[11px] sm:text-xs' : 'text-lg'}`}>
                         {phoneme.symbol}
                       </span>
                     </div>
@@ -195,8 +195,8 @@ export default function PhonemePanel({ word, onClose, trustLevel = 'trusted' }: 
                     key={index}
                     className="bg-white dark:bg-gray-800 rounded-xl p-3 sm:p-4 border border-gray-200/70 dark:border-gray-700 flex items-center gap-3 sm:gap-4"
                   >
-                    <div className="shrink-0 w-10 h-10 sm:w-12 sm:h-12 rounded-full bg-primary-50 dark:bg-primary-900/30 flex items-center justify-center">
-                      <span className="text-lg font-bold text-primary-700 dark:text-primary-300 font-mono">
+                    <div className="shrink-0 min-w-10 h-10 sm:min-w-12 sm:h-12 px-2 rounded-full bg-primary-50 dark:bg-primary-900/30 flex items-center justify-center">
+                      <span className={`font-bold text-primary-700 dark:text-primary-300 font-mono whitespace-nowrap ${phoneme.symbol.length > 3 ? 'text-[11px] sm:text-xs' : 'text-lg'}`}>
                         {phoneme.symbol}
                       </span>
                     </div>

--- a/src/pages/DemoPage.tsx
+++ b/src/pages/DemoPage.tsx
@@ -105,8 +105,24 @@ function DemoPracticeCard({ item, example }: { item: DemoItem; example: DemoExam
         </p>
       )}
 
-      {/* Score strip — same component the practice page shows after scoring */}
-      <ScoringPanel currentAttempt={example.attempt} variant="strip" />
+      {/* Score strip — same component the practice page shows after scoring.
+          The sparkline rides in the hero column so progress sits alongside the
+          accuracy/fluency/completeness metrics instead of a separate card. */}
+      <ScoringPanel
+        currentAttempt={example.attempt}
+        variant="strip"
+        heroExtra={
+          <div className="border-t border-gray-200/70 dark:border-gray-700 pt-3">
+            <div className="flex items-center justify-between mb-1.5">
+              <span className="text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                Progress
+              </span>
+              <DemoBadge />
+            </div>
+            <PhraseTrendSparkline scores={item.history} />
+          </div>
+        }
+      />
 
       {/* Full sentence, translation toggle, audio controls, and Sound Details.
           Keyed by example so word selection and scores reset when switching. */}
@@ -263,32 +279,6 @@ export default function DemoPage() {
           </div>
 
           <DemoPracticeCard item={item} example={example} />
-        </div>
-
-        {/* Progress over time */}
-        <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200/70 dark:border-gray-700 p-6">
-          <div className="flex items-center justify-between mb-3">
-            <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300">
-              Progress on “{item.text}”
-            </h3>
-            <DemoBadge />
-          </div>
-          <PhraseTrendSparkline scores={item.history} />
-          <div className="mt-4 space-y-1.5">
-            {item.history.map((score, i) => (
-              <div
-                key={i}
-                className="flex items-center justify-between text-sm text-gray-600 dark:text-gray-400"
-              >
-                <span>Attempt {i + 1}</span>
-                <span className="font-semibold text-gray-900 dark:text-gray-100">{score}</span>
-              </div>
-            ))}
-          </div>
-          <p className="mt-3 text-xs text-gray-500 dark:text-gray-400">
-            +{item.history[item.history.length - 1] - item.history[0]} points across{' '}
-            {item.history.length} attempts.
-          </p>
         </div>
 
         {/* Footer CTA */}


### PR DESCRIPTION
## Summary

Fixes two UI issues on the interactive demo page that undercut confidence in the app.

### 1. `EN_NASAL` phoneme badge overflow
Long phoneme symbols overflowed the fixed-size badge circle and overlapped the adjacent "How to say it" text. The badge is now a min-width pill (`min-w-10 … px-2`) that grows with its content, and symbols longer than 3 characters render at a smaller font so they stay contained. Applied to both the metadata and no-metadata card branches in `PhonemePanel`.

### 2. Progress sparkline placement
The sparkline previously lived in its own card followed by a per-attempt score list (`Attempt 1 … 72`, etc.). Per the request:
- Removed the attempts list from the demo entirely.
- Moved the sparkline into the score strip's hero column, directly below the overall score.
- The accuracy / fluency / completeness metrics now spread vertically (`justify-between`) so the two columns stay balanced.

`ScoringPanel` gains an optional `heroExtra` slot (only used by the demo) to host the sparkline; when present, the strip switches to `items-stretch` and the sub-metrics distribute vertically.

## Changes
- `src/components/pronunciation/shared/PhonemePanel.tsx` — pill-style badge that fits long symbols.
- `src/components/pronunciation/ScoringPanel.tsx` — optional `heroExtra` hero-column slot + balanced strip layout.
- `src/pages/DemoPage.tsx` — sparkline moved into the score strip; separate progress card and attempt list removed.

## Testing
- Typecheck clean for all changed files (only a pre-existing unrelated `baseUrl` deprecation warning remains).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XAUTaqXYKineQQUxm141Ge)_