### PR TITLE
Replace IPA feedback with intuitive pronunciation guides

### DIFF
--- a/e2e/linkedin-screenshots.spec.ts
+++ b/e2e/linkedin-screenshots.spec.ts
@@ -19,10 +19,10 @@ const screenMatrix: Screen[] = [
     fileName: 'dashboard-sentences.png',
     readyText: 'Sentences',
     role: 'button',
-    // Expand the "Previous attempts" accordion so the phoneme-tip panel
+    // Expand the "Previous attempts" accordion so the pronunciation guide
     // renders populated from the seeded attempt instead of the "Click a
     // word..." empty state. Captured full-page so branding + sentence +
-    // phoneme tips all appear together.
+    // pronunciation tips all appear together.
     postNav: async (page) => {
       await page
         .getByRole('button', { name: /^Previous attempts/, exact: false })
@@ -34,7 +34,7 @@ const screenMatrix: Screen[] = [
         .first()
         .click();
       await expect(
-        page.getByRole('heading', { name: /How to pronounce these sounds/i }),
+        page.getByRole('heading', { name: /Pronunciation guide/i }),
       ).toBeVisible({ timeout: 10_000 });
       await page.evaluate(() => window.scrollTo(0, 0));
     },
@@ -84,7 +84,7 @@ function buildSeedPayload() {
     };
   });
 
