### PR TITLE
Codex/public eye dialect tour

### DIFF
--- a/src/components/pronunciation/shared/FocusAreasCard.test.tsx
+++ b/src/components/pronunciation/shared/FocusAreasCard.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import FocusAreasCard from './FocusAreasCard';
+
+describe('FocusAreasCard', () => {
+  it('uses English sound labels and reference words instead of provider IDs', () => {
+    render(
+      <FocusAreasCard
+        words={[
+          {
+            id: 'rio',
+            text: 'Rio',
+            accuracyScore: 68,
+            phonemes: [
+              { symbol: 'R_TAP', score: 62, isProblem: true },
+              { symbol: 'IY', score: 84, isProblem: false },
+            ],
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText(/“H” sound/).closest('li')).toHaveTextContent('“H” sound (like hat)');
+    expect(screen.queryByText('R_TAP')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/pronunciation/shared/FocusAreasCard.test.tsx
+++ b/src/components/pronunciation/shared/FocusAreasCard.test.tsx
@@ -23,4 +23,26 @@ describe('FocusAreasCard', () => {
     expect(screen.getByText(/“H” sound/).closest('li')).toHaveTextContent('“H” sound (like hat)');
     expect(screen.queryByText('R_TAP')).not.toBeInTheDocument();
   });
+
+  it('uses the remapped H-sound teaching tip for an initial R, not the tap tip', () => {
+    render(
+      <FocusAreasCard
+        words={[
+          {
+            id: 'rio',
+            text: 'Rio',
+            accuracyScore: 68,
+            phonemes: [
+              { symbol: 'R_TAP', score: 62, isProblem: true },
+              { symbol: 'IY', score: 84, isProblem: false },
+            ],
+          },
+        ]}
+      />,
+    );
+
+    const item = screen.getByText(/“H” sound/).closest('li');
+    expect(item).toHaveTextContent(/pretend it is an ['’]H['’]/);
+    expect(item).not.toHaveTextContent(/quick tap/i);
+  });
 });

--- a/src/components/pronunciation/shared/FocusAreasCard.tsx
+++ b/src/components/pronunciation/shared/FocusAreasCard.tsx
@@ -1,6 +1,7 @@
 import { Target } from 'lucide-react';
 import type { NormalizedWordFeedback } from './types';
-import { getPhonemeById, getPhonemeDisplayLabel } from '@/lib/phonemeMetadata';
+import { getPhonemeById } from '@/lib/phonemeMetadata';
+import { getEyeDialectSound, getReferenceWord } from '@/lib/pronunciationGuide';
 
 interface FocusAreasCardProps {
   words: NormalizedWordFeedback[];
@@ -8,6 +9,8 @@ interface FocusAreasCardProps {
 
 interface ProblemPhoneme {
   symbol: string;
+  sound: string;
+  referenceWord?: string;
   score: number;
   tip: string;
 }
@@ -21,9 +24,12 @@ function collectProblemPhonemes(words: NormalizedWordFeedback[]): ProblemPhoneme
 
   for (const word of words) {
     if (!word.phonemes) continue;
-    for (const phoneme of word.phonemes) {
+    for (const [index, phoneme] of word.phonemes.entries()) {
       if (!phoneme.isProblem || phoneme.score === undefined) continue;
-      const existing = bySymbol.get(phoneme.symbol);
+      const contextualSymbol = index === 0 && /^r/i.test(word.text) && /^(r|r_tap)$/i.test(phoneme.symbol)
+        ? 'HH'
+        : phoneme.symbol;
+      const existing = bySymbol.get(contextualSymbol);
       if (existing && existing.score <= phoneme.score) continue;
 
       const metadata = getPhonemeById(phoneme.symbol);
@@ -33,8 +39,10 @@ function collectProblemPhonemes(words: NormalizedWordFeedback[]): ProblemPhoneme
         metadata?.englishApprox ||
         metadata?.articulation ||
         `Needs more precision.`;
-      bySymbol.set(phoneme.symbol, {
-        symbol: phoneme.symbol,
+      bySymbol.set(contextualSymbol, {
+        symbol: contextualSymbol,
+        sound: getEyeDialectSound(contextualSymbol),
+        referenceWord: getReferenceWord(contextualSymbol),
         score: phoneme.score,
         tip,
       });
@@ -45,8 +53,8 @@ function collectProblemPhonemes(words: NormalizedWordFeedback[]): ProblemPhoneme
 }
 
 /**
- * Standalone Focus Areas card surfacing the lowest-scoring problem phonemes
- * across the entire sentence. Rendered below Sound Details on the practice page.
+ * Standalone Focus Areas card surfacing the lowest-scoring problem sounds
+ * across the sentence using English-friendly labels instead of provider IDs.
  */
 export default function FocusAreasCard({ words }: FocusAreasCardProps) {
   const problems = collectProblemPhonemes(words);
@@ -70,10 +78,10 @@ export default function FocusAreasCard({ words }: FocusAreasCardProps) {
           >
             <span className="text-primary-500 dark:text-primary-400 shrink-0">•</span>
             <span>
-              <strong className="font-mono font-semibold text-gray-900 dark:text-gray-100">
-                {getPhonemeDisplayLabel(p.symbol)}:
-              </strong>{' '}
-              {p.tip}
+              <strong className="font-semibold text-gray-900 dark:text-gray-100">
+                “{p.sound}” sound
+              </strong>
+              {p.referenceWord && <> (like <strong>{p.referenceWord}</strong>)</>}: {p.tip}
             </span>
           </li>
         ))}

--- a/src/components/pronunciation/shared/FocusAreasCard.tsx
+++ b/src/components/pronunciation/shared/FocusAreasCard.tsx
@@ -32,7 +32,7 @@ function collectProblemPhonemes(words: NormalizedWordFeedback[]): ProblemPhoneme
       const existing = bySymbol.get(contextualSymbol);
       if (existing && existing.score <= phoneme.score) continue;
 
-      const metadata = getPhonemeById(phoneme.symbol);
+      const metadata = getPhonemeById(contextualSymbol);
       const tip =
         phoneme.tip ||
         metadata?.teachingTips?.[0] ||

--- a/src/components/pronunciation/shared/PhonemePanel.tsx
+++ b/src/components/pronunciation/shared/PhonemePanel.tsx
@@ -43,6 +43,7 @@ export default function PhonemePanel({
     word: word.text,
     phonemes: guidePhonemes,
     pronunciationNote: word.pronunciationNote,
+    respelling: word.respelling,
   });
   const problemSounds = word.phonemes?.filter((phoneme) => phoneme.isProblem) ?? [];
   const wordScore = word.score ?? word.accuracyScore;

--- a/src/components/pronunciation/shared/types.ts
+++ b/src/components/pronunciation/shared/types.ts
@@ -41,6 +41,8 @@ export interface NormalizedWordFeedback {
   guidePhonemes?: string[];
   /** Human-authored pronunciation note from the canonical word record. */
   pronunciationNote?: string;
+  /** Optional curated English eye-dialect respelling. */
+  respelling?: string;
 }
 
 /**

--- a/src/lib/demo/demoData.test.ts
+++ b/src/lib/demo/demoData.test.ts
@@ -30,6 +30,16 @@ describe('demoData', () => {
     }
   });
 
+  it('does not carry learner-facing IPA transcriptions', () => {
+    for (const item of DEMO_ITEMS) {
+      expect(item).not.toHaveProperty('ipa');
+      for (const word of item.words) {
+        expect(word.respelling).toBeTruthy();
+        expect(word.respelling).not.toMatch(/[ɐɲʎʒẽĩõũ]/);
+      }
+    }
+  });
+
   it('scores the native example near-perfect (95–100)', () => {
     for (const item of DEMO_ITEMS) {
       const native = item.examples.find((e) => e.kind === 'native')!;

--- a/src/lib/demo/demoData.ts
+++ b/src/lib/demo/demoData.ts
@@ -470,7 +470,7 @@ const BASE_ITEMS: DemoItemBase[] = [
       },
       {
         text: 'mãe',
-        respelling: 'MYE',
+        respelling: 'My',
         score: 66,
         errorType: 'mispronounced',
         phonemes: [

--- a/src/lib/demo/demoData.ts
+++ b/src/lib/demo/demoData.ts
@@ -3,7 +3,7 @@
  * ------------------------------------------------------------------
  * Everything in this file is hand-authored sample data used to power
  * the public `/demo` experience and parts of `/tour`. It lets a
- * visitor explore LusoPronounce's scoring, phoneme feedback, and
+ * visitor explore LusoPronounce's scoring, pronunciation guidance, and
  * progress tracking WITHOUT an account, Azure Speech credentials, a
  * microphone, or a database.
  *
@@ -16,7 +16,7 @@
  * practice corpus. Keeping the demo's clips in their own folder means the
  * "Listen (native voice)" button works both locally and on the deploy.
  *
- * The SCORES, phoneme breakdowns, and attempt history are illustrative
+ * The SCORES, sound breakdowns, and attempt history are illustrative
  * and are NOT real Azure Speech pronunciation-assessment output. The UI
  * clearly labels this as demo data wherever it is shown.
  */
@@ -51,16 +51,18 @@ export function getDemoAttemptAudioUrl(id: string, kind: 'bad' | 'best'): string
   return `/demo-audio/attempts/${id}.${kind}.wav`;
 }
 
-/** A single phoneme within a demo word, with its illustrative score. */
+/** A single assessed sound within a demo word, with its illustrative score. */
 export interface DemoPhonemeScore {
   /** Phoneme id matching data/phoneme_metadata.json (e.g. "LH", "AN_NASAL"). */
   symbol: string;
   score: number;
 }
 
-/** Word-level demo feedback, including its phoneme breakdown. */
+/** Word-level demo feedback, including its assessed sound breakdown. */
 export interface DemoWordFeedback {
   text: string;
+  /** Curated English eye-dialect pronunciation shown to public-demo learners. */
+  respelling: string;
   score: number;
   errorType?: ErrorType;
   phonemes: DemoPhonemeScore[];
@@ -93,7 +95,7 @@ export interface DemoExample {
   audioBundled: boolean;
   /** Sample assessment for this example. */
   attempt: AttemptScore;
-  /** Word-by-word breakdown with phonemes for this example. */
+  /** Word-by-word breakdown with assessed sounds for this example. */
   words: DemoWordFeedback[];
   /** Coaching notes tailored to this example. */
   coaching: string[];
@@ -107,8 +109,6 @@ export interface DemoItem {
   text: string;
   /** English translation. */
   translation: string;
-  /** Rough IPA transcription for display. */
-  ipa: string;
   /** 1 (easiest) – 4 (hardest). */
   difficulty: number;
   /** CEFR level of the source sentence (e.g. "A1"). */
@@ -117,7 +117,7 @@ export interface DemoItem {
   focusSounds: string[];
   /** Sample assessment shown in the score card (the best-effort attempt). */
   attempt: AttemptScore;
-  /** Word-by-word breakdown with phonemes (the best-effort attempt). */
+  /** Word-by-word breakdown with assessed sounds (the best-effort attempt). */
   words: DemoWordFeedback[];
   /** Illustrative history of overall scores across prior attempts (oldest → newest). */
   history: number[];
@@ -193,6 +193,7 @@ function mapWordScores(
     const score = transform(w.score);
     return {
       text: w.text,
+      respelling: w.respelling,
       score,
       errorType: errorFloor !== null && score < errorFloor ? 'mispronounced' : undefined,
       phonemes: w.phonemes.map((p) => ({ symbol: p.symbol, score: transform(p.score) })),
@@ -272,6 +273,7 @@ const BASE_ITEMS: DemoItemBase[] = [
     const words: DemoWordFeedback[] = [
       {
         text: 'Oi,',
+        respelling: 'Oy',
         score: 95,
         phonemes: [
           { symbol: 'OW', score: 96 },
@@ -280,6 +282,7 @@ const BASE_ITEMS: DemoItemBase[] = [
       },
       {
         text: 'tudo',
+        respelling: 'TOO-doo',
         score: 90,
         phonemes: [
           { symbol: 'T', score: 95 },
@@ -291,6 +294,7 @@ const BASE_ITEMS: DemoItemBase[] = [
       },
       {
         text: 'bem?',
+        respelling: 'BAYNG',
         score: 80,
         errorType: 'mispronounced',
         phonemes: [
@@ -298,14 +302,13 @@ const BASE_ITEMS: DemoItemBase[] = [
           { symbol: 'EN_NASAL', score: 72 },
           { symbol: 'Y', score: 78 },
         ],
-        tip: 'The "em" is nasal and glides toward "y" — "bẽi", not a flat English "beng".',
+        tip: 'The "em" is nasal and glides toward "y" — start from "bay" and keep the sound in your nose; do not finish with a hard "ng".',
       },
     ];
     return {
       id: 'gemini_small_talk_001',
       text: 'Oi, tudo bem?',
       translation: 'Hi, how are you?',
-      ipa: 'oj ˈtudu ˈbẽj',
       difficulty: 1,
       cefr: 'A1',
       focusSounds: ['nasal em', 'vowel reduction'],
@@ -322,6 +325,7 @@ const BASE_ITEMS: DemoItemBase[] = [
     const words: DemoWordFeedback[] = [
       {
         text: 'Estou',
+        respelling: 'ees-TOH',
         score: 85,
         phonemes: [
           { symbol: 'IY', score: 82 },
@@ -333,6 +337,7 @@ const BASE_ITEMS: DemoItemBase[] = [
       },
       {
         text: 'muito',
+        respelling: 'MWEEN-too',
         score: 82,
         phonemes: [
           { symbol: 'M', score: 94 },
@@ -345,6 +350,7 @@ const BASE_ITEMS: DemoItemBase[] = [
       },
       {
         text: 'feliz',
+        respelling: 'feh-LEES',
         score: 84,
         phonemes: [
           { symbol: 'F', score: 96 },
@@ -357,6 +363,7 @@ const BASE_ITEMS: DemoItemBase[] = [
       },
       {
         text: 'hoje.',
+        respelling: 'OH-zhee',
         score: 78,
         errorType: 'mispronounced',
         phonemes: [
@@ -371,7 +378,6 @@ const BASE_ITEMS: DemoItemBase[] = [
       id: 'gemini_feelings_001',
       text: 'Estou muito feliz hoje.',
       translation: "I'm very happy today.",
-      ipa: 'isˈto ˈmũjtu feˈlis ˈoʒi',
       difficulty: 2,
       cefr: 'A1',
       focusSounds: ['soft j (zh)', 'silent h'],
@@ -388,11 +394,13 @@ const BASE_ITEMS: DemoItemBase[] = [
     const words: DemoWordFeedback[] = [
       {
         text: 'A',
+        respelling: 'Ah',
         score: 92,
         phonemes: [{ symbol: 'AH', score: 92 }],
       },
       {
         text: 'conta,',
+        respelling: 'KOHN-tah',
         score: 78,
         errorType: 'mispronounced',
         phonemes: [
@@ -405,6 +413,7 @@ const BASE_ITEMS: DemoItemBase[] = [
       },
       {
         text: 'por',
+        respelling: 'Pohr',
         score: 76,
         errorType: 'mispronounced',
         phonemes: [
@@ -416,6 +425,7 @@ const BASE_ITEMS: DemoItemBase[] = [
       },
       {
         text: 'favor.',
+        respelling: 'fah-VOHR',
         score: 74,
         errorType: 'mispronounced',
         phonemes: [
@@ -432,7 +442,6 @@ const BASE_ITEMS: DemoItemBase[] = [
       id: 'gemini_food_003',
       text: 'A conta, por favor.',
       translation: 'The check, please.',
-      ipa: 'a ˈkõtɐ poɾ faˈvoɾ',
       difficulty: 3,
       cefr: 'A1',
       focusSounds: ['tapped r', 'nasal on'],
@@ -449,6 +458,7 @@ const BASE_ITEMS: DemoItemBase[] = [
     const words: DemoWordFeedback[] = [
       {
         text: 'Minha',
+        respelling: 'MEEN-yah',
         score: 82,
         phonemes: [
           { symbol: 'M', score: 96 },
@@ -460,6 +470,7 @@ const BASE_ITEMS: DemoItemBase[] = [
       },
       {
         text: 'mãe',
+        respelling: 'MYE',
         score: 66,
         errorType: 'mispronounced',
         phonemes: [
@@ -467,10 +478,11 @@ const BASE_ITEMS: DemoItemBase[] = [
           { symbol: 'AN_NASAL', score: 55 },
           { symbol: 'Y', score: 62 },
         ],
-        tip: 'The "ãe" is a nasal diphthong — glide from a nasal "ã" toward "i" without stopping the airflow.',
+        tip: 'The "ãe" is a nasal "eye" glide — keep the airflow through your nose and do not finish with a hard "y".',
       },
       {
         text: 'se',
+        respelling: 'See',
         score: 88,
         phonemes: [
           { symbol: 'S', score: 92 },
@@ -480,6 +492,7 @@ const BASE_ITEMS: DemoItemBase[] = [
       },
       {
         text: 'chama',
+        respelling: 'SHAH-mah',
         score: 85,
         phonemes: [
           { symbol: 'SH', score: 88 },
@@ -491,6 +504,7 @@ const BASE_ITEMS: DemoItemBase[] = [
       },
       {
         text: 'Ana.',
+        respelling: 'AH-nah',
         score: 90,
         phonemes: [
           { symbol: 'AA', score: 92 },
@@ -503,7 +517,6 @@ const BASE_ITEMS: DemoItemBase[] = [
       id: 'gemini_family_friends_001',
       text: 'Minha mãe se chama Ana.',
       translation: "My mother's name is Ana.",
-      ipa: 'ˈmiɲɐ ˈmɐ̃j si ˈʃɐmɐ ˈɐnɐ',
       difficulty: 3,
       cefr: 'B2',
       focusSounds: ['nasal ãe', 'nh (palatal)'],
@@ -511,7 +524,7 @@ const BASE_ITEMS: DemoItemBase[] = [
       words,
       history: [60, 65, 70, 74],
       coaching: [
-        'Both halves of the "ãe" in "mãe" need to stay nasal. Practice slowly: "mã—ẽ", never closing into a hard "y".',
+        'Keep the "eye" glide in "mãe" nasal from start to finish; never close into a hard "y".',
         'For "nh" in "Minha", press the middle of your tongue to the roof of your mouth — think "meen-ya" as one blended sound.',
       ],
     };
@@ -520,6 +533,7 @@ const BASE_ITEMS: DemoItemBase[] = [
     const words: DemoWordFeedback[] = [
       {
         text: 'Que',
+        respelling: 'Kee',
         score: 90,
         phonemes: [
           { symbol: 'K', score: 94 },
@@ -529,6 +543,7 @@ const BASE_ITEMS: DemoItemBase[] = [
       },
       {
         text: 'horas',
+        respelling: 'OH-rahs',
         score: 80,
         errorType: 'mispronounced',
         phonemes: [
@@ -541,6 +556,7 @@ const BASE_ITEMS: DemoItemBase[] = [
       },
       {
         text: 'são?',
+        respelling: 'SOWN',
         score: 64,
         errorType: 'mispronounced',
         phonemes: [
@@ -548,14 +564,13 @@ const BASE_ITEMS: DemoItemBase[] = [
           { symbol: 'AN_NASAL', score: 52 },
           { symbol: 'W', score: 68 },
         ],
-        tip: 'The "ão" is the same nasal diphthong as in "pão" — keep it resonating in the nose, then glide to "w".',
+        tip: 'The "ão" is a nasal "own" glide — keep it resonating in the nose and do not finish with a hard "n".',
       },
     ];
     return {
       id: 'gemini_questions_005',
       text: 'Que horas são?',
       translation: 'What time is it?',
-      ipa: 'ki ˈɔɾɐs ˈsɐ̃w',
       difficulty: 4,
       cefr: 'B2',
       focusSounds: ['nasal ão', 'tapped r'],
@@ -563,7 +578,7 @@ const BASE_ITEMS: DemoItemBase[] = [
       words,
       history: [56, 62, 67, 71],
       coaching: [
-        'The nasal "ão" in "são" is dragging the score down. Hum "ãaão" with your mouth barely open, then add the final "w" glide.',
+        'The nasal "ão" in "são" is dragging the score down. Start from "own", keep the sound in your nose, and avoid a hard final "n".',
         'Remember the "h" in "horas" is silent, and the "r" is a single tap — not an English "r".',
       ],
     };

--- a/src/lib/pronunciationGuide.test.ts
+++ b/src/lib/pronunciationGuide.test.ts
@@ -31,6 +31,21 @@ describe('buildPronunciationGuide', () => {
     expect(guide.respelling).toBe('FREE-o');
   });
 
+  it('uses an explicit curated respelling when public content provides one', () => {
+    const guide = buildPronunciationGuide({
+      word: 'mãe',
+      phonemes: ['M', 'AN_NASAL', 'Y'],
+      pronunciationNote: 'Nasal vowel guidance.',
+      respelling: 'MYE',
+    });
+
+    expect(guide.respelling).toBe('MYE');
+    expect(guide.spellingRules[0]).toEqual({
+      spelling: 'ÃE',
+      sound: 'nasal "EYE" sound',
+    });
+  });
+
   it('describes distinctive Portuguese letter patterns without IPA', () => {
     const guide = buildPronunciationGuide({
       word: 'caminho',

--- a/src/lib/pronunciationGuide.test.ts
+++ b/src/lib/pronunciationGuide.test.ts
@@ -36,10 +36,10 @@ describe('buildPronunciationGuide', () => {
       word: 'mãe',
       phonemes: ['M', 'AN_NASAL', 'Y'],
       pronunciationNote: 'Nasal vowel guidance.',
-      respelling: 'MYE',
+      respelling: 'My',
     });
 
-    expect(guide.respelling).toBe('MYE');
+    expect(guide.respelling).toBe('My');
     expect(guide.spellingRules[0]).toEqual({
       spelling: 'ÃE',
       sound: 'nasal "EYE" sound',

--- a/src/lib/pronunciationGuide.ts
+++ b/src/lib/pronunciationGuide.ts
@@ -21,6 +21,7 @@ interface BuildPronunciationGuideOptions {
   word: string;
   phonemes?: string[];
   pronunciationNote?: string;
+  respelling?: string;
 }
 
 interface EyeDialectPhone {
@@ -86,6 +87,11 @@ const REFERENCE_WORDS: Record<string, PronunciationReference> = {
   OW: { sound: 'oh', word: 'go' },
   AO: { sound: 'aw', word: 'law' },
   UW: { sound: 'oo', word: 'food' },
+  AN_NASAL: { sound: 'nasal uh', word: 'huh' },
+  EN_NASAL: { sound: 'nasal ay', word: 'pain' },
+  IN_NASAL: { sound: 'nasal ee', word: 'seen' },
+  ON_NASAL: { sound: 'nasal oh', word: 'own' },
+  UN_NASAL: { sound: 'nasal oo', word: 'moon' },
   P: { sound: 'P', word: 'spin' },
   B: { sound: 'B', word: 'boy' },
   T: { sound: 'T', word: 'stop' },
@@ -283,6 +289,7 @@ function buildSpellingRules(word: string): PronunciationSpellingRule[] {
   if (/lh/.test(normalized)) add({ spelling: 'LH', sound: '"LY" sound', referenceWord: 'million' });
   if (/ch/.test(normalized)) add({ spelling: 'CH', sound: '"SH" sound', referenceWord: 'shoe' });
   if (/ão/.test(normalized)) add({ spelling: 'ÃO', sound: 'nasal "OWN" sound' });
+  if (/ãe/.test(normalized)) add({ spelling: 'ÃE', sound: 'nasal "EYE" sound' });
   if (/ç/.test(normalized)) add({ spelling: 'Ç', sound: '"S" sound', referenceWord: 'sun' });
   if (/c[eiéêí]/.test(normalized)) add({ spelling: 'C before E or I', sound: '"S" sound', referenceWord: 'sun' });
   if (/g[eiéêí]/.test(normalized)) add({ spelling: 'G before E or I', sound: '"ZH" sound', referenceWord: 'pleasure' });
@@ -306,9 +313,10 @@ export function buildPronunciationGuide({
   word,
   phonemes = [],
   pronunciationNote,
+  respelling: providedRespelling,
 }: BuildPronunciationGuideOptions): PronunciationGuide {
   const noteRespelling = extractRespellingFromNote(pronunciationNote);
-  const respelling = noteRespelling ?? (
+  const respelling = providedRespelling ?? noteRespelling ?? (
     phonemes.length > 0 ? respellFromPhonemes(word, phonemes) : word
   );
 

--- a/src/pages/DemoPage.tsx
+++ b/src/pages/DemoPage.tsx
@@ -49,7 +49,7 @@ function scoreChipClasses(score: number): string {
 /**
  * Adapt the demo's hand-authored word feedback to the normalized shape the
  * real practice components consume. The word-level tip is attached to the
- * word's lowest-scoring phoneme so it surfaces in Sound Details/Focus Areas.
+ * weakest sound and also supplies the curated eye-dialect pronunciation.
  */
 function toNormalizedWords(words: DemoWordFeedback[]): NormalizedWordFeedback[] {
   return words.map((w, index) => {
@@ -64,6 +64,9 @@ function toNormalizedWords(words: DemoWordFeedback[]): NormalizedWordFeedback[] 
       accuracyScore: w.score,
       score: w.score,
       errorType: w.errorType ?? null,
+      guidePhonemes: w.phonemes.map((p) => p.symbol),
+      pronunciationNote: w.tip,
+      respelling: w.respelling,
       phonemes: w.phonemes.map((p, i) => ({
         symbol: p.symbol,
         score: p.score,
@@ -124,7 +127,7 @@ function DemoPracticeCard({ item, example }: { item: DemoItem; example: DemoExam
         }
       />
 
-      {/* Full sentence, translation toggle, audio controls, and Sound Details.
+      {/* Full sentence, translation toggle, audio controls, and pronunciation guide.
           Keyed by example so word selection and scores reset when switching. */}
       <PronunciationFeedbackPanel
         key={`${item.id}:${example.kind}`}
@@ -139,7 +142,7 @@ function DemoPracticeCard({ item, example }: { item: DemoItem; example: DemoExam
         showDifficultyBadge={false}
       />
 
-      {/* Focus Areas — problem phonemes across the sentence (empty for native) */}
+      {/* Focus Areas — learner-friendly problem sounds across the sentence */}
       <FocusAreasCard words={normalizedWords} />
 
       {/* Coaching — tailored to the selected example */}
@@ -199,7 +202,7 @@ export default function DemoPage() {
                 recording yourself, compare three audio examples — the{' '}
                 <strong>native speaker</strong>, an intentionally <strong>bad attempt</strong>, and
                 a <strong>best-effort attempt</strong> — and see how each one scores. The scores and
-                phoneme feedback are realistic <strong>samples</strong>, not live Azure Speech
+                sound-by-sound feedback are realistic <strong>samples</strong>, not live Azure Speech
                 results. No microphone, account, or API keys are used.
               </p>
             </div>

--- a/src/pages/tour/TourVisuals.test.tsx
+++ b/src/pages/tour/TourVisuals.test.tsx
@@ -19,7 +19,7 @@ describe('tour evidence visuals', () => {
     expect(screen.getAllByText(/^illustrative$/i).length).toBeGreaterThan(0);
     expect(screen.getByText(/score 66\/100/i)).toBeInTheDocument();
     expect(screen.getByText(/say it like/i)).toBeInTheDocument();
-    expect(screen.getByText('MYE')).toBeInTheDocument();
+    expect(screen.getByText('My')).toBeInTheDocument();
     expect(screen.queryByText('AN_NASAL')).not.toBeInTheDocument();
     expect(screen.queryByText('IPA')).not.toBeInTheDocument();
     expect(container.textContent).not.toMatch(IPA_GLYPHS);

--- a/src/pages/tour/TourVisuals.test.tsx
+++ b/src/pages/tour/TourVisuals.test.tsx
@@ -6,34 +6,41 @@ import {
   WalkthroughFrame,
 } from './TourVisuals';
 
+const IPA_GLYPHS = /[ɐɲʎʒʃɛɔɾ̃]/;
+
 describe('tour evidence visuals', () => {
   beforeAll(() => {
     vi.spyOn(HTMLMediaElement.prototype, 'pause').mockImplementation(() => undefined);
   });
 
   it('renders the production word-coaching UI and switches its selected word', () => {
-    render(<InteractiveAttemptFrame />);
+    const { container } = render(<InteractiveAttemptFrame />);
 
     expect(screen.getAllByText(/^illustrative$/i).length).toBeGreaterThan(0);
     expect(screen.getByText(/score 66\/100/i)).toBeInTheDocument();
     expect(screen.getByText(/say it like/i)).toBeInTheDocument();
-    expect(screen.getByText('Muhny')).toBeInTheDocument();
+    expect(screen.getByText('MYE')).toBeInTheDocument();
     expect(screen.queryByText('AN_NASAL')).not.toBeInTheDocument();
+    expect(screen.queryByText('IPA')).not.toBeInTheDocument();
+    expect(container.textContent).not.toMatch(IPA_GLYPHS);
 
     fireEvent.click(screen.getByRole('button', { name: 'Minha' }));
 
     expect(screen.getByText(/score 82\/100/i)).toBeInTheDocument();
-    expect(screen.getByText('Mee-nyuh')).toBeInTheDocument();
+    expect(screen.getByText('MEEN-yah')).toBeInTheDocument();
     expect(screen.getAllByText(/^NY$/).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/canyon/i).length).toBeGreaterThan(0);
   });
 
-  it('describes the current provider granularity without inventing phoneme scores', () => {
-    render(<AssessmentTransformation />);
+  it('describes provider granularity without exposing IPA to learners', () => {
+    const { container } = render(<AssessmentTransformation />);
 
     expect(screen.getByText(/word granularity/i)).toBeInTheDocument();
     expect(screen.getByText(/never invent a missing sound score/i)).toBeInTheDocument();
-    expect(screen.getByText(/NH in “minha”/i)).toBeInTheDocument();
+    expect(screen.getByText(/Say “minha” like MEEN-yah/i)).toBeInTheDocument();
+    expect(screen.getByText(/The spelling rule/i)).toBeInTheDocument();
+    expect(screen.queryByText('IPA')).not.toBeInTheDocument();
+    expect(container.textContent).not.toMatch(IPA_GLYPHS);
   });
 
   it('keeps the seeded capture state local to the tour', () => {
@@ -41,5 +48,15 @@ describe('tour evidence visuals', () => {
 
     expect(screen.getByText(/seeded recording ready/i)).toBeInTheDocument();
     expect(screen.getByText(/microphone access begins only in authenticated practice/i)).toBeInTheDocument();
+  });
+
+  it('uses respelling, reference words, and spelling rules in the walkthrough', () => {
+    const { container } = render(<WalkthroughFrame activeStep={3} />);
+
+    expect(screen.getByText('MEEN-yah')).toBeInTheDocument();
+    expect(screen.getAllByText(/^NY$/).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/canyon/i).length).toBeGreaterThan(0);
+    expect(screen.getByText(/The spelling rule/i)).toBeInTheDocument();
+    expect(container.textContent).not.toMatch(IPA_GLYPHS);
   });
 });

--- a/src/pages/tour/TourVisuals.tsx
+++ b/src/pages/tour/TourVisuals.tsx
@@ -127,7 +127,7 @@ export function InteractiveAttemptFrame() {
   const [selectedWord, setSelectedWord] = useState<NormalizedWordFeedback>(DEFAULT_HERO_WORD);
 
   return (
-    <div className="dark overflow-hidden rounded-[1.4rem] border border-white/12 bg-[#0f1724] shadow-[0_24px_60px_rgba(0,0,0,0.28)]">
+    <div className="overflow-hidden rounded-[1.4rem] border border-white/12 bg-[#0f1724] shadow-[0_24px_60px_rgba(0,0,0,0.28)]">
       <div className="flex items-center justify-between gap-3 border-b border-white/10 bg-[#111b2a] px-4 py-3 sm:px-5">
         <div>
           <p className="text-xs font-semibold text-slate-200">Coaching for “{selectedWord.text}”</p>
@@ -156,7 +156,7 @@ export function InteractiveAttemptFrame() {
           />
         </div>
 
-        <div aria-live="polite">
+        <div className="dark" aria-live="polite">
           <PhonemePanel word={selectedWord} trustLevel="trusted" />
         </div>
       </div>

--- a/src/pages/tour/TourVisuals.tsx
+++ b/src/pages/tour/TourVisuals.tsx
@@ -15,7 +15,7 @@ import {
   type NormalizedWordFeedback,
 } from '@/components/pronunciation/shared';
 import { getDemoItem, getDemoNativeAudioUrl } from '@/lib/demo/demoData';
-import { getPhonemeById } from '@/lib/phonemeMetadata';
+import { buildPronunciationGuide } from '@/lib/pronunciationGuide';
 import { PIPELINE_STAGES } from './tourContent';
 
 const SAMPLE = getDemoItem('gemini_family_friends_001') ?? getDemoItem('gemini_small_talk_001')!;
@@ -78,6 +78,14 @@ function cleanWord(value: string): string {
   return value.replace(/[.,!?]/g, '');
 }
 
+const MINHA_WORD = SAMPLE.words.find((word) => cleanWord(word.text) === 'minha') ?? SAMPLE.words[0];
+const MINHA_GUIDE = buildPronunciationGuide({
+  word: cleanWord(MINHA_WORD.text),
+  phonemes: MINHA_WORD.phonemes.map((sound) => sound.symbol),
+  pronunciationNote: MINHA_WORD.tip,
+  respelling: MINHA_WORD.respelling,
+});
+
 const HERO_WORDS: NormalizedWordFeedback[] = SAMPLE.words.map((word, index) => ({
   id: `tour-word-${index}`,
   index,
@@ -85,6 +93,9 @@ const HERO_WORDS: NormalizedWordFeedback[] = SAMPLE.words.map((word, index) => (
   accuracyScore: word.score,
   score: word.score,
   errorType: word.errorType ?? null,
+  guidePhonemes: word.phonemes.map((phoneme) => phoneme.symbol),
+  pronunciationNote: word.tip,
+  respelling: word.respelling,
   level:
     word.score >= 90
       ? 'excellent'
@@ -177,7 +188,6 @@ function Waveform({ active = false }: { active?: boolean }) {
 export function WalkthroughFrame({ activeStep }: { activeStep: number }) {
   const [playing, setPlaying] = useState(false);
   const audioRef = useRef<HTMLAudioElement>(null);
-  const metadata = getPhonemeById('NH');
 
   useEffect(() => {
     audioRef.current?.pause();
@@ -317,25 +327,28 @@ export function WalkthroughFrame({ activeStep }: { activeStep: number }) {
                 <p className="text-[10px] font-semibold uppercase tracking-[0.14em] text-amber-200">Weak word</p>
                 <p className="mt-2 text-2xl font-semibold text-white">minha</p>
                 <p className="mt-1 text-sm text-amber-200">Illustrative word score: 82</p>
-                <div className="mt-4 flex flex-wrap gap-2">
-                  {['M', 'IY', 'NH', 'AH'].map((symbol) => {
-                    const meta = getPhonemeById(symbol);
-                    return (
-                      <span key={symbol} className={`rounded-md border px-2 py-1 font-mono text-xs ${symbol === 'NH' ? 'border-amber-300 bg-amber-300/10 text-amber-100' : 'border-white/10 text-slate-400'}`}>
-                        /{meta?.ipa ?? symbol}/
-                      </span>
-                    );
-                  })}
+                <div className="mt-4 rounded-xl border border-white/10 bg-black/15 p-3">
+                  <p className="text-[10px] font-semibold uppercase tracking-[0.14em] text-slate-500">Say it like</p>
+                  <p className="mt-1 text-xl font-bold tracking-wide text-white">{MINHA_GUIDE.respelling}</p>
                 </div>
               </div>
               <div className="rounded-xl border border-primary-300/25 bg-primary-300/[0.06] p-4">
                 <p className="text-[10px] font-semibold uppercase tracking-[0.14em] text-primary-300">PT-BR coaching guidance</p>
-                <p className="mt-2 text-base font-semibold text-white">NH · /{metadata?.ipa}/</p>
-                <p className="mt-2 text-sm leading-6 text-slate-300">{metadata?.teachingTips?.[0]}</p>
-                <p className="mt-3 text-xs text-slate-400">
-                  Example: <span className="text-slate-200">{metadata?.exampleWords?.[0]?.pt}</span>{' '}
-                  <span className="font-mono">/{metadata?.exampleWords?.[0]?.ipa}/</span>
-                </p>
+                <div className="mt-3 flex flex-wrap gap-2">
+                  {MINHA_GUIDE.references.map((reference) => (
+                    <span key={`${reference.sound}-${reference.word}`} className="rounded-lg border border-white/10 bg-black/15 px-2.5 py-1.5 text-xs text-slate-300">
+                      <strong className="text-white">{reference.sound}</strong> like <strong className="text-white">{reference.word}</strong>
+                    </span>
+                  ))}
+                </div>
+                {MINHA_GUIDE.spellingRules[0] && (
+                  <div className="mt-4 border-l-2 border-primary-300 pl-3">
+                    <p className="text-[10px] font-semibold uppercase tracking-[0.14em] text-primary-300">The spelling rule</p>
+                    <p className="mt-1 text-sm text-slate-200">
+                      <strong>{MINHA_GUIDE.spellingRules[0].spelling}</strong> = {MINHA_GUIDE.spellingRules[0].sound}
+                    </p>
+                  </div>
+                )}
               </div>
             </div>
           )}
@@ -354,7 +367,6 @@ export function WalkthroughFrame({ activeStep }: { activeStep: number }) {
 }
 
 export function AssessmentTransformation() {
-  const metadata = getPhonemeById('NH');
   return (
     <div>
       <div className="grid gap-4 xl:grid-cols-[1fr_auto_1fr_auto_1fr] xl:items-stretch">
@@ -414,18 +426,29 @@ export function AssessmentTransformation() {
         <div className="rounded-2xl border border-primary-300/25 bg-primary-300/[0.06] p-5">
           <p className="text-xs font-semibold text-primary-200">3 · Actionable learner feedback</p>
           <div className="mt-5 flex items-center gap-3">
-            <span className="flex h-12 w-12 items-center justify-center rounded-xl border border-primary-300/30 bg-primary-300/10 font-mono text-lg font-bold text-primary-100">
-              /{metadata?.ipa}/
+            <span className="flex min-h-12 min-w-12 items-center justify-center rounded-xl border border-primary-300/30 bg-primary-300/10 px-3 text-lg font-bold text-primary-100">
+              {MINHA_GUIDE.respelling}
             </span>
             <div>
-              <p className="font-semibold text-white">NH in “minha”</p>
-              <p className="text-xs text-slate-400">Target sound and articulation guidance</p>
+              <p className="font-semibold text-white">Say “minha” like {MINHA_GUIDE.respelling}</p>
+              <p className="text-xs text-slate-400">English-friendly respelling and reference words</p>
             </div>
           </div>
-          <div className="mt-5 border-l-2 border-primary-300 pl-4">
-            <p className="text-[10px] font-semibold uppercase tracking-[0.14em] text-primary-300">How to try it</p>
-            <p className="mt-2 text-sm leading-6 text-slate-200">{metadata?.teachingTips?.[0]}</p>
+          <div className="mt-5 flex flex-wrap gap-2">
+            {MINHA_GUIDE.references.map((reference) => (
+              <span key={`${reference.sound}-${reference.word}`} className="rounded-lg border border-white/10 bg-black/15 px-2.5 py-1.5 text-xs text-slate-300">
+                <strong className="text-white">{reference.sound}</strong> like <strong className="text-white">{reference.word}</strong>
+              </span>
+            ))}
           </div>
+          {MINHA_GUIDE.spellingRules[0] && (
+            <div className="mt-5 border-l-2 border-primary-300 pl-4">
+              <p className="text-[10px] font-semibold uppercase tracking-[0.14em] text-primary-300">The spelling rule</p>
+              <p className="mt-2 text-sm leading-6 text-slate-200">
+                <strong>{MINHA_GUIDE.spellingRules[0].spelling}</strong> = {MINHA_GUIDE.spellingRules[0].sound}
+              </p>
+            </div>
+          )}
           <p className="mt-4 text-xs leading-5 text-slate-400">
             Azure identifies the weak word; LusoPronounce explains the sound worth practicing. Per-sound values in this tour remain illustrative.
           </p>


### PR DESCRIPTION
Reopens the work originally merged as #131, which was reverted out of `develop` in #132 (along with #129 and #130) due to regressions introduced after the recruiter-tour baseline (#128). Filed fresh since GitHub does not allow reopening a merged pull request — content is identical to the original merge (tree verified against commit `f65f147`).

Stacked on #134 (reopened #129), matching the original merge order — this PR's base branch is #134's head, not `develop` directly.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VHYiYa22epgAJAY5xFuMuX)_