### PR TITLE
fix(deploy): redirect stray Vercel deploy to Railway to fix login/register "Unknown error"

### DIFF
--- a/docs/audits/VERCEL_CONFIG_REVIEW.md
+++ b/docs/audits/VERCEL_CONFIG_REVIEW.md
@@ -1,5 +1,16 @@
 # Vercel Config Review
 
+## Resolution (2026-07-17)
+
+A `vercel.json` doing a static rewrite was added at some point after this review,
+without the split-origin work (`VITE_API_BASE_URL` + expanded CORS) this doc
+calls for. That served the frontend from `luso-pronunciation.vercel.app` while
+`/api/*` requests had no backend behind them, causing login/register to fail
+with `405 Method Not Allowed`. `vercel.json` now only redirects every path to
+the Railway deployment (the single source of truth for this app per
+`CLAUDE.md`), so an accidental future Vercel deploy can't silently serve a
+broken build again.
+
 ## Current State
 
 - There is **no `vercel.json`** in the repo.

--- a/vercel.json
+++ b/vercel.json
@@ -1,9 +1,10 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "framework": "vite",
-  "buildCommand": "npm run build",
-  "outputDirectory": "dist",
-  "rewrites": [
-    { "source": "/(.*)", "destination": "/index.html" }
+  "redirects": [
+    {
+      "source": "/:path*",
+      "destination": "https://lusopronunciation-production.up.railway.app/:path*",
+      "permanent": false
+    }
   ]
 }


### PR DESCRIPTION
## Summary

- The live site was being served from `luso-pronunciation.vercel.app` via a static-only `vercel.json` rewrite, with no backend behind it. `POST /api/auth/login` and `/api/auth/register` hit that rewrite and got back a `405 Method Not Allowed` (non-JSON) response, which the client's fetch wrapper (`src/api/auth.ts`) surfaced as the literal string "Unknown error".
- The real backend (Express + MongoDB + JWT) is deployed and working correctly on Railway at `https://lusopronunciation-production.up.railway.app` — confirmed via deploy logs (server boots, MongoDB connects, invite gating configured).
- `vercel.json` now redirects every path to the Railway deployment instead of attempting to build/serve a copy of the frontend, so an accidental future Vercel deploy can't silently serve a broken build again.
- Added a short resolution note to `docs/audits/VERCEL_CONFIG_REVIEW.md`, which had already flagged this exact split-origin risk before `vercel.json` was added.

## Root cause

This was purely a deployment-topology bug, not an application bug — `src/server/routes/auth.ts` and `src/api/auth.ts` were both working correctly; requests to Vercel just never reached that code.

## Test plan

- [x] Validated `vercel.json` is valid JSON
- [ ] After merge/deploy, confirm `luso-pronunciation.vercel.app` redirects to the Railway URL and that login/register work end-to-end there

## Note

This PR does not add password-reset functionality — that's a separate, currently entirely-missing feature (no backend route, model field, frontend page, or email-sending mechanism) that will need its own follow-up.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XQ7XBxo7nwidREJs6eyDas)_