### PR TITLE
fix(auth): remove app nav from auth page, promote tour/demo CTA

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -31,25 +31,23 @@ function AppShell() {
     <AppLayout>
       <Routes>
         <Route path="/" element={<RequireAuth><PracticePage /></RequireAuth>} />
-          <Route path="/auth" element={<AuthPage />} />
-          <Route path="/auth/callback" element={<OAuthCallbackPage />} />
-          <Route path="/practice/sentence" element={<Navigate to="/" replace />} />
-          <Route path="/practice/word" element={<Navigate to="/?tab=words" replace />} />
-          <Route path="/review" element={<RequireAuth><Review /></RequireAuth>} />
-          <Route path="/sessions" element={<Navigate to="/review" replace />} />
-          <Route path="/builder" element={<RequireAuth><SentenceBuilderPage /></RequireAuth>} />
-          <Route path="/sentences/custom" element={<RequireAuth><CustomSentenceListPage /></RequireAuth>} />
-          <Route path="/practice/custom/:id" element={<RequireAuth><CustomSentencePracticePage /></RequireAuth>} />
-          <Route path="/admin/lexicon" element={<RequireAuth><AdminLexiconPage /></RequireAuth>} />
-          <Route path="/progress" element={<RequireAuth><ProgressPage /></RequireAuth>} />
-          <Route path="/settings" element={<RequireAuth><SettingsPage /></RequireAuth>} />
-          {import.meta.env.DEV && (
-            <>
-              <Route path="/dev/pronunciation-fixtures" element={<Suspense fallback={null}><PronunciationFixtures /></Suspense>} />
-              <Route path="/dev/analytics" element={<Suspense fallback={null}><DevAnalyticsPage /></Suspense>} />
-              <Route path="/dev/metrics" element={<Suspense fallback={null}><DevMetricsPage /></Suspense>} />
-            </>
-          )}
+        <Route path="/practice/sentence" element={<Navigate to="/" replace />} />
+        <Route path="/practice/word" element={<Navigate to="/?tab=words" replace />} />
+        <Route path="/review" element={<RequireAuth><Review /></RequireAuth>} />
+        <Route path="/sessions" element={<Navigate to="/review" replace />} />
+        <Route path="/builder" element={<RequireAuth><SentenceBuilderPage /></RequireAuth>} />
+        <Route path="/sentences/custom" element={<RequireAuth><CustomSentenceListPage /></RequireAuth>} />
+        <Route path="/practice/custom/:id" element={<RequireAuth><CustomSentencePracticePage /></RequireAuth>} />
+        <Route path="/admin/lexicon" element={<RequireAuth><AdminLexiconPage /></RequireAuth>} />
+        <Route path="/progress" element={<RequireAuth><ProgressPage /></RequireAuth>} />
+        <Route path="/settings" element={<RequireAuth><SettingsPage /></RequireAuth>} />
+        {import.meta.env.DEV && (
+          <>
+            <Route path="/dev/pronunciation-fixtures" element={<Suspense fallback={null}><PronunciationFixtures /></Suspense>} />
+            <Route path="/dev/analytics" element={<Suspense fallback={null}><DevAnalyticsPage /></Suspense>} />
+            <Route path="/dev/metrics" element={<Suspense fallback={null}><DevMetricsPage /></Suspense>} />
+          </>
+        )}
       </Routes>
     </AppLayout>
   );
@@ -62,6 +60,8 @@ function AppRoutes() {
         {/* Public, unauthenticated marketing surfaces (own standalone layout) */}
         <Route path="/tour" element={<TourPage />} />
         <Route path="/demo" element={<DemoPage />} />
+        <Route path="/auth" element={<AuthPage />} />
+        <Route path="/auth/callback" element={<OAuthCallbackPage />} />
         {/* Everything else runs inside the authenticated app shell */}
         <Route path="/*" element={<AppShell />} />
       </Routes>

--- a/src/pages/AuthPage.tsx
+++ b/src/pages/AuthPage.tsx
@@ -1,4 +1,5 @@
 import { Link, useNavigate, useSearchParams } from 'react-router-dom';
+import { Compass, PlayCircle } from 'lucide-react';
 import AuthForm from '@/components/auth/AuthForm';
 import type { User } from '@/shared/types';
 
@@ -13,13 +14,28 @@ export default function AuthPage() {
 
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex flex-col items-center justify-center py-12 px-4 sm:px-6 lg:px-8">
+      <div className="w-full max-w-md rounded-xl border border-primary-200 bg-primary-50 p-4 dark:border-primary-400/30 dark:bg-primary-500/10">
+        <p className="text-sm font-medium text-primary-900 dark:text-primary-200">
+          New here? No account needed to preview LusoPronounce.
+        </p>
+        <div className="mt-3 flex flex-col gap-2 sm:flex-row">
+          <Link
+            to="/tour"
+            className="inline-flex flex-1 items-center justify-center gap-2 rounded-lg bg-primary-600 px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-primary-700"
+          >
+            <Compass size={18} />
+            Take a tour
+          </Link>
+          <Link
+            to="/demo"
+            className="inline-flex flex-1 items-center justify-center gap-2 rounded-lg border border-primary-300 bg-white px-4 py-2.5 text-sm font-semibold text-primary-700 transition-colors hover:bg-primary-50 dark:border-primary-400/40 dark:bg-transparent dark:text-primary-300 dark:hover:bg-primary-500/10"
+          >
+            <PlayCircle size={18} />
+            Try the demo
+          </Link>
+        </div>
+      </div>
       <AuthForm onSuccess={handleSuccess} oauthError={oauthError || undefined} />
-      <p className="mt-6 text-sm text-gray-500 dark:text-gray-400 text-center">
-        New here? <Link to="/tour" className="text-primary-600 dark:text-primary-400 font-medium hover:underline">Take a tour</Link>
-        {' '}or{' '}
-        <Link to="/demo" className="text-primary-600 dark:text-primary-400 font-medium hover:underline">try the demo</Link>
-        {' '}— no account needed.
-      </p>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Moved the `/auth` and `/auth/callback` routes out of the authenticated `AppShell` (alongside `/tour` and `/demo`), so signed-out visitors no longer see the Practice/Review/Progress/Settings header and nav bar on the login/register screen.
- Restyled the "Take a tour" / "try the demo" links on the auth page from a small muted text line into a prominent bordered callout with two full-width button-style CTAs.

## Test plan
- [x] `npx tsc --noEmit` — no type errors
- [x] `npx vite build` — builds successfully
- [x] `npx vitest run` — all 280 tests pass
- [ ] Manual check in browser (not run in this environment)


---
_Generated by [Claude Code](https://claude.ai/code/session_01GFgG1X5xaHS7EdLRhtA8UH)_