-  // Word-level scores for the "Estou com fome." sentence so the phoneme panel
+  // Word-level scores for the "Estou com fome." sentence so the pronunciation guide
   // can auto-select the first word and enrich it with canonical phonemes.
   const estouComFomeWordScores = [
     { token: 'Estou', overallScore: 82, accuracyScore: 84, errorType: 'none' as const },

--- a/src/components/pronunciation/PronunciationFeedbackPanel.tsx
+++ b/src/components/pronunciation/PronunciationFeedbackPanel.tsx
@@ -325,7 +325,7 @@ export default function PronunciationFeedbackPanel({
         </div>
       )}
 
-      {/* Sound Details / Phoneme panel - only meaningful once an attempt is scored */}
+      {/* Pronunciation guide - only meaningful once an attempt is scored */}
       {hasAttempts && (
         <PhonemePanel
           word={selectedWord}

--- a/src/components/pronunciation/shared/PhonemePanel.test.tsx
+++ b/src/components/pronunciation/shared/PhonemePanel.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import PhonemePanel from './PhonemePanel';
+
+describe('Pronunciation guide panel', () => {
+  it('shows eye dialect, reference words, and the spelling rule instead of IPA', () => {
+    render(
+      <PhonemePanel
+        word={{
+          id: 'rio',
+          text: 'Rio',
+          accuracyScore: 76,
+          score: 76,
+          guidePhonemes: ['R_TAP', 'IY', 'OW'],
+          phonemes: [
+            { symbol: 'R_TAP', score: 72, isProblem: true },
+            { symbol: 'IY', score: 84, isProblem: false },
+            { symbol: 'OW', score: 82, isProblem: false },
+          ],
+        }}
+      />,
+    );
+
+    expect(screen.getByRole('heading', { name: 'Pronunciation guide' })).toBeInTheDocument();
+    expect(screen.getByText('Hee-oh')).toBeInTheDocument();
+    expect(screen.getByText(/R at the start/).closest('p')).toHaveTextContent('R at the start = "H" sound (like hat)');
+    expect(screen.getByRole('heading', { name: 'Reference words' }).closest('section')).toHaveTextContent('H like hat');
+    expect(screen.getByRole('heading', { name: 'Focus for your next try' }).closest('section')).toHaveTextContent('“H”');
+    expect(screen.queryByText('R_TAP')).not.toBeInTheDocument();
+    expect(screen.queryByText(/\/ɾ\//)).not.toBeInTheDocument();
+  });
+});

--- a/src/components/pronunciation/shared/PhonemePanel.tsx
+++ b/src/components/pronunciation/shared/PhonemePanel.tsx
@@ -1,7 +1,11 @@
 import type { NormalizedWordFeedback } from './types';
-import { getPhonemeById } from '@/lib/phonemeMetadata';
 import { findHomograph } from '@/lib/homographs';
 import type { TrustLevel } from '@/lib/assessmentTrust';
+import {
+  buildPronunciationGuide,
+  getEyeDialectSound,
+  getReferenceWord,
+} from '@/lib/pronunciationGuide';
 
 interface PhonemePanelProps {
   word?: NormalizedWordFeedback | null;
@@ -10,78 +14,62 @@ interface PhonemePanelProps {
 }
 
 /**
- * Ring color for per-phoneme score circles, matching the app's score bands.
+ * Learner-facing pronunciation guide for the selected word.
+ * Assessment phonemes remain available internally for scoring, but the UI uses
+ * English respelling, familiar reference words, and Portuguese spelling rules.
  */
-function getPhonemeRingColor(score: number): string {
-  if (score >= 80) return 'border-emerald-500 text-emerald-700 dark:border-emerald-400 dark:text-emerald-300';
-  if (score >= 60) return 'border-amber-500 text-amber-700 dark:border-amber-400 dark:text-amber-300';
-  return 'border-rose-500 text-rose-700 dark:border-rose-400 dark:text-rose-300';
-}
-
-/**
- * Circular score indicator shown on the right of each phoneme card.
- */
-function PhonemeScoreRing({ score }: { score: number }) {
-  const rounded = Math.round(score);
-  return (
-    <div
-      className={`shrink-0 w-11 h-11 sm:w-14 sm:h-14 rounded-full border-2 bg-white dark:bg-gray-800 flex flex-col items-center justify-center ${getPhonemeRingColor(rounded)}`}
-      aria-label={`Score ${rounded} out of 100`}
-    >
-      <span className="text-sm sm:text-base font-bold leading-none">{rounded}</span>
-      <span className="hidden sm:block text-[9px] text-gray-400 dark:text-gray-500 mt-0.5">/100</span>
-    </div>
-  );
-}
-
-/**
- * Panel displaying phoneme details and tips for a selected word.
- */
-export default function PhonemePanel({ word, onClose, trustLevel = 'trusted' }: PhonemePanelProps) {
-  // Empty state: no word selected
+export default function PhonemePanel({
+  word,
+  onClose,
+  trustLevel = 'trusted',
+}: PhonemePanelProps) {
   if (!word) {
     return (
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-200 dark:border-gray-700 p-4 sm:p-6">
         <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
-          Sound Details (Phonemes & Tips)
+          Pronunciation guide
         </h3>
         <div className="bg-gray-50 dark:bg-gray-700/50 rounded-lg p-4 border border-gray-200 dark:border-gray-600 text-center">
           <p className="text-sm text-gray-600 dark:text-gray-400">
-            Click a word in the sentence to see tips for its sounds.
+            Click a word in the sentence to see how to say it.
           </p>
         </div>
       </div>
     );
   }
 
-  const problemPhonemes = word.phonemes?.filter(p => p.isProblem) || [];
+  const guidePhonemes = word.guidePhonemes ?? word.phonemes?.map((phoneme) => phoneme.symbol) ?? [];
+  const guide = buildPronunciationGuide({
+    word: word.text,
+    phonemes: guidePhonemes,
+    pronunciationNote: word.pronunciationNote,
+  });
+  const problemSounds = word.phonemes?.filter((phoneme) => phoneme.isProblem) ?? [];
   const wordScore = word.score ?? word.accuracyScore;
   const wordLevel = word.level || (wordScore >= 90 ? 'excellent' : wordScore >= 80 ? 'good' : wordScore >= 70 ? 'ok' : 'practice');
   const homograph = findHomograph(word.text);
 
   return (
-    <div className="bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-200 dark:border-gray-700 p-4 sm:p-6 space-y-4">
-      {/* Header */}
-      <div className="flex items-start justify-between">
+    <div className="bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-200 dark:border-gray-700 p-4 sm:p-6 space-y-5">
+      <div className="flex items-start justify-between gap-4">
         <div>
-          <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-1">
-            Sound Details (Phonemes & Tips)
+          <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+            Pronunciation guide
           </h3>
-          <p className="text-xl font-semibold text-gray-900 dark:text-gray-100">
-            <span className="text-primary-600 dark:text-primary-400">{word.text}</span>
-          </p>
           <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">
-            Word score: {wordScore}/100 • {wordLevel}
+            <span className="font-semibold text-primary-600 dark:text-primary-400">{word.text}</span>
+            {' '}• Score {wordScore}/100 • {wordLevel}
           </p>
           <p className="text-xs text-gray-400 dark:text-gray-500 mt-1">
-            Tap any word in the sentence to inspect its sounds.
+            Tap any word in the sentence to inspect its pronunciation.
           </p>
         </div>
         {onClose && (
           <button
+            type="button"
             onClick={onClose}
             className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
-            aria-label="Close"
+            aria-label="Close pronunciation guide"
           >
             ✕
           </button>
@@ -94,8 +82,8 @@ export default function PhonemePanel({ word, onClose, trustLevel = 'trusted' }: 
           className="bg-gray-50 dark:bg-gray-700/50 rounded-lg p-4 border border-gray-200 dark:border-gray-600"
         >
           <p className="text-sm text-gray-600 dark:text-gray-400">
-            Phoneme tips are hidden for this attempt because the audio couldn't be scored reliably.
-            Re-record the full sentence in a quieter room to see detailed coaching.
+            Personalized sound coaching is hidden because this recording could not be scored reliably.
+            The pronunciation and spelling guide below still comes from the reference word.
           </p>
         </div>
       )}
@@ -106,129 +94,124 @@ export default function PhonemePanel({ word, onClose, trustLevel = 'trusted' }: 
           className="rounded-lg p-3 border border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/20"
         >
           <p className="text-xs text-amber-800 dark:text-amber-300">
-            Parts of this recording were hard to score — tips below may be less precise than usual.
+            Parts of this recording were hard to score, so personalized coaching may be less precise than usual.
           </p>
         </div>
       )}
 
-      {homograph && trustLevel !== 'untrusted' && (
+      {homograph && (
         <div
           data-testid="phoneme-panel-homograph"
           className="rounded-lg p-3 border border-indigo-200 dark:border-indigo-800 bg-indigo-50 dark:bg-indigo-900/20"
         >
           <p className="text-xs text-indigo-900 dark:text-indigo-200 mb-1">
-            <strong>{homograph.form}</strong> has more than one common pronunciation in Brazilian
-            Portuguese. Azure scored the reading that best matched your audio.
+            <strong>{homograph.form}</strong> has more than one common pronunciation in Brazilian Portuguese.
+            The intended sound depends on its meaning:
           </p>
-          <ul className="text-xs text-indigo-900 dark:text-indigo-200 space-y-0.5">
-            {homograph.readings.map((r, i) => (
-              <li key={i}>
-                <span className="font-mono">/{r.ipa}/</span> &mdash; {r.meaning}
-              </li>
+          <ul className="text-xs text-indigo-900 dark:text-indigo-200 list-disc pl-4 space-y-0.5">
+            {homograph.readings.map((reading) => (
+              <li key={reading.meaning}>{reading.meaning}</li>
             ))}
           </ul>
         </div>
       )}
 
-      {trustLevel !== 'untrusted' && (!word.phonemes || word.phonemes.length === 0) && (
-        <div className="bg-gray-50 dark:bg-gray-700/50 rounded-lg p-4 border border-gray-200 dark:border-gray-600">
-          <p className="text-sm text-gray-600 dark:text-gray-400 text-center">
-            No phoneme data available for this word yet.
-          </p>
-        </div>
-      )}
+      <div className="rounded-xl border border-primary-200 bg-primary-50 px-5 py-4 dark:border-primary-800 dark:bg-primary-900/20">
+        <p className="text-xs font-semibold uppercase tracking-wide text-primary-700 dark:text-primary-300">
+          Say it like
+        </p>
+        <p className="mt-1 text-3xl font-bold tracking-wide text-gray-900 dark:text-white">
+          {guide.respelling}
+        </p>
+        <p className="mt-2 text-xs text-gray-600 dark:text-gray-400">
+          English phonetic respelling — no special symbols needed.
+        </p>
+      </div>
 
-      {/* How to pronounce these sounds */}
-      {trustLevel !== 'untrusted' && word.phonemes && word.phonemes.length > 0 && (
-        <div className="pt-4 border-t border-gray-200 dark:border-gray-700">
-          <h4 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">
-            🔊 How to pronounce these sounds:
+      {guide.references.length > 0 && (
+        <section aria-labelledby={`reference-words-${word.id}`}>
+          <h4
+            id={`reference-words-${word.id}`}
+            className="text-sm font-semibold text-gray-800 dark:text-gray-200"
+          >
+            Reference words
           </h4>
-          <div className="space-y-3">
-            {word.phonemes.map((phoneme, index) => {
-              const metadata = getPhonemeById(phoneme.symbol);
-              
-              if (metadata) {
-                const desc = metadata.englishApprox || metadata.articulation || '';
-                const tip = metadata.teachingTips?.[0] || '';
-                const ptEx = metadata.exampleWords?.map(w => w.pt).join(', ') || '';
-                const enEx = metadata.englishExamples?.join(', ') || '';
-
-                return (
-                  <div
-                    key={index}
-                    className="bg-white dark:bg-gray-800 rounded-xl p-3 sm:p-4 border border-gray-200/70 dark:border-gray-700 flex items-center gap-3 sm:gap-4"
-                  >
-                    <div className="shrink-0 min-w-10 h-10 sm:min-w-12 sm:h-12 px-2 rounded-full bg-primary-50 dark:bg-primary-900/30 flex items-center justify-center">
-                      <span className={`font-bold text-primary-700 dark:text-primary-300 font-mono whitespace-nowrap ${phoneme.symbol.length > 3 ? 'text-[11px] sm:text-xs' : 'text-lg'}`}>
-                        {phoneme.symbol}
-                      </span>
-                    </div>
-                    <div className="flex-1 min-w-0">
-                      <p className="text-sm text-gray-800 dark:text-gray-200">
-                        <strong className="font-semibold">How to say it:</strong> {desc}
-                      </p>
-                      {tip && (
-                        <p className="text-xs text-primary-700 dark:text-primary-300 mt-1">
-                          💡 {tip}
-                        </p>
-                      )}
-                      <div className="flex flex-wrap gap-x-4 gap-y-0.5 text-xs text-gray-500 dark:text-gray-400 mt-1.5">
-                        {ptEx && (
-                          <span>
-                            <strong className="text-gray-600 dark:text-gray-300">PT:</strong> <em>{ptEx}</em>
-                          </span>
-                        )}
-                        {enEx && (
-                          <span>
-                            <strong className="text-gray-600 dark:text-gray-300">EN:</strong> <em>{enEx}</em>
-                          </span>
-                        )}
-                      </div>
-                    </div>
-                    <PhonemeScoreRing score={phoneme.score} />
-                  </div>
-                );
-              } else {
-                return (
-                  <div
-                    key={index}
-                    className="bg-white dark:bg-gray-800 rounded-xl p-3 sm:p-4 border border-gray-200/70 dark:border-gray-700 flex items-center gap-3 sm:gap-4"
-                  >
-                    <div className="shrink-0 min-w-10 h-10 sm:min-w-12 sm:h-12 px-2 rounded-full bg-primary-50 dark:bg-primary-900/30 flex items-center justify-center">
-                      <span className={`font-bold text-primary-700 dark:text-primary-300 font-mono whitespace-nowrap ${phoneme.symbol.length > 3 ? 'text-[11px] sm:text-xs' : 'text-lg'}`}>
-                        {phoneme.symbol}
-                      </span>
-                    </div>
-                    <div className="flex-1 min-w-0">
-                      <p className="text-sm text-gray-600 dark:text-gray-400 italic">
-                        No extra info available for this sound yet.
-                      </p>
-                      {phoneme.tip && (
-                        <p className="text-xs text-gray-500 dark:text-gray-500 mt-1">
-                          {phoneme.tip}
-                        </p>
-                      )}
-                    </div>
-                    <PhonemeScoreRing score={phoneme.score} />
-                  </div>
-                );
-              }
-            })}
+          <div className="mt-2 flex flex-wrap gap-2">
+            {guide.references.map((reference) => (
+              <span
+                key={`${reference.sound}-${reference.word}`}
+                className="rounded-full border border-gray-200 bg-gray-50 px-3 py-1.5 text-sm text-gray-700 dark:border-gray-600 dark:bg-gray-700/50 dark:text-gray-200"
+              >
+                <strong>{reference.sound}</strong> like <strong>{reference.word}</strong>
+              </span>
+            ))}
           </div>
-        </div>
+        </section>
       )}
 
-      {trustLevel !== 'untrusted' &&
-        problemPhonemes.length === 0 &&
-        word.phonemes &&
-        word.phonemes.length > 0 && (
-          <div className="pt-4 border-t border-gray-200 dark:border-gray-700">
-            <p className="text-sm text-emerald-600 dark:text-emerald-400">
-              ✅ All phonemes are performing well!
+      <section
+        className="border-t border-gray-200 pt-4 dark:border-gray-700"
+        aria-labelledby={`spelling-rules-${word.id}`}
+      >
+        <h4
+          id={`spelling-rules-${word.id}`}
+          className="text-sm font-semibold text-gray-800 dark:text-gray-200"
+        >
+          The spelling rule
+        </h4>
+        <div className="mt-2 space-y-2">
+          {guide.spellingRules.map((rule) => (
+            <p
+              key={rule.spelling}
+              className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-gray-800 dark:border-amber-800/70 dark:bg-amber-900/20 dark:text-gray-200"
+            >
+              <strong>{rule.spelling}</strong> = <strong>{rule.sound}</strong>
+              {rule.referenceWord && <> (like <strong>{rule.referenceWord}</strong>)</>}
             </p>
-          </div>
-        )}
+          ))}
+        </div>
+      </section>
+
+      {trustLevel !== 'untrusted' && problemSounds.length > 0 && (
+        <section
+          className="border-t border-gray-200 pt-4 dark:border-gray-700"
+          aria-labelledby={`focus-sounds-${word.id}`}
+        >
+          <h4
+            id={`focus-sounds-${word.id}`}
+            className="text-sm font-semibold text-gray-800 dark:text-gray-200"
+          >
+            Focus for your next try
+          </h4>
+          <ul className="mt-2 space-y-2">
+            {problemSounds.map((phoneme, index) => {
+              const focusPhoneme = index === 0 && /^r/i.test(word.text) && /^(r|r_tap)$/i.test(phoneme.symbol)
+                ? 'HH'
+                : phoneme.symbol;
+              const sound = getEyeDialectSound(focusPhoneme);
+              const referenceWord = getReferenceWord(focusPhoneme);
+              return (
+                <li
+                  key={`${phoneme.symbol}-${index}`}
+                  className="flex items-start gap-2 text-sm text-gray-700 dark:text-gray-300"
+                >
+                  <span className="mt-0.5 text-rose-500 dark:text-rose-400">•</span>
+                  <span>
+                    Make the <strong>“{sound}”</strong> sound slowly and clearly
+                    {referenceWord ? <>—use <strong>{referenceWord}</strong> as your model.</> : '.'}
+                  </span>
+                </li>
+              );
+            })}
+          </ul>
+        </section>
+      )}
+
+      {trustLevel !== 'untrusted' && problemSounds.length === 0 && word.phonemes && word.phonemes.length > 0 && (
+        <p className="border-t border-gray-200 pt-4 text-sm text-emerald-600 dark:border-gray-700 dark:text-emerald-400">
+          ✓ Every sound scored well. Try the whole word once more at a natural pace.
+        </p>
+      )}
     </div>
   );
 }

--- a/src/components/pronunciation/shared/adapters.ts
+++ b/src/components/pronunciation/shared/adapters.ts
@@ -227,19 +227,6 @@ export function enrichWordsWithCanonicalData(
   });
 
   return words.map(word => {
-    // If Azure already supplied phoneme data, keep it but ensure wordId is set when possible.
-    if (word.phonemes && word.phonemes.length > 0) {
-      if (word.wordId) {
-        return word;
-      }
-      const canonicalFromRefs =
-        (word.index !== undefined && wordRefsByIndex.get(word.index)) ||
-        canonicalByNormalizedText.get(normalizeWordToken(word.text));
-      return canonicalFromRefs
-        ? { ...word, wordId: canonicalFromRefs.id }
-        : word;
-    }
-
     let canonicalWord: Word | undefined;
 
     if (word.wordId) {
@@ -258,17 +245,31 @@ export function enrichWordsWithCanonicalData(
       return word;
     }
 
+    // Keep scored Azure sounds for performance feedback while attaching the
+    // canonical sequence and note for the learner-facing pronunciation guide.
+    if (word.phonemes && word.phonemes.length > 0) {
+      return {
+        ...word,
+        wordId: canonicalWord.id,
+        guidePhonemes: canonicalWord.phonemes,
+        pronunciationNote: canonicalWord.pronunciationNotes,
+      };
+    }
+
     const canonicalPhonemes = canonicalWord.phonemes;
     if (!canonicalPhonemes || canonicalPhonemes.length === 0) {
       return {
         ...word,
         wordId: canonicalWord.id,
+        pronunciationNote: canonicalWord.pronunciationNotes,
       };
     }
 
     return {
       ...word,
       wordId: canonicalWord.id,
+      guidePhonemes: canonicalPhonemes,
+      pronunciationNote: canonicalWord.pronunciationNotes,
       phonemes: canonicalPhonemes.map(symbol => ({
         symbol,
         score: word.accuracyScore,

--- a/src/components/pronunciation/shared/types.ts
+++ b/src/components/pronunciation/shared/types.ts
@@ -36,6 +36,10 @@ export interface NormalizedWordFeedback {
   level?: 'excellent' | 'good' | 'ok' | 'practice';
   /** Optional overall score (for compatibility) */
   score?: number;
+  /** Canonical sound sequence used to build learner-friendly pronunciation guidance. */
+  guidePhonemes?: string[];
+  /** Human-authored pronunciation note from the canonical word record. */
+  pronunciationNote?: string;
 }
 
 /**
@@ -54,4 +58,3 @@ export interface NormalizedWordAudioVariant extends NormalizedAudioVariant {
   startTimeMs?: number;
   endTimeMs?: number;
 }
-

--- a/src/lib/pronunciationGuide.test.ts
+++ b/src/lib/pronunciationGuide.test.ts
@@ -31,6 +31,26 @@ describe('buildPronunciationGuide', () => {
     expect(guide.respelling).toBe('FREE-o');
   });
 
+  it('does not truncate a note respelling containing accented Portuguese letters', () => {
+    const guide = buildPronunciationGuide({
+      word: 'amanhã',
+      phonemes: ['AA', 'M', 'AA', 'NH', 'AN_NASAL'],
+      pronunciationNote: 'a-ma-NHÃ (nasal end).',
+    });
+
+    expect(guide.respelling).toBe('a-ma-NHÃ');
+  });
+
+  it('falls back to the phoneme respelling when a note still spells an initial R literally', () => {
+    const guide = buildPronunciationGuide({
+      word: 'rua',
+      phonemes: ['R_TAP', 'UW', 'AH'],
+      pronunciationNote: "RU-a; start with a Portuguese 'r', then open 'a'.",
+    });
+
+    expect(guide.respelling).toBe('Hoo-uh');
+  });
+
   it('describes distinctive Portuguese letter patterns without IPA', () => {
     const guide = buildPronunciationGuide({
       word: 'caminho',

--- a/src/lib/pronunciationGuide.test.ts
+++ b/src/lib/pronunciationGuide.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { buildPronunciationGuide } from './pronunciationGuide';
+
+describe('buildPronunciationGuide', () => {
+  it('turns an initial Portuguese R into the requested English H respelling', () => {
+    const guide = buildPronunciationGuide({
+      word: 'Rio',
+      phonemes: ['R_TAP', 'IY', 'OW'],
+    });
+
+    expect(guide.respelling).toBe('Hee-oh');
+    expect(guide.references).toEqual([
+      { sound: 'H', word: 'hat' },
+      { sound: 'ee', word: 'see' },
+      { sound: 'oh', word: 'go' },
+    ]);
+    expect(guide.spellingRules[0]).toEqual({
+      spelling: 'R at the start',
+      sound: '"H" sound',
+      referenceWord: 'hat',
+    });
+  });
+
+  it('prefers a curated eye-dialect respelling in the pronunciation note', () => {
+    const guide = buildPronunciationGuide({
+      word: 'frio',
+      phonemes: ['F', 'R_TAP', 'IY', 'OW'],
+      pronunciationNote: 'FREE-o.',
+    });
+
+    expect(guide.respelling).toBe('FREE-o');
+  });
+
+  it('describes distinctive Portuguese letter patterns without IPA', () => {
+    const guide = buildPronunciationGuide({
+      word: 'caminho',
+      phonemes: ['K', 'AA', 'M', 'IY', 'NH', 'OW'],
+    });
+
+    expect(guide.spellingRules).toContainEqual({
+      spelling: 'NH',
+      sound: '"NY" sound',
+      referenceWord: 'canyon',
+    });
+    expect(guide.respelling).not.toMatch(/[ɐɲʎʒ]/);
+  });
+});

--- a/src/lib/pronunciationGuide.ts
+++ b/src/lib/pronunciationGuide.ts
@@ -223,12 +223,12 @@ function extractRespellingFromNote(note?: string): string | undefined {
 
   const parenthetical = [...note.matchAll(/\(([^()]*)\)/g)]
     .map((match) => match[1].trim())
-    .filter((candidate) => /^[A-Za-z]+(?:-[A-Za-z]+)+$/.test(candidate));
+    .filter((candidate) => /^\p{L}+(?:-\p{L}+)+$/u.test(candidate));
   if (parenthetical.length > 0) {
     return parenthetical[parenthetical.length - 1];
   }
 
-  const hyphenated = note.match(/\b[A-Za-z]+(?:-[A-Za-z]+)+\b/g) ?? [];
+  const hyphenated = note.match(/(?<!\p{L})\p{L}+(?:-\p{L}+)+(?!\p{L})/gu) ?? [];
   const eyeDialectCandidate = hyphenated
     .filter((candidate) => /[A-Z]{2}|ee|oo|ah|eh|ay|oy|sh|zh|ny|ly/i.test(candidate))
     .sort((a, b) => b.length - a.length)[0];
@@ -237,7 +237,7 @@ function extractRespellingFromNote(note?: string): string | undefined {
   }
 
   const soundsLike = note.match(/^Sounds like ['‘]([^'’]+)['’]/i);
-  if (soundsLike && /^[A-Za-z]+$/.test(soundsLike[1])) {
+  if (soundsLike && /^\p{L}+$/u.test(soundsLike[1])) {
     const candidate = soundsLike[1];
     return candidate.charAt(0).toUpperCase() + candidate.slice(1);
   }
@@ -307,7 +307,15 @@ export function buildPronunciationGuide({
   phonemes = [],
   pronunciationNote,
 }: BuildPronunciationGuideOptions): PronunciationGuide {
-  const noteRespelling = extractRespellingFromNote(pronunciationNote);
+  const rawNoteRespelling = extractRespellingFromNote(pronunciationNote);
+  // Older notes spell a word-initial R literally (e.g. "RU-a") instead of
+  // the "H" sound the spelling rules teach; only trust the note once it
+  // already follows that convention, otherwise fall back to the phoneme-
+  // derived respelling so the two don't contradict each other.
+  const initialSoundIsH = phonemes.length > 0 && pronunciationPhonemes(word, phonemes)[0] === 'HH';
+  const noteRespelling = rawNoteRespelling && (!initialSoundIsH || /^h/i.test(rawNoteRespelling.trim()))
+    ? rawNoteRespelling
+    : undefined;
   const respelling = noteRespelling ?? (
     phonemes.length > 0 ? respellFromPhonemes(word, phonemes) : word
   );

--- a/src/lib/pronunciationGuide.ts
+++ b/src/lib/pronunciationGuide.ts
@@ -1,0 +1,329 @@
+import { getPhonemeById } from './phonemeMetadata';
+
+export interface PronunciationReference {
+  sound: string;
+  word: string;
+}
+
+export interface PronunciationSpellingRule {
+  spelling: string;
+  sound: string;
+  referenceWord?: string;
+}
+
+export interface PronunciationGuide {
+  respelling: string;
+  references: PronunciationReference[];
+  spellingRules: PronunciationSpellingRule[];
+}
+
+interface BuildPronunciationGuideOptions {
+  word: string;
+  phonemes?: string[];
+  pronunciationNote?: string;
+}
+
+interface EyeDialectPhone {
+  id: string;
+  text: string;
+  vowel: boolean;
+}
+
+const EYE_DIALECT: Record<string, Omit<EyeDialectPhone, 'id'>> = {
+  AA: { text: 'ah', vowel: true },
+  AH: { text: 'uh', vowel: true },
+  EY: { text: 'ay', vowel: true },
+  EH: { text: 'eh', vowel: true },
+  IY: { text: 'ee', vowel: true },
+  OW: { text: 'oh', vowel: true },
+  AO: { text: 'aw', vowel: true },
+  UW: { text: 'oo', vowel: true },
+  AN_NASAL: { text: 'uhn', vowel: true },
+  EN_NASAL: { text: 'eng', vowel: true },
+  IN_NASAL: { text: 'eeng', vowel: true },
+  ON_NASAL: { text: 'ohng', vowel: true },
+  UN_NASAL: { text: 'oong', vowel: true },
+  P: { text: 'p', vowel: false },
+  B: { text: 'b', vowel: false },
+  T: { text: 't', vowel: false },
+  D: { text: 'd', vowel: false },
+  K: { text: 'k', vowel: false },
+  G: { text: 'g', vowel: false },
+  CH: { text: 'ch', vowel: false },
+  JH: { text: 'j', vowel: false },
+  F: { text: 'f', vowel: false },
+  V: { text: 'v', vowel: false },
+  S: { text: 's', vowel: false },
+  Z: { text: 'z', vowel: false },
+  SH: { text: 'sh', vowel: false },
+  ZH: { text: 'zh', vowel: false },
+  HH: { text: 'h', vowel: false },
+  M: { text: 'm', vowel: false },
+  N: { text: 'n', vowel: false },
+  NH: { text: 'ny', vowel: false },
+  L: { text: 'l', vowel: false },
+  LH: { text: 'ly', vowel: false },
+  R_TAP: { text: 'r', vowel: false },
+  W: { text: 'w', vowel: false },
+  Y: { text: 'y', vowel: false },
+};
+
+const PHONEME_ALIASES: Record<string, string> = {
+  R: 'R_TAP',
+  AX: 'AH',
+  AE: 'EH',
+  IH: 'IY',
+  UH: 'UW',
+  NG: 'N',
+};
+
+const REFERENCE_WORDS: Record<string, PronunciationReference> = {
+  AA: { sound: 'ah', word: 'father' },
+  AH: { sound: 'uh', word: 'sofa' },
+  EY: { sound: 'ay', word: 'say' },
+  EH: { sound: 'eh', word: 'bet' },
+  IY: { sound: 'ee', word: 'see' },
+  OW: { sound: 'oh', word: 'go' },
+  AO: { sound: 'aw', word: 'law' },
+  UW: { sound: 'oo', word: 'food' },
+  P: { sound: 'P', word: 'spin' },
+  B: { sound: 'B', word: 'boy' },
+  T: { sound: 'T', word: 'stop' },
+  D: { sound: 'D', word: 'dog' },
+  K: { sound: 'K', word: 'skate' },
+  G: { sound: 'G', word: 'go' },
+  CH: { sound: 'CH', word: 'cheese' },
+  JH: { sound: 'J', word: 'jeep' },
+  F: { sound: 'F', word: 'fan' },
+  V: { sound: 'V', word: 'van' },
+  S: { sound: 'S', word: 'sun' },
+  Z: { sound: 'Z', word: 'zoo' },
+  SH: { sound: 'SH', word: 'shoe' },
+  ZH: { sound: 'ZH', word: 'pleasure' },
+  HH: { sound: 'H', word: 'hat' },
+  M: { sound: 'M', word: 'mom' },
+  N: { sound: 'N', word: 'no' },
+  NH: { sound: 'NY', word: 'canyon' },
+  L: { sound: 'L', word: 'love' },
+  LH: { sound: 'LY', word: 'million' },
+  R_TAP: { sound: 'quick D', word: 'ladder' },
+  W: { sound: 'W', word: 'water' },
+  Y: { sound: 'Y', word: 'yes' },
+};
+
+const ALLOWED_ONSETS = new Set([
+  'BR', 'BL', 'CR', 'CL', 'DR', 'FR', 'FL', 'GR', 'GL', 'PR', 'PL', 'TR', 'VR',
+]);
+
+function normalizePhonemeId(id: string): string {
+  const upper = id.trim().toUpperCase();
+  return PHONEME_ALIASES[upper] ?? upper;
+}
+
+function pronunciationPhonemes(word: string, phonemes: string[]): string[] {
+  const normalized = phonemes.map(normalizePhonemeId);
+
+  // In Brazilian Portuguese, a written R at the start is the English H-like
+  // sound even when older canonical data labels it as a tap.
+  if (/^r/i.test(word.trim()) && normalized[0] === 'R_TAP') {
+    normalized[0] = 'HH';
+  }
+
+  return normalized;
+}
+
+function mergeDiphthongs(phones: EyeDialectPhone[]): EyeDialectPhone[] {
+  const merged: EyeDialectPhone[] = [];
+
+  for (let index = 0; index < phones.length; index += 1) {
+    const current = phones[index];
+    const next = phones[index + 1];
+    const pair = next ? `${current.id}+${next.id}` : '';
+    const diphthong =
+      pair === 'AN_NASAL+OW' ? 'own' :
+      pair === 'OW+IY' ? 'oy' :
+      pair === 'EH+IY' ? 'ay' :
+      pair === 'AA+IY' ? 'eye' :
+      pair === 'AA+UW' ? 'ow' :
+      undefined;
+
+    if (diphthong) {
+      merged.push({ id: pair, text: diphthong, vowel: true });
+      index += 1;
+    } else {
+      merged.push(current);
+    }
+  }
+
+  return merged;
+}
+
+function splitIntervocalicConsonants(consonants: EyeDialectPhone[]): {
+  coda: EyeDialectPhone[];
+  onset: EyeDialectPhone[];
+} {
+  if (consonants.length <= 1) {
+    return { coda: [], onset: consonants };
+  }
+
+  const lastTwo = consonants.slice(-2);
+  const cluster = lastTwo.map((phone) => phone.id === 'R_TAP' ? 'R' : phone.id).join('');
+  if (ALLOWED_ONSETS.has(cluster)) {
+    return {
+      coda: consonants.slice(0, -2),
+      onset: lastTwo,
+    };
+  }
+
+  return {
+    coda: consonants.slice(0, -1),
+    onset: consonants.slice(-1),
+  };
+}
+
+function respellFromPhonemes(word: string, phonemes: string[]): string {
+  const normalized = pronunciationPhonemes(word, phonemes);
+  const phones = mergeDiphthongs(
+    normalized
+      .map((id) => EYE_DIALECT[id] ? { id, ...EYE_DIALECT[id] } : undefined)
+      .filter((phone): phone is EyeDialectPhone => phone !== undefined),
+  );
+  const vowelIndices = phones
+    .map((phone, index) => phone.vowel ? index : -1)
+    .filter((index) => index >= 0);
+
+  if (vowelIndices.length === 0) {
+    return word;
+  }
+
+  const syllables: string[] = [];
+  let onset = phones.slice(0, vowelIndices[0]);
+
+  vowelIndices.forEach((vowelIndex, position) => {
+    const nextVowelIndex = vowelIndices[position + 1];
+    const consonants = nextVowelIndex === undefined
+      ? phones.slice(vowelIndex + 1)
+      : phones.slice(vowelIndex + 1, nextVowelIndex);
+    const split = nextVowelIndex === undefined
+      ? { coda: consonants, onset: [] }
+      : splitIntervocalicConsonants(consonants);
+
+    syllables.push([...onset, phones[vowelIndex], ...split.coda].map((phone) => phone.text).join(''));
+    onset = split.onset;
+  });
+
+  const respelling = syllables.filter(Boolean).join('-');
+  return respelling.charAt(0).toUpperCase() + respelling.slice(1);
+}
+
+function extractRespellingFromNote(note?: string): string | undefined {
+  if (!note) {
+    return undefined;
+  }
+
+  const parenthetical = [...note.matchAll(/\(([^()]*)\)/g)]
+    .map((match) => match[1].trim())
+    .filter((candidate) => /^[A-Za-z]+(?:-[A-Za-z]+)+$/.test(candidate));
+  if (parenthetical.length > 0) {
+    return parenthetical[parenthetical.length - 1];
+  }
+
+  const hyphenated = note.match(/\b[A-Za-z]+(?:-[A-Za-z]+)+\b/g) ?? [];
+  const eyeDialectCandidate = hyphenated
+    .filter((candidate) => /[A-Z]{2}|ee|oo|ah|eh|ay|oy|sh|zh|ny|ly/i.test(candidate))
+    .sort((a, b) => b.length - a.length)[0];
+  if (eyeDialectCandidate) {
+    return eyeDialectCandidate;
+  }
+
+  const soundsLike = note.match(/^Sounds like ['‘]([^'’]+)['’]/i);
+  if (soundsLike && /^[A-Za-z]+$/.test(soundsLike[1])) {
+    const candidate = soundsLike[1];
+    return candidate.charAt(0).toUpperCase() + candidate.slice(1);
+  }
+
+  return undefined;
+}
+
+function buildReferences(word: string, phonemes: string[]): PronunciationReference[] {
+  const ids = pronunciationPhonemes(word, phonemes);
+  const references: PronunciationReference[] = [];
+  const seen = new Set<string>();
+
+  for (const id of ids) {
+    const curated = REFERENCE_WORDS[id];
+    const metadata = getPhonemeById(id);
+    const reference = curated ?? (
+      metadata?.englishExamples?.[0]
+        ? { sound: EYE_DIALECT[id]?.text ?? id, word: metadata.englishExamples[0] }
+        : undefined
+    );
+
+    if (reference && !seen.has(reference.sound.toLowerCase())) {
+      references.push(reference);
+      seen.add(reference.sound.toLowerCase());
+    }
+  }
+
+  return references.slice(0, 4);
+}
+
+function buildSpellingRules(word: string): PronunciationSpellingRule[] {
+  const normalized = word.normalize('NFC').toLowerCase().trim();
+  const rules: PronunciationSpellingRule[] = [];
+  const add = (rule: PronunciationSpellingRule) => {
+    if (!rules.some((existing) => existing.spelling === rule.spelling)) {
+      rules.push(rule);
+    }
+  };
+
+  if (/^r/.test(normalized)) add({ spelling: 'R at the start', sound: '"H" sound', referenceWord: 'hat' });
+  if (/rr/.test(normalized)) add({ spelling: 'RR between vowels', sound: 'strong "H" sound', referenceWord: 'hat' });
+  if (/nh/.test(normalized)) add({ spelling: 'NH', sound: '"NY" sound', referenceWord: 'canyon' });
+  if (/lh/.test(normalized)) add({ spelling: 'LH', sound: '"LY" sound', referenceWord: 'million' });
+  if (/ch/.test(normalized)) add({ spelling: 'CH', sound: '"SH" sound', referenceWord: 'shoe' });
+  if (/ão/.test(normalized)) add({ spelling: 'ÃO', sound: 'nasal "OWN" sound' });
+  if (/ç/.test(normalized)) add({ spelling: 'Ç', sound: '"S" sound', referenceWord: 'sun' });
+  if (/c[eiéêí]/.test(normalized)) add({ spelling: 'C before E or I', sound: '"S" sound', referenceWord: 'sun' });
+  if (/g[eiéêí]/.test(normalized)) add({ spelling: 'G before E or I', sound: '"ZH" sound', referenceWord: 'pleasure' });
+  if (/j/.test(normalized)) add({ spelling: 'J', sound: '"ZH" sound', referenceWord: 'pleasure' });
+  if (/[aeiouáéíóúâêôãõ]s[aeiouáéíóúâêôãõ]/.test(normalized)) add({ spelling: 'S between vowels', sound: '"Z" sound', referenceWord: 'zoo' });
+  if (/^h/.test(normalized)) add({ spelling: 'H at the start', sound: 'silent' });
+  if (/ti|te$/.test(normalized)) add({ spelling: 'T before an "ee" sound', sound: '"CH" sound', referenceWord: 'cheese' });
+  if (/di|de$/.test(normalized)) add({ spelling: 'D before an "ee" sound', sound: '"J" sound', referenceWord: 'jeep' });
+  if (/[aeiouáéíóúâêôãõ][mn](?:[^aeiouáéíóúâêôãõ]|$)/.test(normalized)) {
+    add({ spelling: 'Vowel before M or N', sound: 'nasal vowel; do not fully pronounce the M or N' });
+  }
+
+  if (rules.length === 0) {
+    add({ spelling: 'Portuguese vowels', sound: 'clear, steady sounds; say every syllable' });
+  }
+
+  return rules.slice(0, 3);
+}
+
+export function buildPronunciationGuide({
+  word,
+  phonemes = [],
+  pronunciationNote,
+}: BuildPronunciationGuideOptions): PronunciationGuide {
+  const noteRespelling = extractRespellingFromNote(pronunciationNote);
+  const respelling = noteRespelling ?? (
+    phonemes.length > 0 ? respellFromPhonemes(word, phonemes) : word
+  );
+
+  return {
+    respelling,
+    references: buildReferences(word, phonemes),
+    spellingRules: buildSpellingRules(word),
+  };
+}
+
+export function getEyeDialectSound(phoneme: string): string {
+  const id = normalizePhonemeId(phoneme);
+  return REFERENCE_WORDS[id]?.sound ?? EYE_DIALECT[id]?.text ?? 'this sound';
+}
+
+export function getReferenceWord(phoneme: string): string | undefined {
+  return REFERENCE_WORDS[normalizePhonemeId(phoneme)]?.word;
+}


### PR DESCRIPTION
Reopens the work originally merged as #130, which was reverted out of `develop` in #132 (along with #129 and #131) due to regressions introduced after the recruiter-tour baseline (#128). Filed fresh since GitHub does not allow reopening a merged pull request — content is identical to the original merge (tree verified against commit `178e04c`).

Original description (#130):

## What changed

- Replaces learner-facing IPA and raw phoneme IDs in sentence feedback with English phonetic respelling (eye dialect).
- Adds familiar English reference words for each sound.
- Adds contextual Portuguese spelling rules, including `Rio → Hee-oh` and **R at the start** = **"H" sound** (like **hat**).
- Keeps Azure/canonical phoneme data internal for scoring while separating it from learner-facing guidance.
- Updates retry coaching, trust-state messaging, homograph guidance, and screenshot coverage so IPA does not leak back into the practice experience.

## Why

IPA symbols and internal sound identifiers are accurate for specialists but are not intuitive for most English-speaking learners.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VHYiYa22epgAJAY5xFuMuX)_